### PR TITLE
Remove cilium CNI removal process from install hook

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -96,17 +96,6 @@ do
   chmod -R o-rwX ${dir}
 done
 
-if ! is_strict || (is_strict && snapctl is-connected network-control) 
-  then
-  for link in cni0 cilium_vxlan
-  do
-    if ${SNAP}/sbin/ip link show ${link}
-    then
-      ${SNAP}/sbin/ip link delete ${link}
-    fi
-  done
-fi
-
 if is_strict && snapctl is-connected k8s-kubelet
 then
   snapctl restart microk8s.daemon-containerd


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
The link removal process for `cilium` CNI is repeated in multiple hooks. This process won't work on strict install hook since it checks if interfaces are connected, although all off the snap interfaces connect after the install hook. Also any links should already be cleaned in the `remove` hook, since this process is located there as well.

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
The `cilium` removal process is removed from the `install` hook.

#### Testing
<!-- Please explain how you tested your changes. -->
Existing tests should cover the changes.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [X] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
