### PR TITLE
Point to new community addons repo

### DIFF
--- a/build-scripts/set-env-variables.sh
+++ b/build-scripts/set-env-variables.sh
@@ -51,7 +51,7 @@ export KUBE_SNAP_ROOT="$(readlink -f .)"
 
 export ADDONS_REPOS="
 core,${CORE_ADDONS_REPO:-https://github.com/canonical/microk8s-core-addons},${CORE_ADDONS_REPO_BRANCH:-main}
-community,${COMMUNITY_ADDONS_REPO:-https://github.com/canonical/microk8s-addons},${COMMUNITY_ADDONS_REPO_BRANCH:-main}
+community,${COMMUNITY_ADDONS_REPO:-https://github.com/canonical/microk8s-community-addons},${COMMUNITY_ADDONS_REPO_BRANCH:-main}
 "
 export ADDONS_REPOS_ENABLED="core"
 


### PR DESCRIPTION
### Description

The addons repository has been renamed from `microk8s-addons` to `microk8s-community-addons`. This PR updates the reference to it.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
