### PR TITLE
add crun to containerd-template.toml

### DIFF
--- a/microk8s-resources/default-args/containerd-template.toml
+++ b/microk8s-resources/default-args/containerd-template.toml
@@ -64,6 +64,12 @@ oom_score = 0
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
         BinaryName = "kata-runtime"
 
+   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.crun]
+      runtime_type = "${RUNTIME_TYPE}"
+      pod_annotations = ["*.wasm.*", "wasm.*", "module.wasm.image/*", "*.module.wasm.image", "module.wasm.image/variant.*", "run.oci.handler"]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.crun.options]
+        BinaryName = "crun"
+
   # 'plugins."io.containerd.grpc.v1.cri".cni' contains config related to cni
   [plugins."io.containerd.grpc.v1.cri".cni]
     # bin_dir is the directory in which the binaries for the plugin is kept.


### PR DESCRIPTION
Crun runtime support would be needed for adding native WebAssembly support as add-on. https://github.com/canonical/microk8s-addons/issues/27

*Also verify you have:*
* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
