### PR TITLE
Enable addons to provide commands to the cli under $SNAP_COMMON/plugins

### DIFF
--- a/microk8s-resources/wrappers/microk8s.wrapper
+++ b/microk8s-resources/wrappers/microk8s.wrapper
@@ -8,6 +8,13 @@ function help() {
         echo -e "\t$(basename ${i} | sed 's/microk8s-//g' | sed 's/.wrapper//g')"
     done
     echo -e "\tinspect"
+    plugins="$(find ${SNAP_COMMON}/plugins/* 2> /dev/null)"
+    if [ ! -z "$plugins" ]; then
+	    echo "Available subcommands from addons are:"
+	    for i in "$plugins" ; do
+		    echo -e "\t$(basename ${i})"
+	    done
+    fi
 }
 
 if [ -z "$1" ]; then

--- a/microk8s-resources/wrappers/microk8s.wrapper
+++ b/microk8s-resources/wrappers/microk8s.wrapper
@@ -27,6 +27,9 @@ elif [ "${APP}" == "inspect" ]; then
 elif [ "${APP}" == "help" ] || [ "${APP}" == "--help" ] || [ "$APP" == "-h" ]; then
     help
     readonly EXIT="0"
+elif [ -f "${SNAP_COMMON}/plugins/${APP}" ]; then
+    "${SNAP_COMMON}/plugins/${APP}" "$@"
+    readonly EXIT="$?"
 else
     echo "'${APP}' is not a valid MicroK8s subcommand."
     help

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -20,6 +20,11 @@ then
   done
 fi
 
+if [ ! -d "${SNAP_COMMON}/plugins" ]
+then
+  mkdir -p ${SNAP_COMMON}/plugins
+fi
+
 # This is a one-off patch. It will allow us to refresh the beta snap without breaking the user's deployment.
 # We make sure the certificates used by the deployment from beta do not change. We copy them to SNAP_DATA
 # and make sure the respective services use them.
@@ -333,7 +338,7 @@ then
   mv ${CD_TOML_TMP} ${CD_TOML}
 fi
 
-for dir in ${SNAP_COMMON}/addons ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock ${SNAP_DATA}/tmp/
+for dir in ${SNAP_COMMON}/plugins ${SNAP_COMMON}/addons ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock ${SNAP_DATA}/tmp/
 do
   chmod -R ug+rwX ${dir}
   chmod -R o-rwX ${dir}
@@ -347,7 +352,7 @@ fi
 
 if getent group microk8s >/dev/null 2>&1
 then
-  chgrp microk8s -R ${SNAP_COMMON}/addons ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock/ ${SNAP_DATA}/var/kubernetes/backend/ ${SNAP_DATA}/tmp/ || true
+  chgrp microk8s -R ${SNAP_COMMON}/plugins ${SNAP_COMMON}/addons ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock/ ${SNAP_DATA}/var/kubernetes/backend/ ${SNAP_DATA}/tmp/ || true
 fi
 
 try_copy_users_to_snap_microk8s


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
Addons now can provide commands to the microk8s CLI by inserting executables under `$SNAP_COMMON/plugins`.
E.g. `microk8s istioctl ...`

#### Changes
Added a condition to microk8s.wrapper so that it can scan and pass through to commands under `$SNAP_COMMON/plugins`.

#### Testing
Existing tests should cover the testing. Created a custom addon to populate `$SNAP_COMMON/plugins`, and called the populated executable by `microk8s executable ...`

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->
There could be naming collisions with existing commands in microk8s, but internal commands take precedence in the case of a collision.

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [X] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
