### PR TITLE
scripts: fix the inspect script not to call /bin/mount

### DIFF
--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -209,8 +209,8 @@ function suggest_fixes {
     fi
   fi
 
-  if ! mount | grep -q 'cgroup/memory'; then
-    if ! mount | grep -q 'cgroup2 on /sys/fs/cgroup'; then
+  if ! grep -q 'cgroup/memory' /proc/self/mountinfo; then
+    if ! grep -q 'cgroup/unified.* cgroup2 ' /proc/self/mountinfo; then
       printf -- '\033[0;33mWARNING: \033[0m The memory cgroup is not enabled. \n'
       printf -- 'The cluster may not be functioning properly. Please ensure cgroups are enabled \n'
       printf -- 'See for example: https://microk8s.io/docs/install-alternatives#heading--arm \n'


### PR DESCRIPTION
Do not use mount in the inspect script.