### PR TITLE
Migrate Cilium to install/uninstall via new CLI

### DIFF
--- a/microk8s-resources/actions/disable.cilium.sh
+++ b/microk8s-resources/actions/disable.cilium.sh
@@ -6,10 +6,15 @@ source $SNAP/actions/common/utils.sh
 
 echo "Disabling Cilium"
 
-"$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" delete -f "$SNAP_DATA/actions/cilium.yaml"
+# Upgrade from v1.21 or earlier.
+if [ -e "$SNAP_DATA/actions/cilium.yaml" ]; then
+  "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" delete -f "$SNAP_DATA/actions/cilium.yaml"
+  # Give K8s some time to process the deletion request
+  sleep 15
+else
+  KUBECONFIG="$SNAP_DATA/credentials/client.config" "$SNAP_DATA/bin/cilium" uninstall --wait
+fi
 
-# Give K8s some time to process the deletion request
-sleep 15
 cilium=$(wait_for_service_shutdown "kube-system" "k8s-app=cilium")
 if [[ $cilium == fail ]]
 then
@@ -21,14 +26,19 @@ if [[ $cilium == fail ]]
 then
   echo "Cilium operator did not shut down on time. Proceeding."
 fi
+
+# These commands handle upgrade from Microk8s v1.21 or earlier.
 run_with_sudo rm -f "$SNAP_DATA/args/cni-network/05-cilium-cni.conf"
 run_with_sudo rm -f "$SNAP_DATA/opt/cni/bin/cilium-cni"
-run_with_sudo rm -rf $SNAP_DATA/bin/cilium*
+run_with_sudo rm -rf -- $SNAP_DATA/bin/cilium-*
 run_with_sudo rm -f "$SNAP_DATA/actions/cilium.yaml"
-run_with_sudo rm -rf "$SNAP_DATA/actions/cilium"
-run_with_sudo rm -rf "$SNAP_DATA/var/run/cilium"
-run_with_sudo rm -rf "$SNAP_DATA/sys/fs/bpf"
+run_with_sudo rm -rf -- "$SNAP_DATA/actions/cilium"
+run_with_sudo rm -rf -- "$SNAP_DATA/sys/fs/bpf"
+# End Microk8s v1.21 or earlier block
 
+run_with_sudo rm -f "$SNAP_DATA/args/cni-network/05-cilium.conf"
+run_with_sudo rm -f "$SNAP_DATA/bin/cilium"
+run_with_sudo rm -rf -- "$SNAP_DATA/var/run/cilium"
 if $SNAP/sbin/ip link show "cilium_vxlan"
 then
   echo "Deleting old cilium_vxlan link"

--- a/microk8s-resources/actions/enable.cilium.sh
+++ b/microk8s-resources/actions/enable.cilium.sh
@@ -12,8 +12,6 @@ if ! [ "${ARCH}" = "amd64" ]; then
   exit 1
 fi
 
-"$SNAP/microk8s-enable.wrapper" helm3
-
 echo "Restarting kube-apiserver"
 refresh_opt_in_config "allow-privileged" "true" kube-apiserver
 restart_service apiserver
@@ -33,58 +31,36 @@ if grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
   run_with_sudo preserve_env snapctl restart "${SNAP_NAME}.daemon-containerd"
 fi
 
+echo "Waiting for microk8s to be ready."
+$SNAP/microk8s-status.wrapper --wait-ready >/dev/null
+
 echo "Enabling Cilium"
 
 read -ra CILIUM_VERSION <<< "$1"
-if [ -z "$CILIUM_VERSION" ]; then
-  CILIUM_VERSION="v1.10"
+if [ -n "$CILIUM_VERSION" ]; then
+  CILIUM_VERSION="v$(echo $CILIUM_VERSION | $SNAP/bin/sed 's;^v;;')"
 fi
-CILIUM_ERSION=$(echo $CILIUM_VERSION | sed 's/v//g')
 
-if [ -f "${SNAP_DATA}/bin/cilium-$CILIUM_ERSION" ]
+if [ -f "${SNAP_DATA}/bin/cilium" ]
 then
-  echo "Cilium version $CILIUM_VERSION is already installed."
+  echo "Cilium is already installed, use microk8s.cilium to upgrade."
 else
