### PR TITLE
Change containerd.sock group so there isn't a need for sudo for ctr

### DIFF
--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -64,6 +64,7 @@ do
     then
       chmod -R ug+rwX ${SNAP_DATA}/var/kubernetes/backend || true
       chgrp ${group} -R ${SNAP_DATA}/var/kubernetes/backend || true
+      chgrp ${group} ${SNAP_COMMON}/run/containerd.sock || true
     fi
 
     if ! [ -e "${SNAP_DATA}/var/lock/no-cert-reissue" ] &&

--- a/microk8s-resources/wrappers/microk8s-ctr.wrapper
+++ b/microk8s-resources/wrappers/microk8s-ctr.wrapper
@@ -8,8 +8,6 @@ export IN_SNAP_LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gn
 
 source $SNAP/actions/common/utils.sh
 
-exit_if_not_root
-
 SNAPSHOTTER=$(snapshotter)
 
 if ! [ -e $SNAP_DATA/args/ctr ]


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
Change containerd.sock group so there isn't a need for sudo for ctr

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
Change containerd.sock group in `apiservice-kicker` so that there isn't a need to use sudo

#### Testing
<!-- Please explain how you tested your changes. -->
Existing tests should cover the changes

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [X] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
