### PR TITLE
cleanup calico interface and cni network namespaces on remove

### DIFF
--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -58,3 +58,15 @@ then
 fi
 
 kill_all_container_shims
+
+# Cleanup calico interface.
+if "${SNAP}/sbin/ip" link show vxlan.calico
+then
+  "${SNAP}/sbin/ip" link delete vxlan.calico || true
+fi
+
+# Cleanup cni network namespaces.
+for ns in `"${SNAP}/sbin/ip" netns list | grep "^cni-" | awk '{print $1}'`
+do
+  $SNAP/sbin/ip netns delete "${ns}" || true
+done


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

During remove hook, remove the vxlan.calico interface, as well the network namespaces created by the CNI for the pod workloads.

#### Testing
<!-- Please explain how you tested your changes. -->

```
snap install microk8s

# create a deployment
microk8s.kubectl create deploy nginx --image nginx --replicas 10

# remove microk8s
snap remove microk8s --purge
```

With the added changes, this should leave networking on the host in a clean state.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

- Introduces a short delay in the remove hook (in order to delete the namespaces). The deletion itself takes very little time, so it should not be a problem, but let's keep an eye on it, especially on slower hardware.
- Possible issues with strict, but we already have `ip link delete cni0` (from the flannel days), so I don't expect this to be a problem.

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [X] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->

This is probably something worth backporting to all supported tracks.