### PR TITLE
improve handling for br_netfilter module (#3138)

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -165,6 +165,14 @@ nodes_addon() {
     fi
 }
 
+skip_opt_in_local_config() {
+    # remove an option inside the config file.
+    # argument $1 is the option to be removed
+    # argument $2 is the configuration file under $SNAP_DATA/args
+    local opt="--$1"
+    local config_file="$SNAP_DATA/args/$2"
+    run_with_sudo "${SNAP}/bin/sed" -i '/'"$opt"'/d' "${config_file}"
+}
 
 skip_opt_in_config() {
     # remove an option inside the config file.

--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -184,11 +184,25 @@ fi
 
 if ! [ -f /proc/sys/net/bridge/bridge-nf-call-iptables ]
 then
-  if ! modprobe br_netfilter
+  # NOTE(neoaggelos): https://github.com/canonical/microk8s/issues/3085
+  # Attempt to use modprobe from the host, otherwise fallback to the one
+  # provided with the snap.
+  #
+  # If the br_netfilter module is loaded successfully, make sure to remove
+  # the --proxy-mode=userspace flag from kube-proxy, since it breaks Calico.
+  if /sbin/modprobe br_netfilter || modprobe br_netfilter
   then
-    refresh_opt_in_local_config "proxy-mode" "userspace" kube-proxy
+    echo "Successfully loaded br_netfilter module."
+    if grep -- "--proxy-mode=userspace" $SNAP_DATA/args/kube-proxy
+    then
+      echo "Removing --proxy-mode=userspace flag from kube-proxy, since it breaks Calico."
+      skip_opt_in_local_config "proxy-mode" "kube-proxy"
+    fi
+  else
+    echo "Failed to load br_netfilter. Calico might not work properly."
   fi
 fi
+
 if [ -f /proc/sys/net/bridge/bridge-nf-call-iptables ] &&
    grep 0 /proc/sys/net/bridge/bridge-nf-call-iptables
 then


### PR DESCRIPTION
- try to load using modprobe from the host, fallback to the
  snap binary if that fails
- if br_netfilter module loads successfully, make sure to remove
  the --proxy-mode=userspace flag from kube-proxy

