### PR TITLE
Address most denials in install and configure hooks

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -577,9 +577,9 @@ init_cluster() {
   $SNAP/bin/sed -i 's/HOSTIP/'"${IP}"'/g' $SNAP_DATA/var/tmp/csr-dqlite.conf
   ${SNAP}/usr/bin/openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout ${SNAP_DATA}/var/kubernetes/backend/cluster.key -out ${SNAP_DATA}/var/kubernetes/backend/cluster.crt -subj "/CN=k8s" -config $SNAP_DATA/var/tmp/csr-dqlite.conf -extensions v3_ext
   chmod -R o-rwX ${SNAP_DATA}/var/kubernetes/backend/
-  if getent group microk8s >/dev/null 2>&1
+  if getent group snap_microk8s >/dev/null 2>&1
   then
-    chgrp microk8s -R ${SNAP_DATA}/var/kubernetes/backend/ || true
+    chgrp snap_microk8s -R --preserve=mode ${SNAP_DATA}/var/kubernetes/backend/ || true
   fi
 }
 

--- a/microk8s-resources/wrappers/microk8s-ctr.wrapper
+++ b/microk8s-resources/wrappers/microk8s-ctr.wrapper
@@ -10,5 +10,11 @@ source $SNAP/actions/common/utils.sh
 
 SNAPSHOTTER=$(snapshotter)
 
-declare -a args="($(cat $SNAP_DATA/args/ctr))"
-LD_LIBRARY_PATH="$IN_SNAP_LD_LIBRARY_PATH" CONTAINERD_SNAPSHOTTER="$SNAPSHOTTER" "${SNAP}/bin/ctr" "${args[@]}" "$@"
+if ! [ -e $SNAP_DATA/args/ctr ]
+then
+  echo "Arguments file $SNAP_DATA/args/ctr is missing."
+  exit 1
+else
+  declare -a args="($(cat $SNAP_DATA/args/ctr))"
+  LD_LIBRARY_PATH="$IN_SNAP_LD_LIBRARY_PATH" CONTAINERD_SNAPSHOTTER="$SNAPSHOTTER" "${SNAP}/bin/ctr" "${args[@]}" "$@"
+fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -14,7 +14,7 @@ export OPENSSL_CONF="/snap/microk8s/current/etc/ssl/openssl.cnf"
 
 source $SNAP/actions/common/utils.sh
 
-cp -r ${SNAP}/default-args ${SNAP_DATA}/args
+cp -r --preserve=mode ${SNAP}/default-args ${SNAP_DATA}/args
 mv ${SNAP_DATA}/args/certs.d/localhost__32000 ${SNAP_DATA}/args/certs.d/localhost:32000
 
 # Sym link the host's /var/lib/kubelet to the Snap's.  This will be fixed with layouts when

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,7 +55,9 @@ hooks:
     plugs:
       - account-control
       - dot-kube
+      - firewall-control
       - network
+      - network-observe
   install:
     plugs:
       - account-control


### PR DESCRIPTION
#### Summary
A number of denials were thrown from the install and configure hooks. For example:
```
= Seccomp =
Time: May 30 22:55:39
Log: auid=4294967295 uid=0 gid=0 ses=4294967295 subj=snap.microk8s.hook.install pid=367587 comm="chgrp" exe="/snap/microk8s/3269/bin/chgrp" sig=0 arch=c000003e 260(fchownat) compat=0 ip=0x7fe972f5e44a code=0x50000
Syscall: fchownat
Suggestions:
* don't copy ownership of files (eg, use 'cp -r --preserve=mode' instead of 'cp -a')
* try the snapcraft preload plugin: https://github.com/sergiusens/snapcraft-preload
* adjust program to not use 'fchownat'
* ignore the denial if the program otherwise works correctly (unconditial chown is often just noise)



= AppArmor =
Time: May 30 22:55:43
Log: apparmor="DENIED" operation="capable" profile="snap.microk8s.hook.configure" pid=367789 comm="ip" capability=12  capname="net_admin"
Capability: net_admin
Suggestions:
* adjust program to not require 'CAP_NET_ADMIN' (see 'man 7 capabilities')
* add one of 'bluetooth-control, firewall-control, netlink-audit, netlink-connector, network-control' to 'plugs'
* do nothing if using systemd utility (eg, timedatectl): https://forum.snapcraft.io/t/managing-time-date-and-timezone-in-ubuntu-core/408/44
* do nothing (https://launchpad.net/bugs/1465724)

= AppArmor =
Time: May 30 22:55:43
Log: apparmor="DENIED" operation="open" profile="snap.microk8s.hook.configure" name="/etc/iproute2/group" pid=367789 comm="ip" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
File: /etc/iproute2/group (read)
Suggestions:
* adjust program to read necessary files from $SNAP, $SNAP_DATA, $SNAP_COMMON, $SNAP_USER_DATA or $SNAP_USER_COMMON
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)
* add 'firewall-control' to 'plugs'
* add one of 'network-control, network-observe' to 'plugs'


= AppArmor =
Time: May 30 22:55:36
Log: apparmor="DENIED" operation="connect" profile="snap.microk8s.ctr" name="/run/containerd/containerd.sock" pid=367316 comm="ctr" requested_mask="wr" denied_mask="wr" fsuid=0 ouid=0
File: /run/containerd/containerd.sock (write)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

```


#### Changes
- use of extra interfaces in the install hook
- copy files ignoring ownership
- use the right snap_microk8s group
- ctr will not execute before its args file is available

#### Testing
Build the snap and install it while keeping a second terminal with snappy-debug running.
