### PR TITLE
Flush and delete cni-hostport-dnat rule on snap remove

### DIFF
--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -31,6 +31,8 @@ then
   iptables -D FORWARD -d "$pod_cidr" -m comment --comment "generated for MicroK8s pods" -j ACCEPT || true
   iptables-nft -D FORWARD -s "$pod_cidr" -m comment --comment "generated for MicroK8s pods" -j ACCEPT || true
   iptables-nft -D FORWARD -d "$pod_cidr" -m comment --comment "generated for MicroK8s pods" -j ACCEPT || true
+  iptables -F CNI-HOSTPORT-DNAT
+  iptables -X CNI-HOSTPORT-DNAT
 fi
 
 snapctl stop ${SNAP_NAME}.daemon-containerd 2>&1 || true


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
Flushing and removing the top-level `CNI-HOSTPORT-DNAT` chain on snap remove to clean-up left ip-tables rules.
Closes #3092 
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
Remove hook flushes and removes the chain with `-F` and `-X`. 

#### Testing
<!-- Please explain how you tested your changes. -->
Existing tests should cover the changes. But did multiple `snap remove`'s to test the changes.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->
Flushing and removing that chain might affect other software that utilizes the same chain.

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [X] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
