### PR TITLE
Add `microk8s version` command

### DIFF
--- a/build-scripts/set-env-variables.sh
+++ b/build-scripts/set-env-variables.sh
@@ -58,6 +58,16 @@ export ADDONS_REPOS_ENABLED="core"
 export CLUSTER_AGENT_REPO="${CLUSTER_AGENT_REPO:-https://github.com/canonical/microk8s-cluster-agent}"
 export CLUSTER_AGENT_TAG="${CLUSTER_AGENT_TAG:-main}"
 
+
+write_versions_file() {
+  VERSIONS_FILE="${SNAP_DATA}/versions.json"
+  echo "Writing versions at ${VERSIONS_FILE} ..."
+  rm -rf $VERSIONS_FILE
+  echo "{\"kube\":\"${KUBE_VERSION}\",\"cni\":\"${CNI_VERSION}\"}" > $VERSIONS_FILE
+}
+
+write_versions_file
+
 echo "Building with:"
 echo "KUBE_VERSION=${KUBE_VERSION}"
 echo "ETCD_VERSION=${ETCD_VERSION}"

--- a/microk8s-resources/wrappers/microk8s-version.wrapper
+++ b/microk8s-resources/wrappers/microk8s-version.wrapper
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eu
+
+source $SNAP/actions/common/utils.sh
+
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+
+ARCH="$($SNAP/bin/uname -m)"
+export IN_SNAP_LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
+export PYTHONNOUSERSITE=false
+
+exit_if_no_permissions
+
+LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/version.py $@

--- a/microk8s-resources/wrappers/microk8s.wrapper
+++ b/microk8s-resources/wrappers/microk8s.wrapper
@@ -27,6 +27,9 @@ elif [ "${APP}" == "inspect" ]; then
 elif [ "${APP}" == "help" ] || [ "${APP}" == "--help" ] || [ "$APP" == "-h" ]; then
     help
     readonly EXIT="0"
+elif [ "${APP}" == "--version" ]; then
+    "${SNAP}/microk8s-version.wrapper"
+    readonly EXIT="$?"
 else
     echo "'${APP}' is not a valid MicroK8s subcommand."
     help

--- a/scripts/wrappers/version.py
+++ b/scripts/wrappers/version.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+import click
+import json
+from common.utils import snap_data
+from common.utils import run
+
+
+VERSIONS_FILE_NAME = "versions.json"
+VERSIONS_FILE_PATH = snap_data() / VERSIONS_FILE_NAME
+
+
+VERSIONS = None
+
+
+def get_upstream_version(upstream: str) -> str:
+    global VERSIONS
+
+    if VERSIONS is None:
+        # Cache versions
+        VERSIONS = _read_versions_file()
+
+    return VERSIONS[upstream]
+
+
+def _read_versions_file():
+    with open(VERSIONS_FILE_PATH, mode="r") as versions_file:
+        versions = json.loads(versions_file.read())
+        return versions
+
+
+def get_snap_version_data():
+    output = run("snap", "list", "microk8s")
+    snap_info = output.split("\n")[1]
+    version, revision = snap_info.split()[1:3]
+    return version, revision
+
+
+def print_versions() -> None:
+    version, revision = get_snap_version_data()
+    print(f"MicroK8s {version} revision: {revision}")
+
+    kube_version = get_upstream_version("kube")
+    print(f"  - K8s: {kube_version}")
+
+    cni_version = get_upstream_version("cni")
+    print(f"  - CNI: {cni_version}")
+
+
+@click.command(
+    context_settings={
+        "help_option_names": ["-h", "--help"],
+    }
+)
+def versions_command():
+    """
+    Shows version information for MicroK8s and its upstream components.
+    """
+    print_versions()
+
+
+if __name__ == "__main__":
+    versions_command(prog_name="microk8s version")

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,6 +67,8 @@ apps:
   kubectl:
     command: microk8s-kubectl.wrapper
     completer: kubectl.bash
+  version:
+    command: microk8s-version.wrapper
   add-node:
     command: microk8s-add-node.wrapper
   addons:


### PR DESCRIPTION
### Description

fixes #3065 

The proposed implementation is the following:
- At build time, we write upstream versions (kubernetes and CNI so far) into a var file.
- `version` command reads from the file.
- Snap version and revision is queried from `snap list microk8s`

