### PR TITLE
Fix inconsistent CLI help sections in join and leave  

### DIFF
--- a/.github/workflows/check-unit-tests.yml
+++ b/.github/workflows/check-unit-tests.yml
@@ -21,3 +21,4 @@ jobs:
         run: |
           tox -e scripts
           tox -e wrappers
+          tox -e cluster

--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -900,7 +900,9 @@ def join_etcd(connection_parts, verify=True):
     mark_no_cert_reissue()
 
 
-@click.command(context_settings={"ignore_unknown_options": True, "help_option_names": ["-h", "--help"]})
+@click.command(
+    context_settings={"ignore_unknown_options": True, "help_option_names": ["-h", "--help"]}
+)
 @click.argument("connection", required=True)
 @click.option(
     "--worker", "worker", default=False, flag_value="as-worker", help="Join as a worker only node."

--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -900,7 +900,7 @@ def join_etcd(connection_parts, verify=True):
     mark_no_cert_reissue()
 
 
-@click.command(context_settings={"ignore_unknown_options": True})
+@click.command(context_settings={"ignore_unknown_options": True, "help_option_names": ["-h", "--help"]})
 @click.argument("connection", required=True)
 @click.option(
     "--worker", "worker", default=False, flag_value="as-worker", help="Join as a worker only node."

--- a/scripts/cluster/leave.py
+++ b/scripts/cluster/leave.py
@@ -373,7 +373,7 @@ def delete_dqlite_node(delete_node, dqlite_ep):
                 exit(2)
 
 
-@click.command()
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
 def leave():
     """
     The node will depart from the cluster it is in.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,3 +5,4 @@ pytest
 pytest-xdist
 pyyaml
 sh
+netifaces

--- a/tests/unit/cluster/test_join.py
+++ b/tests/unit/cluster/test_join.py
@@ -1,0 +1,18 @@
+from click.testing import CliRunner
+from join import join as command
+from unittest.mock import patch
+
+
+def test_command_help_arguments():
+    runner = CliRunner()
+    for help_arg in ("-h", "--help"):
+        result = runner.invoke(command, [help_arg])
+        assert result.exit_code == 0
+        assert "Join the node to a cluster" in result.output
+
+
+def test_command_errors_if_no_arguments():
+    runner = CliRunner()
+    result = runner.invoke(command, [])
+    assert result.exit_code != 0
+    assert "Error: Missing argument" in result.output

--- a/tests/unit/cluster/test_join.py
+++ b/tests/unit/cluster/test_join.py
@@ -1,6 +1,5 @@
 from click.testing import CliRunner
 from join import join as command
-from unittest.mock import patch
 
 
 def test_command_help_arguments():

--- a/tests/unit/cluster/test_leave.py
+++ b/tests/unit/cluster/test_leave.py
@@ -1,0 +1,10 @@
+from click.testing import CliRunner
+from leave import leave as command
+
+
+def test_command_help_arguments():
+    runner = CliRunner()
+    for help_arg in ("-h", "--help"):
+        result = runner.invoke(command, [help_arg])
+        assert result.exit_code == 0
+        assert "The node will depart from the cluster it is in" in result.output

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,15 @@ commands =
 [testenv:wrappers]
 setenv = PYTHONPATH={toxinidir}/scripts/wrappers
 commands =
-    pytest -s tests/unit/ --ignore=tests/unit/test_upgrade_calico_cni.py --ignore=tests/unit/test_addons.py {posargs}
+    pytest -s tests/unit/ \ 
+        --ignore=tests/unit/test_upgrade_calico_cni.py \
+        --ignore-glob=tests/unit/cluster/* \
+        --ignore=tests/unit/test_addons.py {posargs}
+
+[testenv:cluster]
+setenv = PYTHONPATH={toxinidir}/scripts/cluster
+commands =
+    pytest -s tests/unit/cluster {posargs}
 
 [testenv:clustering]
 commands = pytest -s tests/test-cluster.py


### PR DESCRIPTION
### Description
This PR unifies CLI help messages for join and leave commands.

#### Before
```bash
$ microk8s join --help
Join a cluster: microk8s join <master>:<port>/<token> [options]

Options:
--skip-verify  skip the certificate verification of the node we are joining to (default: false).
```
```bash
$ microk8s leave --help
Usage: microk8s leave

With microk8s leave the node will depart from the cluster it is in.
```

#### After:
```bash
$ microk8s join --help
Usage: join [OPTIONS] CONNECTION                                                                                                                                       
                                                                                                                                                                       
  Join the node to a cluster                                                                                                                                           
                                                                                                                                                                       
  CONNECTION: the cluster connection endpoint in format                                                                                                                
  <master>:<port>/<token>                                                                                                                                              
                                                                                                                                                                       
Options:                                                                                                                                                                                                                           
  --skip-verify               Skip the certificate verification of the node we are joining to. (default: false)                                                                                                                                                                                                
  -h, --help                  Show this message and exit.
```
```bash
$ microk8s leave --help
Usage: leave [OPTIONS]

  The node will depart from the cluster it is in.

Options:
  -h, --help  Show this message and exit. 
```