### PR TITLE
Add home-read-all to microk8s so the git.wrapper does not complain

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -163,6 +163,7 @@ apps:
     plugs:
       - account-control
       - docker-unprivileged
+      - home-read-all
       - network-control
   daemon-etcd:
     command: run-etcd-with-args


### PR DESCRIPTION
Without the `home-read-all` interface the git.wrapper is not able to clone local directories. Fixes errors like: 
```
+ sudo microk8s addons repo add core .
fatal: repository '.' does not exist
Traceback (most recent call last):
  File "/snap/microk8s/3069/scripts/wrappers/addons.py", line 1[41](https://github.com/canonical/microk8s-core-addons/runs/5736312714?check_suite_focus=true#step:4:41), in <module>
    addons(prog_name="microk8s addons")
  File "/snap/microk8s/3069/usr/lib/python3/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/snap/microk8s/3069/usr/lib/python3/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/snap/microk8s/3069/usr/lib/python3/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/snap/microk8s/3069/usr/lib/python3/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/snap/microk8s/3069/usr/lib/python3/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/snap/microk8s/3069/usr/lib/python3/dist-packages/click/core.py", line [53](https://github.com/canonical/microk8s-core-addons/runs/5736312714?check_suite_focus=true#step:4:53)5, in invoke
    return callback(*args, **kwargs)
  File "/snap/microk8s/3069/scripts/wrappers/addons.py", line 41, in add
    subprocess.check_call(cmd)
  File "/snap/microk8s/3069/usr/lib/python3.6/subprocess.py", line 311, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/snap/microk8s/3069/git.wrapper', 'clone', '.', PosixPath('/var/snap/microk8s/common/addons/core')]' returned non-zero exit status 128.
Error: Process completed with exit code 1.
```
See https://github.com/canonical/microk8s-core-addons/runs/5736312714?check_suite_focus=true for an example run.