### PR TITLE
Calling inspect script properly in strict

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -469,7 +469,7 @@ apps:
       - process-control
       - system-observe
   inspect:
-    command: microk8s.wrapper
+    command: microk8s.wrapper inspect
     plugs:
       - network-observe
       - kubernetes-support


### PR DESCRIPTION
Be able to call `microk8s.inspect` (with dot) in the strict snap.