### PR TITLE
scripts: remove all 'sudo' invocations from inspect.sh

### DIFF
--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -89,7 +89,7 @@ function store_kubernetes_info {
 }
 
 function check_storage_addon {
-  image=`sudo -E /snap/bin/microk8s kubectl get deploy -n kube-system hostpath-provisioner -o jsonpath='{.spec.template.spec.containers[0].image}' 2>&1`
+  image=`/snap/bin/microk8s kubectl get deploy -n kube-system hostpath-provisioner -o jsonpath='{.spec.template.spec.containers[0].image}' 2>&1`
 
   case "$image" in
     cdkbot/hostpath-provisioner-amd64:1.0.0|cdkbot/hostpath-provisioner-arm64:1.0.0)
@@ -111,10 +111,10 @@ function store_dqlite_info {
   # Collect some dqlite details
   printf -- '  Inspect dqlite\n'
   mkdir -p $INSPECT_DUMP/dqlite
-  sudo -E cp ${SNAP_DATA}/var/kubernetes/backend/cluster.yaml $INSPECT_DUMP/dqlite/
-  sudo -E cp ${SNAP_DATA}/var/kubernetes/backend/localnode.yaml $INSPECT_DUMP/dqlite/
-  sudo -E cp ${SNAP_DATA}/var/kubernetes/backend/info.yaml $INSPECT_DUMP/dqlite/
-  sudo -E ls -lh ${SNAP_DATA}/var/kubernetes/backend/ 2>&1 >  $INSPECT_DUMP/dqlite/list.out
+  cp ${SNAP_DATA}/var/kubernetes/backend/cluster.yaml $INSPECT_DUMP/dqlite/
+  cp ${SNAP_DATA}/var/kubernetes/backend/localnode.yaml $INSPECT_DUMP/dqlite/
+  cp ${SNAP_DATA}/var/kubernetes/backend/info.yaml $INSPECT_DUMP/dqlite/
+  ls -lh ${SNAP_DATA}/var/kubernetes/backend/ 2>&1 >  $INSPECT_DUMP/dqlite/list.out
 }
 
 


### PR DESCRIPTION
We are anyway recommending to run the inspect script with sudo (and
under strict confinement we cannor execute /bin/sudo anyway...).
