### PR TITLE
remove the apparmor parameters mount from the microk8s profile

### DIFF
--- a/tests/lxc/microk8s-zfs.profile
+++ b/tests/lxc/microk8s-zfs.profile
@@ -15,10 +15,6 @@ devices:
     path: /sys/module/nf_conntrack/parameters/hashsize
     source: /sys/module/nf_conntrack/parameters/hashsize
     type: disk
-  aadisable1:
-    path: /sys/module/apparmor/parameters/enabled
-    source: /dev/null
-    type: disk
   aadisable2:
     path: /dev/zfs
     source: /dev/zfs

--- a/tests/lxc/microk8s.profile
+++ b/tests/lxc/microk8s.profile
@@ -15,10 +15,6 @@ devices:
     path: /sys/module/nf_conntrack/parameters/hashsize
     source: /sys/module/nf_conntrack/parameters/hashsize
     type: disk
-  aadisable1:
-    path: /sys/module/apparmor/parameters/enabled
-    source: /dev/null
-    type: disk
   aadisable2:
     path: /dev/kmsg
     source: /dev/kmsg


### PR DESCRIPTION
### Summary

Fixes #3121

### Testing

- Launch a container with the new profile (testing with ubuntu:18.04, ubuntu:20.04, ubuntu:22.04)
- Install microk8s and run unit tests.
