### PR TITLE
Improve handling of missing default routes in containerd and kubelite

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -813,7 +813,7 @@ refresh_calico_if_needed() {
 }
 
 remove_docker_specific_args() {
-  # Remove docker specific arguments and return 0 if kubelet needs to be restarted 
+  # Remove docker specific arguments and return 0 if kubelet needs to be restarted
   if grep -e "\-\-network-plugin" ${SNAP_DATA}/args/kubelet ||
     grep -e "\-\-cni-conf-dir" ${SNAP_DATA}/args/kubelet ||
     grep -e "\-\-cni-bin-dir" ${SNAP_DATA}/args/kubelet
@@ -933,4 +933,21 @@ is_first_boot_on_strict() {
     touch "$SENTINEL"
     return 0
   fi
+}
+
+default_route_exists() {
+  # test if we have a default route
+  ( ip route; ip -6 route ) | grep "^default" &>/dev/null
+}
+
+wait_for_default_route() {
+  # wait 10 seconds for default route to appear
+  n=0
+  until [ $n -ge 5 ]
+  do
+    default_route_exists && break
+    echo "Waiting for default route to appear. (attempt $n)"
+    n=$[$n+1]
+    sleep 2
+  done
 }

--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -77,16 +77,15 @@ set -a
 . "${SNAP_DATA}/args/${app}-env"
 set +a
 
-# wait up to two minutes for the default network interface to appear.
-n=0
-until [ $n -ge 20 ]
-do
-  ip route | grep default &> /dev/null && break
-  ip -6 route | grep default &> /dev/null && break
-  echo "Waiting for default route to appear. (attempt $n)"
-  n=$[$n+1]
-  sleep 6
-done
+# check if there is a default route available
+if ! default_route_exists
+then
+  echo "WARNING: No default route exists. MicroK8s might not work properly."
+  echo "Refer to https://microk8s.io/docs for instructions on air-gap deployments."
+fi
+
+# NOTE(neoaggelos): See https://github.com/canonical/microk8s/issues/423 for context
+wait_for_default_route
 
 # Set the path to the Cilium socket correctly for CNI
 export CILIUM_SOCK="${SNAP_DATA}/var/run/cilium/cilium.sock"

--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -38,16 +38,22 @@ then
 fi
 
 ## API server configuration
-# wait up to two minutes for the default network interface to appear.
-n=0
-until [ $n -ge 20 ]
-do
-  ip route | grep default &> /dev/null && break
-  ip -6 route | grep default &> /dev/null && break
-  echo "Waiting for default route to appear. (attempt $n)"
-  n=$[$n+1]
-  sleep 6
-done
+
+# Check if we advertise an address. If we do we do not need to wait for a default network interface.
+if ! grep -E "(--advertise-address|--bind-address)" $SNAP_DATA/args/kube-apiserver &> /dev/null
+then
+  # we keep this command to cleanup the file, as it is no longer needed.
+  rm -f ${SNAP_DATA}/external_ip.txt
+
+  # check if there is a default route available
+  if ! default_route_exists
+  then
+    echo "WARNING: No default route exists. MicroK8s might not work properly."
+    echo "Refer to https://microk8s.io/docs for instructions on air-gap deployments."
+  fi
+
+  wait_for_default_route
+fi
 
 if [ -e ${SNAP_DATA}/args/ha-conf ]
 then
@@ -135,22 +141,6 @@ else
 fi
 
 ## Kube-proxy configuration
-# Check if we advertise an address. If we do we do not need to wait for a default network interface.
-if ! grep -E "(--advertise-address|--bind-address)" $SNAP_DATA/args/kube-apiserver &> /dev/null
-then
-  # we keep this command to cleanup the file, as it is no longer needed.
-  rm -f ${SNAP_DATA}/external_ip.txt
-  # wait up to two minutes for the default network interface to appear.
-  n=0
-  until [ $n -ge 20 ]
-  do
-    ip route | grep default &> /dev/null && break
-    ip -6 route | grep default &> /dev/null && break
-    echo "Waiting for default route to appear. (attempt $n)"
-    n=$[$n+1]
-    sleep 6
-  done
-fi
 
 if [ -e "$SNAP_DATA/args/cni-network/cni.yaml" ]
 then

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -286,6 +286,14 @@ function suggest_fixes {
   then
     printf -- "\033[0;33mWARNING: \033[0m Please ensure br_netfilter kernel module is loaded on the host. \n"
   fi
+
+  if ! ( ip route; ip -6 route ) | grep "^default" &>/dev/null
+  then
+    printf -- "
+\033[0;33mWARNING: \033[0m No default route exists. MicroK8s might not work properly.
+Refer to https://microk8s.io/docs for instructions on air-gap deployments.\n\n
+"
+  fi
 }
 
 function fedora_release {
@@ -388,7 +396,7 @@ then
   check_service "snap.microk8s.daemon-flanneld"
   check_service "snap.microk8s.daemon-etcd"
 else
-  check_service "snap.microk8s.daemon-k8s-dqlite"  
+  check_service "snap.microk8s.daemon-k8s-dqlite"
 fi
 
 if ! [ -e "${SNAP_DATA}/var/lock/no-traefik" ]

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -54,6 +54,7 @@ function store_network {
   mkdir -p $INSPECT_DUMP/network
   ss -pln &> $INSPECT_DUMP/network/ss
   ip addr &> $INSPECT_DUMP/network/ip-addr
+  ip route &> $INSPECT_DUMP/network/ip-addr
   iptables -t nat -L -n -v &> $INSPECT_DUMP/network/iptables
   iptables -S &> $INSPECT_DUMP/network/iptables-S
   iptables -L &> $INSPECT_DUMP/network/iptables-L


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

- Reduce timeout waiting for default route to 10 seconds from 120 (this is to avoid timeouts during snap install)
- Add check in microk8s inspect script
- Emit warning logs that point people to the documentation (TODO)

#### Testing
<!-- Please explain how you tested your changes. -->

```
ip route delete default
```

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

Maybe worth considering the case of slower hardware.

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [X] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
