### PR TITLE
Do not wait for services to start in configure hook in strict

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -655,7 +655,8 @@ then
   touch "${SNAP_DATA}/var/lock/cni-needs-reload"
 fi
 
-if [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ] &&
+if ! is_strict &&
+   [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ] &&
    [ -e "${SNAP_DATA}/var/lock/ha-cluster" ] &&
    ! [ -e "${SNAP_DATA}/var/lock/clustered.lock" ]
 then


### PR DESCRIPTION
#### Summary
In the configure hook we wait for the services to come up and apply the CNI manifest. In strict the snapctl will start services only after the configure hook ends so there is no point in waiting for them. This behavior (services starting after the configure hook) is present only in the snaps we get from the store, not in the ones we build locally.

#### Changes
Add an ! is_strict in the waiting of the apiserver in the configure hook. 

#### Testing
Try:
```
snap install microk8s --channel=latest/edge/MK-565
```
vs 
```
snap install microk8s --channel=latest/edge/strict
```
The first should install 2.5 minutes faster.


#### Possible Regressions
There is a difference in UX. Now the `snap install` will finish before K8s starts so users will need to `microk8s status --wait-ready`
