### PR TITLE
Fix reset denial on accessing home

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -535,6 +535,7 @@ apps:
     command: microk8s-reset.wrapper
     plugs:
       - account-control
+      - home
       - mount-observe
       - network-control
       - network


### PR DESCRIPTION
Fixes the denial:
```
= AppArmor =
Time: Jun 29 20:23:22
Log: apparmor="DENIED" operation="open" profile="snap.microk8s.reset" name="/home/jackal/workspace/microk8s/" pid=1984983 comm="bash" requested_mask="r" denied_mask="r" fsuid=0 ouid=1000
File: /home/jackal/workspace/microk8s/ (read)
Suggestion:
* add 'home' to 'plugs'
```