### PR TITLE
Remove useless iptables rule

### DIFF
--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -55,25 +55,6 @@ then
   fi
 fi
 
-## Kubelet configuration
-pod_cidr="$(cat $SNAP_DATA/args/kubelet | grep "pod-cidr" | tr "=" " "| gawk '{print $2}')"
-if [ -z "$pod_cidr" ]
-then
-  pod_cidr="$(jq .Network $SNAP_DATA/args/flannel-network-mgr-config | tr -d '\"')"
-fi
-if ! [ -z "$pod_cidr" ]
-then
-  if ! iptables -C FORWARD -s "$pod_cidr" -m comment --comment "generated for MicroK8s pods" -j ACCEPT
-  then
-    # The point of "|| true" is that if for any reason this is failing we "fallback"
-    # to the previous manual approach of pointing people to the troubleshooting guide.
-    iptables -t filter -A FORWARD -s "$pod_cidr" -m comment --comment "generated for MicroK8s pods" -j ACCEPT || true
-    iptables -t filter -A FORWARD -d "$pod_cidr" -m comment --comment "generated for MicroK8s pods" -j ACCEPT || true
-    iptables-nft -t filter -A FORWARD -s "$pod_cidr" -m comment --comment "generated for MicroK8s pods" -j ACCEPT || true
-    iptables-nft -t filter -A FORWARD -d "$pod_cidr" -m comment --comment "generated for MicroK8s pods" -j ACCEPT || true
-  fi
-fi
-
 # wait for containerd socket
 if grep -e "--address " $SNAP_DATA/args/containerd &> /dev/null
 then


### PR DESCRIPTION
By default, traffic is handled by the iptables rule generated by calico.
And this rule blocks working NetworkPolicy when FELIX_CHAININSERTMODE is Append.

