### PR TITLE
Fix microk8s config denial

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -531,6 +531,8 @@ apps:
       - network
   config:
     command: microk8s-config.wrapper
+    plugs:
+      - network-observe
   reset:
     command: microk8s-reset.wrapper
     plugs:


### PR DESCRIPTION
Fix the following denial in `microk8s config`:
```
= Seccomp = 
Time: Jun 29 21:37:55 
Log: auid=1000 uid=1000 gid=1000 ses=3 subj=snap.microk8s.config pid=2093990 comm="ip" exe="/snap/microk8s/3502/bin/ip" sig=0 arch=c000003e 41(socket) compat=0 ip=0x7f92612cbc57 code=0x50000 
Syscall: socket 
Suggestions: 
* add account-control (if using NETLINK_AUDIT) 
* add audio-playback (if using NETLINK_KOBJECT_UEVENT) 
* add bluetooth-control (if using AF_{ALG,BLUETOOTH}) 
* add firewall-control (if using NETLINK_{FIREWALL,IP6_FW,NETFILTER,NF_LOG,ROUTE}) 
* add hardware-observe (if using NETLINK_{GENERIC,KOBJECT_UEVENT}) 
* add netlink-audit (if using NETLINK_AUDIT) 
* add netlink-connector (if using NETLINK_CONNECTOR) 
* add network (if using AF_INET{,6}, AF_CONN, NETLINK_ROUTE) 
* add network-bind (if using AF_INET{,6}, NETLINK_ROUTE) 
* add network-control (if using AF_{APPLETALK,BRIDGE,INET,INET6,IPX,PACKET,PPPOX,SNA}, NETLINK_{DNRTMSG,FIB_LOOKUP,GENERIC,INET_DIAG,ISCSI,KOBJECT_UEVENT,RDMA,ROUTE,XFRM}) 
* add network-observe (if using SOCK_RAW, AF_INET{,6}), NETLINK_{GENERIC,INET_DIAG,KOBJECT_UEVENT,ROUTE}) 
* add raw-usb (if using NETLINK_KOBJECT_UEVENT) 
* add time-control (if using NETLINK_AUDIT) 
* add unity7 (if using NETLINK_KOBJECT_UEVENT) 
* add x11 (if using NETLINK_KOBJECT_UEVENT)
```