### PR TITLE
Pin click to 8.0.4 to fix Black

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ passenv =
     MK8S_*
 deps =
     black ==21.4b2
+    click ==8.0.4
     flake8
     flake8-colors
     pep8-naming


### PR DESCRIPTION
Backport relevant parts of #3014 to 1.23 branch.