### PR TITLE
fix name of cluster agent service

### DIFF
--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -56,7 +56,7 @@ do
         if [[ "$csr_modified" -eq "1" ]];
         then
             echo "CSR change detected. Restarting the cluster-agent"
-            snapctl restart microk8s.cluster-agent
+            snapctl restart microk8s.daemon-cluster-agent
 
             echo "CSR change detected. Reconfiguring the kube-apiserver"
             rm -rf .srl


### PR DESCRIPTION
### Summary

Fix the name of the cluster agent service. Followup fix for typo in #3054

### Note

Fixes

```
Apr 13 17:23:24 test-3 microk8s.daemon-apiserver-kicker[3342]: CSR change detected. Restarting the cluster-agent
Apr 13 17:23:24 test-3 microk8s.daemon-apiserver-kicker[8134]: error: error running snapctl: unknown service: "microk8s.cluster-agent"
```