### PR TITLE
fix containerd initialization after reboot

### DIFF
--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -60,7 +60,7 @@ then
 fi
 
 # clean leftover container state if we just booted
-if (is_strict && is_first_boot_on_strict) || (! is_strict && is_first_boot)
+if (is_strict && is_first_boot_on_strict) || (! is_strict && is_first_boot "${SNAP_COMMON}/run/containerd")
 then
   rm -rf "${SNAP_COMMON}/run/containerd" || true
 fi


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

References https://github.com/canonical/microk8s/pull/3190

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

Reverts regression introduced by https://github.com/canonical/microk8s/pull/3190/files#diff-15029275d146b90729a4c97b9541b16d2110d3582322181ffdd86e473b1b4842L57-L59

#### Testing
<!-- Please explain how you tested your changes. -->

Reboot a microk8s instance, make sure that containerd does not get stuck during init.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

Please double check that this is the intended behavior.

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->

Could we possibly test this in a CI setting?