### PR TITLE
Update containerd to 1.6.6 and runc to 1.1.2

### DIFF
--- a/build-scripts/set-env-variables.sh
+++ b/build-scripts/set-env-variables.sh
@@ -17,10 +17,10 @@ export KNATIVE_SERVING_VERSION="${KNATIVE_SERVING_VERSION:-v0.13.0}"
 export KNATIVE_EVENTING_VERSION="${KNATIVE_EVENTING_VERSION:-v0.13.0}"
 export TRAEFIK_VERSION="${TRAEFIK_VERSION:-v2.4.9}"
 # RUNC commit matching the containerd release commit
-# Tag 1.5.11
-export CONTAINERD_COMMIT="${CONTAINERD_COMMIT:-3df54a852345ae127d1fa3092b95168e4a88e2f8}"
-# Release v1.0.3
-export RUNC_COMMIT="${RUNC_COMMIT:-f46b6ba2c9314cfc8caae24a32ec5fe9ef1059fe}"
+# Tag 1.6.6
+export CONTAINERD_COMMIT="${CONTAINERD_COMMIT:-10c12954828e7c7c9b6e0ea9b0c02b01407d3ae1}"
+# Release v1.1.2
+export RUNC_COMMIT="${RUNC_COMMIT:-a916309fff0f838eb94e928713dbc3c0d0ac7aa4}"
 # Set this to the kubernetes fork you want to build binaries from
 export KUBERNETES_REPOSITORY="${KUBERNETES_REPOSITORY:-github.com/kubernetes/kubernetes}"
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -429,7 +429,7 @@ parts:
     override-build: |
       set -eux
       . $SNAPCRAFT_PART_SRC/set-env-variables.sh
-      snap refresh go --channel=1.17/stable || true
+      snap refresh go --channel=1.18/stable || true
       go version
       export GOPATH=$(realpath ../go)
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
@@ -474,20 +474,22 @@ parts:
     override-build: |
       set -eux
       . $SNAPCRAFT_PART_SRC/set-env-variables.sh
-      snap refresh go --channel=1.16/stable || true
+
+      snap refresh go --channel=1.18/stable || true
       go version
       export GOPATH=$(realpath ../go)
-      export GO111MODULE=off
-      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
 
-      # Build runc
-      go get -d github.com/opencontainers/runc
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
+      if [ -d ${GOPATH}/runc ]; then
+        rm -rf ${GOPATH}/runc
+      fi
+      git clone https://github.com/opencontainers/runc ${GOPATH}/runc
       (
-        cd $GOPATH/src/github.com/opencontainers/runc
+        cd $GOPATH/runc
         git checkout ${RUNC_COMMIT}
         make BUILDTAGS='seccomp apparmor'
       )
-      cp $GOPATH/src/github.com/opencontainers/runc/runc $SNAPCRAFT_PART_INSTALL/bin/
+      cp $GOPATH/runc/runc $SNAPCRAFT_PART_INSTALL/bin/
 
       # Assemble the snap
       snapcraftctl build


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

Update containerd to 1.6

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

- containerd upgrade to 1.6.6 (from 1.5.11)
- runc upgrade to 1.1.2 (from 1.0.3). Version retrieved from https://github.com/containerd/containerd/blob/v1.6.6/go.mod#L46
- use Go 1.18 to build containerd and runc

#### Testing
<!-- Please explain how you tested your changes. -->

- Clean install with containerd 1.6.6, test create, scale, teardown a deployment
- Install 1.24, create a deployment, upgrade to containerd 1.6.6, scale and teardown the deployment

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

Pointing to the changelogs for runc and containerd:
- https://github.com/opencontainers/runc/blob/main/CHANGELOG.md
- https://github.com/containerd/containerd/releases

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [X] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
