### PR TITLE
fix configure hook not running on old installs

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -4,14 +4,12 @@ set -eux
 
 source $SNAP/actions/common/utils.sh
 
-if [ ! -f "${SNAP_DATA}/var/lock/installed.lock" ]
-then
-  exit 0
-fi
-
-
 if is_strict
 then
+  if [ ! -f "${SNAP_DATA}/var/lock/installed.lock" ]
+  then
+    exit 0
+  fi
 
   ARCH="$($SNAP/bin/uname -m)"
   export LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

Fix regression from https://github.com/canonical/microk8s/commit/5ff8682524d29037a299ff54d09a885954668ad9#diff-7f1ea137a27c441e1be1e0ddb37091c53b09335f3124c2b47c4792e82b15290dR7

`$SNAP_DATA/var/lock/installed.lock` will not be there on old installs, which prevents the configure hook from running.

Revert change to only check for the lock file on the strict branch.