-  CILIUM_DIR="cilium-$CILIUM_ERSION"
-  SOURCE_URI="https://github.com/cilium/cilium/archive"
-  CILIUM_CNI_CONF="plugins/cilium-cni/05-cilium-cni.conf"
-  CILIUM_LABELS="k8s-app=cilium"
-  NAMESPACE=kube-system
+  SOURCE_URI="https://github.com/cilium/cilium-cli/releases/latest/download/"
 
-  echo "Fetching cilium version $CILIUM_VERSION."
-  run_with_sudo mkdir -p "${SNAP_DATA}/tmp/cilium"
-  (cd "${SNAP_DATA}/tmp/cilium"
-  run_with_sudo "${SNAP}/usr/bin/curl" --cacert $CA_CERT -L $SOURCE_URI/$CILIUM_VERSION.tar.gz -o "$SNAP_DATA/tmp/cilium/cilium.tar.gz"
-  if ! run_with_sudo gzip -f -d "$SNAP_DATA/tmp/cilium/cilium.tar.gz"; then
-    echo "Invalid version \"$CILIUM_VERSION\". Must be a branch on https://github.com/cilium/cilium."
-    exit 1
-  fi
-  run_with_sudo tar -xf "$SNAP_DATA/tmp/cilium/cilium.tar" "$CILIUM_DIR/install" "$CILIUM_DIR/$CILIUM_CNI_CONF")
+  echo "Fetching the latest cilium command line client."
+  run_with_sudo mkdir -p "$SNAP_DATA/tmp/cilium"
+  (cd "$SNAP_DATA/tmp/cilium"
+  run_with_sudo "$SNAP/usr/bin/curl" --cacert $CA_CERT -L $SOURCE_URI/cilium-linux-$ARCH.tar.gz -o "$SNAP_DATA/tmp/cilium/cilium.tar.gz"
+  run_with_sudo gzip -f -d "$SNAP_DATA/tmp/cilium/cilium.tar.gz"
+  run_with_sudo tar -xf "$SNAP_DATA/tmp/cilium/cilium.tar")
+  run_with_sudo mkdir -p "$SNAP_DATA/bin/"
+  run_with_sudo mv "$SNAP_DATA/tmp/cilium/cilium" "$SNAP_DATA/bin/cilium"
+  run_with_sudo chmod +x "$SNAP_DATA/bin"
+  run_with_sudo chmod +x "$SNAP_DATA/bin/cilium"
+  run_with_sudo rm -rf -- "$SNAP_DATA/tmp/cilium"
 
   run_with_sudo mv "$SNAP_DATA/args/cni-network/cni.conf" "$SNAP_DATA/args/cni-network/10-kubenet.conf" 2>/dev/null || true
   run_with_sudo mv "$SNAP_DATA/args/cni-network/flannel.conflist" "$SNAP_DATA/args/cni-network/20-flanneld.conflist" 2>/dev/null || true
-  run_with_sudo cp "$SNAP_DATA/tmp/cilium/$CILIUM_DIR/$CILIUM_CNI_CONF" "$SNAP_DATA/args/cni-network/05-cilium-cni.conf"
-
-  run_with_sudo mkdir -p "$SNAP_DATA/actions/cilium/"
-
-  # Generate the YAMLs for Cilium and apply them
-  (cd "${SNAP_DATA}/tmp/cilium/$CILIUM_DIR/install/kubernetes"
-  ${SNAP_DATA}/bin/helm3 template cilium \
-      --namespace $NAMESPACE \
-      --set cni.confPath="$SNAP_DATA/args/cni-network" \
-      --set cni.binPath="$SNAP_DATA/opt/cni/bin" \
-      --set cni.customConf=true \
-      --set containerRuntime.integration="containerd" \
-      --set global.containerRuntime.socketPath="$SNAP_COMMON/run/containerd.sock" \
-      --set daemon.runPath="$SNAP_DATA/var/run/cilium" \
-      --set operator.replicas=1 \
-      --set keepDeprecatedLabels=true \
-      | run_with_sudo tee "$SNAP_DATA/actions/cilium.yaml" >/dev/null)
-
-  ${SNAP}/microk8s-status.wrapper --wait-ready >/dev/null
-  echo "Deploying $SNAP_DATA/actions/cilium.yaml. This may take several minutes."
-  "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" apply -f "$SNAP_DATA/actions/cilium.yaml"
-  "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" -n $NAMESPACE rollout status ds/cilium
 
   if [ -e "$SNAP_DATA/args/cni-network/cni.yaml" ]
   then
