### PR TITLE
Implement "microk8s images export-local" command

### DIFF
--- a/scripts/cluster/images.py
+++ b/scripts/cluster/images.py
@@ -40,7 +40,7 @@ def get_all_ctr_images():
     return [tag for tag in images if tag and not tag.startswith("sha256:")]
 
 
-@images.command("export", help="Export OCI images from the current MicroK8s node")
+@images.command("export-local", help="Export OCI images from the current MicroK8s node")
 @click.argument("output", default="-")
 @click.argument("images", nargs=-1)
 def export_images(output: str, images: List[str]):

--- a/scripts/cluster/images.py
+++ b/scripts/cluster/images.py
@@ -1,9 +1,14 @@
 #!/usr/bin/python3
+import os
+import subprocess
 import sys
+from typing import List
 
 import click
 
 from distributed_op import do_image_import
+
+CTR = "{}/microk8s-ctr.wrapper".format(os.getenv("SNAP"))
 
 images = click.Group()
 
@@ -23,6 +28,33 @@ def import_images(image: str):
             sys.exit(1)
 
     do_image_import(image_data)
+
+
+def get_all_ctr_images():
+    """
+    Return list of all OCI images from containerd.
+    """
+    images = subprocess.check_output([CTR, "image", "ls", "--quiet"]).decode().split("\n")
+
+    # drop the sha256-digest aliases
+    return [tag for tag in images if tag and not tag.startswith("sha256:")]
+
+
+@images.command("export", help="Export OCI images from the current MicroK8s node")
+@click.argument("output", default="-")
+@click.argument("images", nargs=-1)
+def export_images(output: str, images: List[str]):
+    if not images:
+        images = get_all_ctr_images()
+
+    for image in images:
+        click.echo("Checking {}".format(image), err=True)
+        try:
+            subprocess.check_call([CTR, "image", "export", "-", image], stdout=subprocess.DEVNULL)
+        except subprocess.CalledProcessError:
+            subprocess.check_call([CTR, "content", "fetch", "--all-platforms"], stdout=sys.stderr)
+
+    subprocess.check_call([CTR, "image", "export", output, *images])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

Builds on top of #3183, review after that one is merged.

Implement "microk8s images export" command, which can be used to export all (or a selected set) of OCI images from the local containerd daemon.

This can be used in conjunction with the microk8s images import command of #3183, see the testing section for details.

This command is used as a useful wrapper around the `microk8s.ctr image export` command, solving some of its shortcomings.

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->



#### Testing
<!-- Please explain how you tested your changes. -->

```
# extract all images from cluster1
ubuntu@cluster1:$ microk8s images export > all-images.tar

# on any control plane of cluster2 (supposedly airgap)
ubuntu@cluster2:$ microk8s images import < all-images.tar
Pushing OCI images to node1:25000
Pushing OCI images to node2:25000
Pushing OCI images to node3:25000
```

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

none

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [X] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->

Doing a `microk8s.ctr image export` is not sufficient due to the following issue. This is the reason why we do the `microk8s.ctr content fetch` command (where needed):

```bash
root@s2:~# microk8s.ctr image pull docker.io/library/alpine:3.10
docker.io/library/alpine:3.10:                                                    resolved       |++++++++++++++++++++++++++++++++++++++| 
index-sha256:451eee8bedcb2f029756dc3e9d73bab0e7943c1ac55cff3a4861c52a0fdd3e98:    done           |++++++++++++++++++++++++++++++++++++++| 
manifest-sha256:e515aad2ed234a5072c4d2ef86a1cb77d5bfe4b11aa865d9214875734c4eeb3c: done           |++++++++++++++++++++++++++++++++++++++| 
config-sha256:e7b300aee9f9bf3433d32bc9305bfdd22183beb59d933b48d77ab56ba53a197a:   done           |++++++++++++++++++++++++++++++++++++++| 
layer-sha256:396c31837116ac290458afcb928f68b6cc1c7bdd6963fc72f52f365a2a89c1b5:    done           |++++++++++++++++++++++++++++++++++++++| 
elapsed: 5.7 s                                                                    total:  2.0 Mi (359.9 KiB/s)                                     
unpacking linux/amd64 sha256:451eee8bedcb2f029756dc3e9d73bab0e7943c1ac55cff3a4861c52a0fdd3e98...
done: 233.482914ms	
root@s2:~# microk8s.ctr image export - docker.io/library/alpine:3.10
ctr: content digest sha256:591118c9bc1ccd06bc6f91a3949d63b3a5a3f09d4650c86e362a851645d2895d: not found
```