### PR TITLE
Fixes for git to work with strict confinement

### DIFF
--- a/microk8s-resources/wrappers/git.wrapper
+++ b/microk8s-resources/wrappers/git.wrapper
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+export GIT_EXEC_PATH="$SNAP/usr/lib/git-core"
+export GIT_TEMPLATE_DIR="$SNAP/usr/share/git-core/templates"
+export GIT_CONFIG_NOSYSTEM=1
+
+"$SNAP/usr/bin/git" $@

--- a/microk8s-resources/wrappers/microk8s-addons.wrapper
+++ b/microk8s-resources/wrappers/microk8s-addons.wrapper
@@ -5,8 +5,6 @@ set -eu
 source $SNAP/actions/common/utils.sh
 
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
-export GIT_EXEC_PATH="$SNAP/usr/lib/git-core"
-export GIT_TEMPLATE_DIR="$SNAP/usr/share/git-core/templates"
 
 ARCH="$($SNAP/bin/uname -m)"
 export IN_SNAP_LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"

--- a/scripts/wrappers/addons.py
+++ b/scripts/wrappers/addons.py
@@ -10,6 +10,8 @@ import yaml
 
 from common.utils import get_current_arch, snap_common
 
+GIT = os.path.expandvars("$SNAP/git.wrapper")
+
 addons = click.Group()
 
 repository = click.Group("repo")
@@ -32,7 +34,7 @@ def add(name: str, repository: str, reference: str, force: bool):
         click.echo("Removing {}".format(repo_dir))
         shutil.rmtree(repo_dir)
 
-    cmd = ["git", "clone", repository, repo_dir]
+    cmd = [GIT, "clone", repository, repo_dir]
     if reference is not None:
         cmd += ["-b", reference]
 
@@ -73,7 +75,7 @@ def update(name: str):
         sys.exit(1)
 
     click.echo("Updating repository {}".format(name))
-    subprocess.check_call(["git", "pull"], cwd=repo_dir)
+    subprocess.check_call([GIT, "pull"], cwd=repo_dir)
 
     if not (repo_dir / "addons.yaml").exists():
         click.echo(
@@ -104,10 +106,10 @@ def list(format: str):
             source = "(built-in)"
             try:
                 remote_url = subprocess.check_output(
-                    ["git", "remote", "get-url", "origin"], cwd=repo_dir, stderr=subprocess.DEVNULL
+                    [GIT, "remote", "get-url", "origin"], cwd=repo_dir, stderr=subprocess.DEVNULL
                 ).decode()
                 revision = subprocess.check_output(
-                    ["git", "rev-parse", "HEAD"], cwd=repo_dir, stderr=subprocess.DEVNULL
+                    [GIT, "rev-parse", "HEAD"], cwd=repo_dir, stderr=subprocess.DEVNULL
                 ).decode()[:6]
                 source = "{}@{}".format(remote_url.strip(), revision.strip())
             except (subprocess.CalledProcessError, TypeError, ValueError):

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -16,7 +16,7 @@ then
   mkdir -p ${SNAP_COMMON}/addons
   snap_current=`echo "${SNAP}" | sed -e "s,${SNAP_REVISION},current,"`
   for addon in $(cat "${SNAP}/addons/.auto-add"); do
-    git clone "${snap_current}/addons/${addon}" "${SNAP_COMMON}/addons/${addon}"
+    "${SNAP}/git.wrapper" clone "${snap_current}/addons/${addon}" "${SNAP_COMMON}/addons/${addon}"
   done
 fi
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -22,12 +22,6 @@ else
   echo "\`/var/lib/kubelet\` already exists.  Will not be linking to $SNAP_COMMON"
 fi
 
-# Install the core addons
-snap_current=`echo "${SNAP}" | sed -e "s,${SNAP_REVISION},current,"`
-for addon in $(cat "${SNAP}/addons/.auto-add"); do
-  git clone "${snap_current}/addons/${addon}" "${SNAP_COMMON}/addons/${addon}"
-done
-
 # Create the certificates
 mkdir ${SNAP_DATA}/certs
 # Allow the ability to add external IPs to the csr, by moving the csr.conf.template to SNAP_DATA


### PR DESCRIPTION
### Summary

git uses a few helper paths and configuration files from the system. Make sure that we do not get failures when running in strict

Also, remove the git clone from the install hook (it is already there in the configure hook).