### PR TITLE
Prepare for 1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MicroK8s
 
-![](https://img.shields.io/badge/Kubernetes-1.23-326de6.svg)
+![](https://img.shields.io/badge/Kubernetes-1.24-326de6.svg)
 
 <img src="/docs/images/certified_kubernetes_color-222x300.png" align="right" width="200px">
 

--- a/build-scripts/patches/0000-Kubelite-integration.patch
+++ b/build-scripts/patches/0000-Kubelite-integration.patch
@@ -1,4 +1,4 @@
-From 3198c607c243bd4363eadc7d9223e3a743f85215 Mon Sep 17 00:00:00 2001
+From 16262f01a972ef4f2f88c5953e8114106e834351 Mon Sep 17 00:00:00 2001
 From: Konstantinos Tsakalozos <kos.tsakalozos@canonical.com>
 Date: Wed, 3 Mar 2021 18:19:37 +0200
 Subject: [PATCH] Kubelite integration
@@ -19,10 +19,10 @@ Subject: [PATCH] Kubelite integration
  create mode 100644 cmd/kubelite/kubelite.go
 
 diff --git a/cmd/kube-apiserver/app/server.go b/cmd/kube-apiserver/app/server.go
-index 411567a4175..a871cc9c975 100644
+index 0887d9124ba..c7ece2136a1 100644
 --- a/cmd/kube-apiserver/app/server.go
 +++ b/cmd/kube-apiserver/app/server.go
-@@ -96,7 +96,7 @@ func checkNonZeroInsecurePort(fs *pflag.FlagSet) error {
+@@ -86,7 +86,7 @@ func init() {
  }
  
  // NewAPIServerCommand creates a *cobra.Command object with default parameters
@@ -31,7 +31,7 @@ index 411567a4175..a871cc9c975 100644
  	s := options.NewServerRunOptions()
  	cmd := &cobra.Command{
  		Use: "kube-apiserver",
-@@ -138,8 +138,11 @@ cluster's shared state through which all other components interact.`,
+@@ -124,8 +124,11 @@ cluster's shared state through which all other components interact.`,
  			if errs := completedOptions.Validate(); len(errs) != 0 {
  				return utilerrors.NewAggregate(errs)
  			}
@@ -46,10 +46,10 @@ index 411567a4175..a871cc9c975 100644
  		Args: func(cmd *cobra.Command, args []string) error {
  			for _, arg := range args {
 diff --git a/cmd/kube-scheduler/app/server.go b/cmd/kube-scheduler/app/server.go
-index b65f4e74d09..0885de22da1 100644
+index e6bda61b6e6..049b52fefaa 100644
 --- a/cmd/kube-scheduler/app/server.go
 +++ b/cmd/kube-scheduler/app/server.go
-@@ -120,7 +120,11 @@ func runCommand(cmd *cobra.Command, opts *options.Options, registryOptions ...Op
+@@ -128,7 +128,11 @@ func runCommand(cmd *cobra.Command, opts *options.Options, registryOptions ...Op
  	ctx, cancel := context.WithCancel(context.Background())
  	defer cancel()
  	go func() {
@@ -63,10 +63,10 @@ index b65f4e74d09..0885de22da1 100644
  		cancel()
  	}()
 diff --git a/cmd/kubelet/app/server.go b/cmd/kubelet/app/server.go
-index 43dfd8d4f45..015a3df23f3 100644
+index 86c73b030d5..efeb017e92f 100644
 --- a/cmd/kubelet/app/server.go
 +++ b/cmd/kubelet/app/server.go
-@@ -112,7 +112,7 @@ const (
+@@ -114,7 +114,7 @@ const (
  )
  
  // NewKubeletCommand creates a *cobra.Command object with default parameters
@@ -75,7 +75,7 @@ index 43dfd8d4f45..015a3df23f3 100644
  	cleanFlagSet := pflag.NewFlagSet(componentKubelet, pflag.ContinueOnError)
  	cleanFlagSet.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
  	kubeletFlags := options.NewKubeletFlags()
-@@ -287,7 +287,12 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
+@@ -253,7 +253,12 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
  				klog.ErrorS(err, "kubelet running with insufficient permissions")
  			}
  			// set up signal context here in order to be reused by kubelet and docker shim
@@ -89,15 +89,15 @@ index 43dfd8d4f45..015a3df23f3 100644
  
  			// make the kubelet's config safe for logging
  			config := kubeletServer.KubeletConfiguration.DeepCopy()
-@@ -298,7 +303,7 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
+@@ -264,7 +269,7 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
  			klog.V(5).InfoS("KubeletConfiguration", "configuration", config)
  
  			// run the kubelet
--			if err := Run(ctx, kubeletServer, kubeletDeps, utilfeature.DefaultFeatureGate); err != nil {
-+			if err := Run(runctx, kubeletServer, kubeletDeps, utilfeature.DefaultFeatureGate); err != nil {
- 				klog.ErrorS(err, "Failed to run kubelet")
- 				os.Exit(1)
- 			}
+-			return Run(ctx, kubeletServer, kubeletDeps, utilfeature.DefaultFeatureGate)
++			return Run(runctx, kubeletServer, kubeletDeps, utilfeature.DefaultFeatureGate)
+ 		},
+ 	}
+ 
 diff --git a/cmd/kubelite/app/daemons/daemon.go b/cmd/kubelite/app/daemons/daemon.go
 new file mode 100644
 index 00000000000..dbef03cf07e
@@ -394,7 +394,7 @@ index 00000000000..667b24f68e6
 +	println("Stopping kubelite")
 +}
 diff --git a/pkg/volume/csi/csi_plugin.go b/pkg/volume/csi/csi_plugin.go
-index 0ae6d084f0e..f27f9e1b812 100644
+index 3b0a5773e58..6da5e3d4ea1 100644
 --- a/pkg/volume/csi/csi_plugin.go
 +++ b/pkg/volume/csi/csi_plugin.go
 @@ -243,20 +243,24 @@ func (p *csiPlugin) Init(host volume.VolumeHost) error {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -343,8 +343,7 @@ parts:
       - git
     override-build: |
       set -eux
-      # TODO: switch to stable when 1.18.1 get released there
-      snap refresh go --channel=1.18/candidate || true
+      snap refresh go --channel=1.18/stable || true
       . ./set-env-variables.sh
 
       # if "${KUBE_SNAP_BINS}" exist we have to use the binaries from there


### PR DESCRIPTION
In preparation for 1.24:
 - update the README
 - use the 1.24 k8s patchs
 - use golang from 1.18 stable 