### PR TITLE
Configure nginx ingress with host IP

### DIFF
--- a/microk8s-resources/actions/enable.ingress.sh
+++ b/microk8s-resources/actions/enable.ingress.sh
@@ -23,7 +23,11 @@ echo "Enabling Ingress"
 
 ARCH=$(arch)
 TAG="0.33.0"
-EXTRA_ARGS="- --publish-status-address=127.0.0.1"
+HOST_IP=$(get_default_ip)
+if ! valid_ip "${HOST_IP}"; then
+  HOST_IP="127.0.0.1"
+fi
+EXTRA_ARGS="- --publish-status-address=${HOST_IP}"
 DEFAULT_CERT="- ' '"
 
 if [ ! -z "$CERT_SECRET" ]


### PR DESCRIPTION
If possible, use the host IP when setting the nginx ingress "public" IP.

Fixes issue #824