### PR TITLE
Updating the interfaces user by the 'microk8s' command

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -237,8 +237,22 @@ apps:
     plugs:
       - account-control
       - docker-unprivileged
+      - dot-config-helm
+      - dot-kube
+      - firewall-control
       - home-read-all
+      - home
+      - kernel-module-observe
+      - kubernetes-support
+      - login-session-observe
+      - home-read-all
+      - log-observe
+      - mount-observe
+      - network
       - network-control
+      - network-observe
+      - opengl
+      - system-observe
   daemon-etcd:
     command: run-etcd-with-args
     daemon: simple

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -245,7 +245,6 @@ apps:
       - kernel-module-observe
       - kubernetes-support
       - login-session-observe
-      - home-read-all
       - log-observe
       - mount-observe
       - network


### PR DESCRIPTION
#### Summary
We have two ways to call a command, for example we can call inspect with `microk8s inspect` or `microk8s.inspect`. Both commands should have the same set of interfaces so that we have the same apparmor rules. This PR adds to the `microk8s` wrapper the same interface as the inspect script and the enable command. 

#### Changes
- Update the list of the interfaces used by the `microk8s` command

#### Testing
Manually build the snap and call `microk8s.inspect` and `microk8s inspect` commands and see they do not produce any denials.
