### PR TITLE
Ensure the configure hook detects the API server comming up

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -788,6 +788,15 @@ refresh_calico_if_needed() {
 
 ############################# Strict functions ######################################
 
+log_init () {
+  echo `date +"[%m-%d %H:%M:%S]" start logging` > $SNAP_COMMON/var/log/microk8s.log
+}
+
+log () {
+  echo -n `date +"[%m-%d %H:%M:%S]"` >> $SNAP_COMMON/var/log/microk8s.log
+  echo ": $@" >> $SNAP_COMMON/var/log/microk8s.log
+}
+
 is_strict() {
   # Return 0 if we are in strict mode
   if cat $SNAP/meta/snap.yaml | grep confinement | grep -q strict
@@ -841,13 +850,12 @@ check_snap_interfaces() {
     then
         snapctl set-health blocked "You must connect ${missing[*]} before proceeding"
         exit 0
-    else
-        if [ $1 -gt 0 ]
-        then
-            snapctl start --enable ${SNAP_NAME}
-            snapctl set-health okay
-        fi
     fi
+}
+
+enable_snap() {
+  snapctl start --enable ${SNAP_NAME}
+  snapctl set-health okay
 }
 
 exit_if_not_root() {

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -9,7 +9,10 @@ fi
 
 source $SNAP/actions/common/utils.sh
 
-check_snap_interfaces 0  # Check for interfaces but do not start until this script has run.
+ARCH="$($SNAP/bin/uname -m)"
+export LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
+
+check_snap_interfaces # Check for interfaces but do not start until this script has run.
 
 need_api_restart=false
 need_proxy_restart=false
@@ -358,8 +361,6 @@ then
   chgrp snap_microk8s -R ${SNAP_COMMON}/addons ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock/ ${SNAP_DATA}/var/kubernetes/backend/ ${SNAP_DATA}/tmp/ || true
 fi
 
-try_copy_users_to_snap_microk8s
-
 if ! [ -e "${SNAP_DATA}/opt/cni/bin/flanneld" ]
 then
   # cover situation where cilium was installed prior to this update
@@ -598,6 +599,8 @@ fi
 # Refresh calico if needed
 refresh_calico_if_needed
 
+enable_snap
+
 # Restart reconfigured services
 if ${need_api_restart} ||
    ${need_proxy_restart} ||
@@ -649,4 +652,3 @@ then
   fi
 fi
 
-check_snap_interfaces 1  # Check for interfaces and enable all services.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,7 +53,9 @@ slots:
 hooks:
   configure:
     plugs:
+      - account-control
       - dot-kube
+      - network
   install:
     plugs:
       - network-bind


### PR DESCRIPTION
This PR works on the following:

- in the configure hook sets the LD_LIBRARY_PATH to include the libcurl so we can curl the API server and detect when it is ready.
- adds two interfaces in the configure hook so curl is not blocked
- remove `try_copy_users_to_snap_microk8s` as we are not able to do the user modifications from within a strict snap
- break up the check_snap_interfaces into two to improve code readability.
- introduces two log functions. Although these functions are not used they are very useful for tracing the happy path in the snaps hooks. Lets keep them for debugging purposes.
