### PR TITLE
Implement "microk8s images import" command

### DIFF
--- a/microk8s-resources/wrappers/microk8s-images.wrapper
+++ b/microk8s-resources/wrappers/microk8s-images.wrapper
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eu
+
+source $SNAP/actions/common/utils.sh
+
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+
+ARCH="$($SNAP/bin/uname -m)"
+export IN_SNAP_LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
+export PYTHONNOUSERSITE=false
+
+exit_if_no_permissions
+
+LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/cluster/images.py $@

--- a/scripts/cluster/distributed_op.py
+++ b/scripts/cluster/distributed_op.py
@@ -62,21 +62,23 @@ def get_cluster_agent_endpoints(include_self=False):
             port = get_cluster_agent_port()
             nodes.append(("127.0.0.1:{}".format(port), token.rstrip()))
 
-        with open(callback_tokens_file, "r+") as fp:
-            for _, line in enumerate(fp):
-                node_ep, token = line.split()
-                host = node_ep.split(":")[0]
+        try:
+            with open(callback_tokens_file, "r+") as fin:
+                for line in fin:
+                    node_ep, token = line.split()
+                    host = node_ep.split(":")[0]
 
-                try:
-                    subprocess.check_call(
-                        [KUBECTL, "get", "node", host],
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
-                    )
-                    nodes.append((node_ep, token.rstrip()))
-                except subprocess.CalledProcessError:
-                    print("Node {} not present".format(host))
-
+                    try:
+                        subprocess.check_call(
+                            [KUBECTL, "get", "node", host],
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                        )
+                        nodes.append((node_ep, token.rstrip()))
+                    except subprocess.CalledProcessError:
+                        print("Node {} not present".format(host))
+        except OSError:
+            pass
     return nodes
 
 

--- a/scripts/cluster/images.py
+++ b/scripts/cluster/images.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+import sys
+
+import click
+
+from distributed_op import do_image_import
+
+images = click.Group()
+
+
+@images.command("import", help="Import OCI images into the MicroK8s cluster")
+@click.argument("image", default="-")
+def import_images(image: str):
+
+    if image == "-":
+        image_data = sys.stdin.buffer.read()
+    else:
+        try:
+            with open(image, "rb") as fin:
+                image_data = fin.read()
+        except OSError as e:
+            click.echo("Error: failed to read {}: {}".format(image, e), err=True)
+            sys.exit(1)
+
+    do_image_import(image_data)
+
+
+if __name__ == "__main__":
+    images(prog_name="microk8s images")

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,6 +73,8 @@ apps:
     command: microk8s-addons.wrapper
   refresh-certs:
     command: microk8s-refresh-certs.wrapper
+  images:
+    command: microk8s-images.wrapper
   join:
     command: microk8s-join.wrapper
   remove-node:


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

Implement `microk8s images import` command, which can be used to import OCI images to all nodes of a MicroK8s cluster.

Assumes https://github.com/canonical/microk8s-cluster-agent/pull/4

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

- Refactor existing code in `distributed_op`: Pull out the code that retrieves the list of all current nodes and their callback tokens
- Implement `do_image_import`, similar to the existing `do_op`.
- Implement `microk8s.images import` command, importing images to the whole cluster.

#### Testing
<!-- Please explain how you tested your changes. -->

Manually

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

Please check if I have missed something in the original code where the list of nodes is retrieved. There was a lot of duplicate code which I have tried to refactor.

I have tried to preserve the error messages in all cases.

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [X] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->