### PR TITLE
Remove unnecessary changes from the strict patch for kubectl, leave and start

### DIFF
--- a/microk8s-resources/wrappers/microk8s-kubectl.wrapper
+++ b/microk8s-resources/wrappers/microk8s-kubectl.wrapper
@@ -30,7 +30,7 @@ fi
 declare -a args="($(cat $SNAP_DATA/args/kubectl))"
 if [ -n "${args[@]-}" ]
 then
-  EDITOR="${SNAP}/bin/nano" "${SNAP}/kubectl" "${args[@]}" "$@"
+  "${SNAP}/kubectl" "${args[@]}" "$@"
 else
-  EDITOR="${SNAP}/bin/nano" "${SNAP}/kubectl" "$@"
+  "${SNAP}/kubectl" "$@"
 fi

--- a/microk8s-resources/wrappers/microk8s-leave.wrapper
+++ b/microk8s-resources/wrappers/microk8s-leave.wrapper
@@ -23,4 +23,4 @@ then
   exit 1
 fi
 
-run_with_sudo ${SNAP}/usr/bin/python3 ${SNAP}/scripts/cluster/leave.py $@
+run_with_sudo preserve_env ${SNAP}/usr/bin/python3 ${SNAP}/scripts/cluster/leave.py $@

--- a/microk8s-resources/wrappers/microk8s-start.wrapper
+++ b/microk8s-resources/wrappers/microk8s-start.wrapper
@@ -52,10 +52,10 @@ then
     exit 1
 else
     start_all_containers
-    if test -e ${SNAP_DATA}/var/lock/stopped.lock
+    if run_with_sudo test -e ${SNAP_DATA}/var/lock/stopped.lock
     then
         # Mark the api server as starting
-        rm ${SNAP_DATA}/var/lock/stopped.lock &> /dev/null
+        run_with_sudo rm ${SNAP_DATA}/var/lock/stopped.lock &> /dev/null
     fi
 fi
 


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
Remove unnecessary changes from the strict patch for kubectl, leave and start since `run_with_sudo` is now strict aware and new strict logic is merged to the master branch.

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
Removed the changes in c792a245690867cadf08df01d63806f3fba99fa4 for `kubectl` `start` and `leave` wrappers.

#### Testing
<!-- Please explain how you tested your changes. -->
Existing tests should cover the changes.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [X] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
