### PR TITLE
Do not load the community repo

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -54,6 +54,7 @@ jobs:
           export SKIP_PROMETHEUS="False"
           (cd tests; pytest -s verify-branches.py)
           sudo -E bash -c "cd /var/snap/microk8s/common/addons/core/tests; pytest -s -ra test-addons.py"
+          sudo microk8s enable community
           sudo -E bash -c "cd /var/snap/microk8s/common/addons/community/tests; pytest -s -ra test-addons.py"
           sudo snap remove microk8s --purge
       - name: Running upgrade tests

--- a/build-scripts/set-env-variables.sh
+++ b/build-scripts/set-env-variables.sh
@@ -53,7 +53,7 @@ export ADDONS_REPOS="
 core,${CORE_ADDONS_REPO:-https://github.com/canonical/microk8s-core-addons},${CORE_ADDONS_REPO_BRANCH:-main}
 community,${COMMUNITY_ADDONS_REPO:-https://github.com/canonical/microk8s-addons},${COMMUNITY_ADDONS_REPO_BRANCH:-main}
 "
-export ADDONS_REPOS_ENABLED="core community"
+export ADDONS_REPOS_ENABLED="core"
 
 echo "Building with:"
 echo "KUBE_VERSION=${KUBE_VERSION}"

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -369,7 +369,7 @@ def parse_xable_single_arg(addon_arg: str, available_addons: list):
             if is_community_addon(get_current_arch(), addon_name):
                 click.echo("To use the community maintained flavor enable the respective repository:")
                 click.echo("")
-                click.echo("    mcirok8s enable community")
+                click.echo("    microk8s enable community")
                 click.echo("")
 
             sys.exit(1)

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -232,12 +232,7 @@ def get_available_addons(arch):
 
             for addon in addons["microk8s-addons"]["addons"]:
                 if arch in addon["supported_architectures"]:
-                    available.append(
-                        {
-                            **addon,
-                            "repository": dir,
-                        }
-                    )
+                    available.append({**addon, "repository": dir})
         except Exception:
             LOG.exception("could not load addons from %s", addons_yaml)
 
@@ -367,7 +362,9 @@ def parse_xable_single_arg(addon_arg: str, available_addons: list):
         if len(matching_repos) == 0:
             click.echo("Addon {} was not found in any repository".format(addon_name), err=True)
             if is_community_addon(get_current_arch(), addon_name):
-                click.echo("To use the community maintained flavor enable the respective repository:")
+                click.echo(
+                    "To use the community maintained flavor enable the respective repository:"
+                )
                 click.echo("")
                 click.echo("    microk8s enable community")
                 click.echo("")

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -199,6 +199,29 @@ def kubectl_get_clusterroles():
     )
 
 
+def is_community_addon(arch, addon_name):
+    """
+    Check if an addon is part of the community repo.
+
+    :param arch: architecture of the addon we are looking for
+    :param addon_name: name of the addon we are looking for
+    :return: True if the addon is in the community repo
+    """
+    try:
+        addons_yaml = f"{os.environ['SNAP']}/addons/community/addons.yaml"
+        with open(addons_yaml, "r") as fin:
+            addons = yaml.safe_load(fin)
+
+        for addon in addons["microk8s-addons"]["addons"]:
+            if arch in addon["supported_architectures"]:
+                if addon_name == addon["name"]:
+                    return True
+    except Exception:
+        LOG.exception("could not load addons from %s", addons_yaml)
+
+    return False
+
+
 def get_available_addons(arch):
     available = []
     for dir in os.listdir(snap_common() / "addons"):
@@ -343,6 +366,12 @@ def parse_xable_single_arg(addon_arg: str, available_addons: list):
         matching_repos = [repo for (repo, addon) in available_addons if addon == addon_name]
         if len(matching_repos) == 0:
             click.echo("Addon {} was not found in any repository".format(addon_name), err=True)
+            if is_community_addon(get_current_arch(), addon_name):
+                click.echo("To use the community maintained flavor enable the respective repository:")
+                click.echo("")
+                click.echo("    mcirok8s enable community")
+                click.echo("")
+
             sys.exit(1)
         elif len(matching_repos) == 1:
             click.echo(

--- a/scripts/wrappers/reset.py
+++ b/scripts/wrappers/reset.py
@@ -71,6 +71,10 @@ def disable_addons(destroy_storage):
         if addon["name"] == "ha-cluster":
             continue
 
+        # Do not disable the community repository
+        if addon["name"] == "community":
+            continue
+
         print(f"Disabling addon : {addon['repository']}/{addon['name']}")
         # Do not disable disabled addons
         if addon in disabled:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -560,7 +560,7 @@ parts:
         reference="$(echo ${line} | cut -f3 -d',')"
         git clone "${repository}" -b "${reference}" "addons/${name}"
       done
-      echo "${ADDONS_REPOS_ENABLED}" > addons/.auto-add
+      echo "core" > addons/.auto-add
 
       snapcraftctl build
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -560,7 +560,7 @@ parts:
         reference="$(echo ${line} | cut -f3 -d',')"
         git clone "${repository}" -b "${reference}" "addons/${name}"
       done
-      echo "core" > addons/.auto-add
+      echo "${ADDONS_REPOS_ENABLED}" > addons/.auto-add
 
       snapcraftctl build
 

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -96,6 +96,7 @@ fi
 lxc exec $NAME -- /var/tmp/tests/smoke-test.sh
 # use 'script' for required tty: https://github.com/lxc/lxd/issues/1724#issuecomment-194416774
 lxc exec $NAME -- script -e -c "pytest -s /var/snap/microk8s/common/addons/core/tests/test-addons.py"
+lxc exec $NAME -- microk8s enable community
 lxc exec $NAME -- script -e -c "pytest -s /var/snap/microk8s/common/addons/community/tests/test-addons.py"
 lxc exec $NAME -- microk8s reset
 lxc delete $NAME --force


### PR DESCRIPTION
With this PR we stop loading the community repository by default. This was we do not clutter the UX with often irrelevant addons. If however we detect that an addon is in the community repository we prompt the user to enable the repository with a `microk8s enable community` call.