### PR TITLE
Add cluster-info dump output directory

### DIFF
--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -130,7 +130,8 @@ function store_kubernetes_info {
     export KUBECONFIG=$SNAP_DATA/credentials/client.config
     $SNAP/kubectl version > $INSPECT_DUMP/k8s/version 2>&1
     $SNAP/kubectl cluster-info > $INSPECT_DUMP/k8s/cluster-info 2>&1
-    $SNAP/kubectl cluster-info dump -A > $INSPECT_DUMP/k8s/cluster-info-dump 2>&1
+    $SNAP/kubectl cluster-info dump -A > $INSPECT_DUMP/k8s/cluster-info-dump 2>&1 # Leave the cluster-info-dump file for legacy
+    $SNAP/kubectl cluster-info dump -A --output-directory="$INSPECT_DUMP/k8s/cluster-info-dump-dir" 2>&1 # Split cluster-info-dump into multiple files for easier parsing
     $SNAP/kubectl get all --all-namespaces -o wide > $INSPECT_DUMP/k8s/get-all 2>&1
     $SNAP/kubectl get pv > $INSPECT_DUMP/k8s/get-pv 2>&1
     $SNAP/kubectl get pvc --all-namespaces > $INSPECT_DUMP/k8s/get-pvc 2>&1
@@ -138,6 +139,7 @@ function store_kubernetes_info {
     sudo -E /snap/bin/microk8s kubectl version 2>&1 | sudo tee $INSPECT_DUMP/k8s/version > /dev/null
     sudo -E /snap/bin/microk8s kubectl cluster-info 2>&1 | sudo tee $INSPECT_DUMP/k8s/cluster-info > /dev/null
     sudo -E /snap/bin/microk8s kubectl cluster-info dump -A 2>&1 | sudo tee $INSPECT_DUMP/k8s/cluster-info-dump > /dev/null
+    sudo -E /snap/bin/microk8s kubectl cluster-info dump -A --output-directory="$INSPECT_DUMP/k8s/cluster-info-dump-dir" 2>&1 > /dev/null
     sudo -E /snap/bin/microk8s kubectl get all --all-namespaces -o wide 2>&1 | sudo tee $INSPECT_DUMP/k8s/get-all > /dev/null
     sudo -E /snap/bin/microk8s kubectl get pv 2>&1 | sudo tee $INSPECT_DUMP/k8s/get-pv > /dev/null # 2>&1 redirects stderr and stdout to /dev/null if no resources found
     sudo -E /snap/bin/microk8s kubectl get pvc --all-namespaces 2>&1 | sudo tee $INSPECT_DUMP/k8s/get-pvc > /dev/null # 2>&1 redirects stderr and stdout to /dev/null if no resources found


### PR DESCRIPTION
#### Summary
Closes #3255 

After running microk8s inspect a file is created called cluster-info-dump that contains the output from kubectl cluster-info dump.

The issue is this file contains a mix of json and plain text, making it very difficult to parse (by humans or programatically).

By passing an `output-directory` parameter to the `cluster-info dump` command, kubectl will split the output into multiple files, making the output much easier to browse and parse.

New file structure looks something like this
```sh
.
├── k8s
│   ├── cluster-info-dump
│   └── cluster-info-dump-all
│       ├── default
│       │   ├── my-pod-1-77d9bd5bb-bsf9v
│       │   │   └── logs.txt
│       │   ├── my-pod-2-fwvmk-m2w27
│       │   │   └── logs.txt
│       │   ├── daemonsets.json
│       │   ├── deployments.json
│       │   ├── events.json
│       │   ├── pods.json
│       │   ├── replicasets.json
│       │   ├── replication-controllers.json
│       │   ├── services.json
│       ├── nodes.json
```

#### Changes
Adding `--output-directory` to `kubectl cluster-info dump` command. See [docs](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#-em-dump-em-)

#### Testing
Running script locally generates "legacy" `cluster-info-dump` AND the `cluster-info-dump-dir` directory.

#### Possible Regressions
I made sure to leave `cluster-info-dump` in the inspection report so that there are no possible regressions. I can remove if needed of course as I think this adds to the time it takes to generate an inspection-report.

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
