### PR TITLE
Do not print path to wrapper script for start/stop/config commands

### DIFF
--- a/microk8s-resources/wrappers/microk8s-config.wrapper
+++ b/microk8s-resources/wrappers/microk8s-config.wrapper
@@ -22,7 +22,7 @@ while true; do
             shift
             ;;
         -h|--help)
-            echo "Usage: $0 [OPTIONS]"
+            echo "Usage: microk8s config [OPTIONS]"
             echo
             echo "Retrieve the client config, similar to microk8s kubectl config view --raw"
             echo
@@ -37,7 +37,7 @@ while true; do
             break
             ;;
         *)
-            echo "$0: invalid option -- $1"
+            echo "microk8s config: invalid option -- $1"
             exit 1
     esac
 done

--- a/microk8s-resources/wrappers/microk8s-start.wrapper
+++ b/microk8s-resources/wrappers/microk8s-start.wrapper
@@ -23,7 +23,7 @@ while true; do
             shift
             ;;
         -h|--help)
-            echo "Usage: $0 [OPTIONS]"
+            echo "Usage: microk8s start [OPTIONS]"
             echo
             echo "Start Kubernetes services"
             echo
@@ -37,7 +37,7 @@ while true; do
             break
             ;;
         *)
-            echo "$0: invalid option -- $1"
+            echo "microk8s start: invalid option -- $1"
             exit 1
     esac
 done

--- a/microk8s-resources/wrappers/microk8s-stop.wrapper
+++ b/microk8s-resources/wrappers/microk8s-stop.wrapper
@@ -21,7 +21,7 @@ eval set -- "$PARSED"
 while true; do
     case "$1" in
         -h|--help)
-            echo "Usage: $0 [OPTIONS]"
+            echo "Usage: microk8s stop [OPTIONS]"
             echo
             echo "Stop Kubernetes services"
             echo
@@ -34,7 +34,7 @@ while true; do
             break
             ;;
         *)
-            echo "$0: invalid option -- $1"
+            echo "microk8s stop: invalid option -- $1"
             exit 1
     esac
 done


### PR DESCRIPTION
### Summary

Fix `microk8s start`, `microk8s stop` and `microk8s config` commands printing the internal wrapper script in usage messages.