@@ -92,19 +68,18 @@ else
     # give a bit slack before moving the file out, sometimes it gives out this error "rpc error: code = Unknown desc = checkpoint in progress".
     sleep 2s
     run_with_sudo mv "$SNAP_DATA/args/cni-network/cni.yaml" "$SNAP_DATA/args/cni-network/cni.yaml.disabled"
+    "$SNAP/kubectl" --kubeconfig="$SNAP_DATA/credentials/client.config" -n kube-system delete replicaset -l "k8s-app=calico-kube-controllers"
+    "$SNAP/kubectl" --kubeconfig="$SNAP_DATA/credentials/client.config" -n kube-system delete pod -l "k8s-app=calico-kube-controllers"
+    "$SNAP/kubectl" --kubeconfig="$SNAP_DATA/credentials/client.config" -n kube-system delete pod -l "k8s-app=calico-node"
   fi
 
-  # Fetch the Cilium CLI binary and install
-  CILIUM_POD=$("$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" -n $NAMESPACE get pod -l $CILIUM_LABELS -o jsonpath="{.items[0].metadata.name}")
-  CILIUM_BIN=$(mktemp)
-  "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" -n $NAMESPACE cp $CILIUM_POD:/usr/bin/cilium $CILIUM_BIN >/dev/null
-  run_with_sudo mkdir -p "$SNAP_DATA/bin/"
-  run_with_sudo mv $CILIUM_BIN "$SNAP_DATA/bin/cilium-$CILIUM_ERSION"
-  run_with_sudo chmod +x "$SNAP_DATA/bin/"
-  run_with_sudo chmod +x "$SNAP_DATA/bin/cilium-$CILIUM_ERSION"
-  run_with_sudo ln -s $SNAP_DATA/bin/cilium-$CILIUM_ERSION $SNAP_DATA/bin/cilium
+  if [ -z "$CILIUM_VERSION" ]; then
+    KUBECONFIG="$SNAP_DATA/credentials/client.config" $SNAP_DATA/bin/cilium install --wait
+  else
+    KUBECONFIG="$SNAP_DATA/credentials/client.config" $SNAP_DATA/bin/cilium install --wait --version "$CILIUM_VERSION"
+  fi
 
-  run_with_sudo rm -rf "$SNAP_DATA/tmp/cilium"
+  KUBECONFIG="$SNAP_DATA/credentials/client.config" $SNAP_DATA/bin/cilium status --wait --wait-duration=2m
 fi
 
 echo "Cilium is enabled"

--- a/microk8s-resources/wrappers/microk8s-cilium.wrapper
+++ b/microk8s-resources/wrappers/microk8s-cilium.wrapper
@@ -13,6 +13,4 @@ fi
 
 source $SNAP/actions/common/utils.sh
 exit_if_stopped
-export CILIUM_MONITOR_SOCK="$SNAP_DATA/var/run/cilium/monitor1_2.sock"
-export CILIUM_HEALTH_SOCK="$SNAP_DATA/var/run/cilium/health.sock"
-"${SNAP_DATA}/bin/cilium" -H "unix:///var/snap/microk8s/current/var/run/cilium/cilium.sock" "$@"
+KUBECONFIG="$SNAP_DATA/credentials/client.config" "${SNAP_DATA}/bin/cilium" "$@"


### PR DESCRIPTION
The Cilium community has developed a new CLI for installing, operating
and debugging Kubernetes clusters with Cilium installed[0]. We can reuse
that CLI here for a much simpler, less error-prone upgrade process.

For the most part, the new CLI almost removes the need for these
microk8s-specific scripts. However, the CLI cannot know how to uninstall
existing CNIs in a microk8s-specific environment, so we still need some
logic here to clean that up in order for Cilium to successfully deploy
and avoid conflicts with existing components.

A few notes about implementation choices:
* Remove previous CNIs and CNI config before initiating Cilium install
  to ensure that Cilium manages pods after the cilium install command
  has been run.
* disable.cilium.sh is handling disabling the old version during
  microk8s upgrade.
* Use 'rm -rf -- $directories" to reduce likelihood of removing bad
  directories, rather than 'rm -rf $directories'

[0] https://github.com/cilium/cilium-cli/
