### PR TITLE
Check the correct file for AppArmor confinement.

### DIFF
--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -4,8 +4,16 @@ set -ex
 
 source $SNAP/actions/common/utils.sh
 # Re-exec outside of apparmor confinement
-if ! is_strict && [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
-    exec aa-exec -p unconfined -- "$0" "$@"
+if ! is_strict && [ -d /sys/kernel/security/apparmor ]; then
+    status_file=/proc/self/attr/apparmor/current
+    # Fallback for older kernels, check the legacy interfaces
+    # https://www.kernel.org/doc/html/latest/admin-guide/LSM/index.html
+    if [ ! -f $status_file ]; then
+        status_file=/proc/self/attr/current
+    fi
+    if [ "$(cat $status_file)" != "unconfined" ]; then
+        exec aa-exec -p unconfined -- "$0" "$@"
+    fi
 fi
 
 # Why we put the /snap/microk8s/current in the path?


### PR DESCRIPTION
Documentation:
https://www.kernel.org/doc/html/latest/admin-guide/LSM/index.html

Fixes:
https://github.com/canonical/microk8s/issues/3161

<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

#### Testing
<!-- Please explain how you tested your changes. -->
~Currently untested -- I need to get the necessary tooling working to build and test.~ Tested install and boot on Manjaro linux with kernel version 5.17.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->
Older kernels without the separate security module folders in /proc/.../attr might now fail to install microk8s.

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [n/a] The introduced changes are covered by unit and/or integration tests.
I don't think it's applicable in this case

#### Notes
<!-- Please add any other information that you think may be relevant -->
