### PR TITLE
snap: declare the microk8s user and group

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,9 @@ grade: stable
 confinement: strict
 base: core18
 
+system-usernames:
+  snap_microk8s: shared
+
 plugs:
   home-read-all:
     interface: home


### PR DESCRIPTION
**NOTE**: this depends on https://github.com/snapcore/snapcraft/pull/3545

With this declaration, snapd will automatically create a user and a
group called "snap_microk8s".
