### PR TITLE
Support JSON and YAML format for microk8s add-node command

### DIFF
--- a/scripts/cluster/add_token.py
+++ b/scripts/cluster/add_token.py
@@ -1,4 +1,5 @@
 import json
+import yaml
 import os
 import sys
 import time
@@ -97,19 +98,32 @@ def print_pretty(token, check):
     for ip in all_ips:
         print(f"microk8s join {ip}:{port}/{token}/{check}")
 
-
-def print_json(token, check):
+def get_output_dict(token, check):
     _, all_ips, port = get_network_info()
-    print(
-        json.dumps(
-            {
+    info = {
                 "token": f"{token}/{check}",
                 "urls": [f"{ip}:{port}/{token}/{check}" for ip in all_ips],
-            },
+    }
+    return info
+
+
+def print_json(token, check):
+    info = get_output_dict(token, check)
+    print(
+        json.dumps(
+            info,
             indent=2,
         )
     )
 
+def print_yaml(token, check):
+    info = get_output_dict(token, check)
+    print(
+        yaml.dump(
+            info,
+            indent=2,
+        )
+    )
 
 def print_short(token, check):
     default_ip, all_ips, port = get_network_info()
@@ -145,7 +159,7 @@ if __name__ == "__main__":
         "--format",
         help="Format the output of the token in pretty, short, token, or token-check",
         default="pretty",
-        choices={"pretty", "short", "token", "token-check", "json"},
+        choices={"pretty", "short", "token", "token-check", "json", "yaml"},
     )
 
     # read arguments from the command line
@@ -173,5 +187,7 @@ if __name__ == "__main__":
         print(f"{token}/{check}")
     elif args.format == "json":
         print_json(token, check)
+    elif args.format == "yaml":
+        print_yaml(token, check)
     else:
         print(token)

--- a/scripts/cluster/add_token.py
+++ b/scripts/cluster/add_token.py
@@ -101,29 +101,21 @@ def print_pretty(token, check):
 def get_output_dict(token, check):
     _, all_ips, port = get_network_info()
     info = {
-                "token": f"{token}/{check}",
-                "urls": [f"{ip}:{port}/{token}/{check}" for ip in all_ips],
+        "token": f"{token}/{check}",
+        "urls": [f"{ip}:{port}/{token}/{check}" for ip in all_ips],
     }
     return info
 
 
 def print_json(token, check):
     info = get_output_dict(token, check)
-    print(
-        json.dumps(
-            info,
-            indent=2,
-        )
-    )
+    print(json.dumps(info, indent=2))
+
 
 def print_yaml(token, check):
     info = get_output_dict(token, check)
-    print(
-        yaml.dump(
-            info,
-            indent=2,
-        )
-    )
+    print(yaml.dump(info, indent=2))
+
 
 def print_short(token, check):
     default_ip, all_ips, port = get_network_info()

--- a/scripts/cluster/add_token.py
+++ b/scripts/cluster/add_token.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 import time
@@ -97,6 +98,19 @@ def print_pretty(token, check):
         print(f"microk8s join {ip}:{port}/{token}/{check}")
 
 
+def print_json(token, check):
+    _, all_ips, port = get_network_info()
+    print(
+        json.dumps(
+            {
+                "token": f"{token}/{check}",
+                "urls": [f"{ip}:{port}/{token}/{check}" for ip in all_ips],
+            },
+            indent=2,
+        )
+    )
+
+
 def print_short(token, check):
     default_ip, all_ips, port = get_network_info()
 
@@ -131,7 +145,7 @@ if __name__ == "__main__":
         "--format",
         help="Format the output of the token in pretty, short, token, or token-check",
         default="pretty",
-        choices={"pretty", "short", "token", "token-check"},
+        choices={"pretty", "short", "token", "token-check", "json"},
     )
 
     # read arguments from the command line
@@ -157,5 +171,7 @@ if __name__ == "__main__":
         print_short(token, check)
     elif args.format == "token-check":
         print(f"{token}/{check}")
+    elif args.format == "json":
+        print_json(token, check)
     else:
         print(token)

--- a/scripts/cluster/add_token.py
+++ b/scripts/cluster/add_token.py
@@ -98,6 +98,7 @@ def print_pretty(token, check):
     for ip in all_ips:
         print(f"microk8s join {ip}:{port}/{token}/{check}")
 
+
 def get_output_dict(token, check):
     _, all_ips, port = get_network_info()
     info = {


### PR DESCRIPTION
### Summary

Add support for `--format json` in the `microk8s add-node` command. Example output:

```bash
$ microk8s add-node --format json
{
  "token": "d1b89bff339243598ea96e72a23cf015/9f45c8048db9",
  "urls": [
    "10.0.0.197:25000/d1b89bff339243598ea96e72a23cf015/9f45c8048db9",
    "10.0.0.210:25000/d1b89bff339243598ea96e72a23cf015/9f45c8048db9"
  ]
}
```