### PR TITLE
Add runc/containerd patches for strict confinement

### DIFF
--- a/build-scripts/patches/runc/0001-apparmor-change-profile-immediately-not-on-exec.patch
+++ b/build-scripts/patches/runc/0001-apparmor-change-profile-immediately-not-on-exec.patch
@@ -1,0 +1,36 @@
+From 08607d16c6f9ef393e18e0f62fcd967e91c5f7c9 Mon Sep 17 00:00:00 2001
+From: Alberto Mardegan <mardy@users.sourceforge.net>
+Date: Wed, 16 Jun 2021 15:04:16 +0300
+Subject: [PATCH 1/3] apparmor: change profile immediately, not on exec
+
+---
+ libcontainer/apparmor/apparmor_linux.go | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/libcontainer/apparmor/apparmor_linux.go b/libcontainer/apparmor/apparmor_linux.go
+index 5da14fb3..93ede183 100644
+--- a/libcontainer/apparmor/apparmor_linux.go
++++ b/libcontainer/apparmor/apparmor_linux.go
+@@ -49,9 +49,9 @@ func setProcAttr(attr, value string) error {
+ 	return err
+ }
+ 
+-// changeOnExec reimplements aa_change_onexec from libapparmor in Go
+-func changeOnExec(name string) error {
+-	if err := setProcAttr("exec", "exec "+name); err != nil {
++// changeProfile reimplements aa_change_profile from libapparmor in Go
++func changeProfile(name string) error {
++	if err := setProcAttr("current", "changeprofile "+name); err != nil {
+ 		return fmt.Errorf("apparmor failed to apply profile: %s", err)
+ 	}
+ 	return nil
+@@ -64,5 +64,5 @@ func ApplyProfile(name string) error {
+ 		return nil
+ 	}
+ 
+-	return changeOnExec(name)
++	return changeProfile(name)
+ }
+-- 
+2.25.1
+

--- a/build-scripts/patches/runc/0002-setns_init_linux-set-the-NNP-flag-after-changing-the.patch
+++ b/build-scripts/patches/runc/0002-setns_init_linux-set-the-NNP-flag-after-changing-the.patch
@@ -1,0 +1,44 @@
+From 66fd3c5129599834de8262ee90a1ab2bf6b68ff0 Mon Sep 17 00:00:00 2001
+From: Alberto Mardegan <mardy@users.sourceforge.net>
+Date: Wed, 16 Jun 2021 15:04:40 +0300
+Subject: [PATCH 2/3] setns_init_linux: set the NNP flag after changing the
+ apparmor profile
+
+With the current version of the AppArmor kernel module, it's not
+possible to switch the AppArmor profile if the NoNewPrivileges flag is
+set. So, we invert the order of the two operations.
+---
+ libcontainer/setns_init_linux.go | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/libcontainer/setns_init_linux.go b/libcontainer/setns_init_linux.go
+index 97987f1d..eec427a0 100644
+--- a/libcontainer/setns_init_linux.go
++++ b/libcontainer/setns_init_linux.go
+@@ -57,11 +57,6 @@ func (l *linuxSetnsInit) Init() error {
+ 			return err
+ 		}
+ 	}
+-	if l.config.NoNewPrivileges {
+-		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+-			return err
+-		}
+-	}
+ 	if err := selinux.SetExecLabel(l.config.ProcessLabel); err != nil {
+ 		return err
+ 	}
+@@ -80,6 +75,11 @@ func (l *linuxSetnsInit) Init() error {
+ 	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
+ 		return err
+ 	}
++	if l.config.NoNewPrivileges {
++		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
++			return err
++		}
++	}
+ 	// Set seccomp as close to execve as possible, so as few syscalls take
+ 	// place afterward (reducing the amount of syscalls that users need to
+ 	// enable in their seccomp profiles).
+-- 
+2.25.1
+

--- a/build-scripts/patches/runc/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
+++ b/build-scripts/patches/runc/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
@@ -1,0 +1,55 @@
+From 728d989c7643a87ca9d57e3135e35c7af833bae0 Mon Sep 17 00:00:00 2001
+From: Alberto Mardegan <mardy@users.sourceforge.net>
+Date: Thu, 17 Jun 2021 14:31:35 +0300
+Subject: [PATCH 3/3] standard_init_linux: change AppArmor profile as late as
+ possible
+
+---
+ libcontainer/standard_init_linux.go | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/libcontainer/standard_init_linux.go b/libcontainer/standard_init_linux.go
+index d77022ad..6f43da5f 100644
+--- a/libcontainer/standard_init_linux.go
++++ b/libcontainer/standard_init_linux.go
+@@ -114,10 +114,6 @@ func (l *linuxStandardInit) Init() error {
+ 			return errors.Wrap(err, "sethostname")
+ 		}
+ 	}
+-	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
+-		return errors.Wrap(err, "apply apparmor profile")
+-	}
+-
+ 	for key, value := range l.config.Config.Sysctl {
+ 		if err := writeSystemProperty(key, value); err != nil {
+ 			return errors.Wrapf(err, "write sysctl key %s", key)
+@@ -137,17 +133,21 @@ func (l *linuxStandardInit) Init() error {
+ 	if err != nil {
+ 		return errors.Wrap(err, "get pdeath signal")
+ 	}
+-	if l.config.NoNewPrivileges {
+-		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+-			return errors.Wrap(err, "set nonewprivileges")
+-		}
+-	}
+ 	// Tell our parent that we're ready to Execv. This must be done before the
+ 	// Seccomp rules have been applied, because we need to be able to read and
+ 	// write to a socket.
+ 	if err := syncParentReady(l.pipe); err != nil {
+ 		return errors.Wrap(err, "sync ready")
+ 	}
++	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
++		return errors.Wrap(err, "apply apparmor profile")
++	}
++	if l.config.NoNewPrivileges {
++		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
++			return errors.Wrap(err, "set nonewprivileges")
++		}
++	}
++
+ 	if err := selinux.SetExecLabel(l.config.ProcessLabel); err != nil {
+ 		return errors.Wrap(err, "set process label")
+ 	}
+-- 
+2.25.1
+


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
Added patches for runc/containerd to work properly in strict confinement.

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
Added apparmor and privilege patches for runc/containerd for strict confinement

#### Testing
<!-- Please explain how you tested your changes. -->
Existing tests should cover the changes.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [X] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
