### PR TITLE
Strict check to use nano from snap for kubectl when we are strictly confined

### DIFF
--- a/microk8s-resources/wrappers/microk8s-kubectl.wrapper
+++ b/microk8s-resources/wrappers/microk8s-kubectl.wrapper
@@ -22,6 +22,11 @@ then
   source $SNAP_DATA/args/kubectl-env
 fi
 
+if is_strict
+then
+  export EDITOR="${SNAP}/bin/nano"
+fi
+
 declare -a args="($(cat $SNAP_DATA/args/kubectl))"
 if [ -n "${args[@]-}" ]
 then


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
Added a strict check so nano from snap is used for kubectl only when we are confined

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
Adds a `is_strict` check in `microk8s-kubectl.wrapper` and set `EDITOR="${SNAP}/bin/nano"` if strictly confined.

#### Testing
<!-- Please explain how you tested your changes. -->
Existing tests should cover the changes.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [X] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
