### PR TITLE
Make sure to use microk8s.kubectl

### DIFF
--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -13,7 +13,7 @@ import yaml
 
 LOG = logging.getLogger(__name__)
 
-kubeconfig = "--kubeconfig=" + os.path.expandvars("${SNAP_DATA}/credentials/client.config")
+KUBECTL = os.path.expandvars("$SNAP/microk8s-kubectl.wrapper")
 
 
 def get_current_arch():
@@ -188,14 +188,19 @@ def ensure_started():
 
 def kubectl_get(cmd, namespace="--all-namespaces"):
     if namespace == "--all-namespaces":
-        return run("kubectl", kubeconfig, "get", cmd, "--all-namespaces", die=False)
+        return run(KUBECTL, "get", cmd, "--all-namespaces", die=False)
     else:
-        return run("kubectl", kubeconfig, "get", cmd, "-n", namespace, die=False)
+        return run(KUBECTL, "get", cmd, "-n", namespace, die=False)
 
 
 def kubectl_get_clusterroles():
     return run(
-        "kubectl", kubeconfig, "get", "clusterroles", "--show-kind", "--no-headers", die=False
+        KUBECTL,
+        "get",
+        "clusterroles",
+        "--show-kind",
+        "--no-headers",
+        die=False,
     )
 
 


### PR DESCRIPTION
If we call kubectl simply, the system installed kubectl has precedence.
That may lead to some weird issues like an error due to a discrepancy
between kubectl cli and kubernetes API versions.

Closes: #3175

<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

#### Testing
<!-- Please explain how you tested your changes. -->

1. prepare `kubectl` on the system that always fails

       $ sudo ln -s /bin/false /usr/local/bin/kubectl
       $ kubectl; echo $?
       1

1. install the patched snap

       $ sudo snap install --dangerous --classic ./microk8s.snap

1. execute addon enable command, which was failing in #3175

1. confirm the command now works.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
