### PR TITLE
Pass credentials over the content interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -653,4 +653,5 @@ slots:
     interface: content
     content: microk8s
     source:
-      read: [$SNAP/.microk8s-info/microk8s]
+      read:
+        - $SNAP_DATA/credentials


### PR DESCRIPTION
#### Summary
Use the content interface to pass the microk8s credentials to juju (or anyone else that may need them)

#### Changes
Update the content interface with the right path to the k8s credentials

#### Testing
```
snap install microk8s --channel=latest/edge/MK-530
```
Build a tester snap https://github.com/ktsakalozos/microk8s-content-tester.git and snap install it.
Connect the interface:
```
snap connect tester:microk8s  microk8s:microk8s
```
Get a shell into the tester snap:
```
sudo snap run --shell tester.hello
```
The client.config file is available:
```
ls -lh $SNAP_DATA/credentials/
```

#### Notes
This interface will be in the MicroK8s strict snap.