### PR TITLE
[Backport 1.24] Make sure to use microk8s-kubectl.wrapper (#3176)

### DIFF
--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -13,7 +13,7 @@ import yaml
 
 LOG = logging.getLogger(__name__)
 
-kubeconfig = "--kubeconfig=" + os.path.expandvars("${SNAP_DATA}/credentials/client.config")
+KUBECTL = os.path.expandvars("$SNAP/microk8s-kubectl.wrapper")
 
 
 def get_current_arch():
@@ -188,14 +188,19 @@ def ensure_started():
 
 def kubectl_get(cmd, namespace="--all-namespaces"):
     if namespace == "--all-namespaces":
-        return run("kubectl", kubeconfig, "get", cmd, "--all-namespaces", die=False)
+        return run(KUBECTL, "get", cmd, "--all-namespaces", die=False)
     else:
-        return run("kubectl", kubeconfig, "get", cmd, "-n", namespace, die=False)
+        return run(KUBECTL, "get", cmd, "-n", namespace, die=False)
 
 
 def kubectl_get_clusterroles():
     return run(
-        "kubectl", kubeconfig, "get", "clusterroles", "--show-kind", "--no-headers", die=False
+        KUBECTL,
+        "get",
+        "clusterroles",
+        "--show-kind",
+        "--no-headers",
+        die=False,
     )
 
 


### PR DESCRIPTION
Backport of https://github.com/canonical/microk8s/pull/3176 to 1.24 branch