### PR TITLE
Fix containerd build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -425,7 +425,7 @@ parts:
     override-build: |
       set -eux
       . $SNAPCRAFT_PART_SRC/set-env-variables.sh
-      snap refresh go --channel=1.15/stable || true
+      snap refresh go --channel=1.17/stable || true
       go version
       export GOPATH=$(realpath ../go)
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
@@ -433,15 +433,15 @@ parts:
       # Build containerd
       rm -rf $GOPATH
       mkdir -p $GOPATH
-      go get -d github.com/containerd/containerd
+      git clone https://github.com/containerd/containerd $GOPATH/containerd
       (
-        cd $GOPATH/src/github.com/containerd/containerd
+        cd $GOPATH/containerd
         git checkout -f ${CONTAINERD_COMMIT}
         # building the btrfs driver can be disabled via the
         # build tag no_btrfs, removing this dependency
         make
       )
-      cp $GOPATH/src/github.com/containerd/containerd/bin/* $SNAPCRAFT_PART_INSTALL/bin/
+      cp $GOPATH/containerd/bin/* $SNAPCRAFT_PART_INSTALL/bin/
       rm $SNAPCRAFT_PART_INSTALL/bin/containerd-stress
 
       # Assemble the snap


### PR DESCRIPTION
### Summary

Fixes for building containerd.

- Update Go to version 1.17 (same as in go.mod of containerd)
- Fetch containerd repository with git clone instead of go get.

This needs to be backported to all stable tracks, and is affecting #3030 

### Notes

Fixes the following error

```
+ go get -d github.com/containerd/containerd
[06/Apr/2022:21:06:34 +0000] "CONNECT github.com:443 HTTP/1.1" 200 83078509 "-" "git/2.17.1"
package embed: unrecognized import path "embed": import path does not begin with hostname
```