### PR TITLE
Include kernel module utils in the snap - 1.23

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -506,6 +506,7 @@ parts:
       - hostname
       - iproute2
       - jq
+      - kmod
       - libatm1
       - members
       - net-tools


### PR DESCRIPTION
Back porting https://github.com/canonical/microk8s/pull/3102 to 1.23