### PR TITLE
Added a strict flag to skip addons tests that are expected to fail in test-distro

### DIFF
--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -96,8 +96,8 @@ else
   lxc exec $NAME -- snap install microk8s --channel=${TO_CHANNEL}
 fi
 # use 'script' for required tty: https://github.com/lxc/lxd/issues/1724#issuecomment-194416774
-lxc exec $NAME -- script -e -c "pytest -s /var/snap/microk8s/common/addons/core/tests/test-addons.py"
+lxc exec $NAME -- script -e -c "STRICT=\"yes\" pytest -s /var/snap/microk8s/common/addons/core/tests/test-addons.py"
 lxc exec $NAME -- microk8s enable community
-lxc exec $NAME -- script -e -c "pytest -s /var/snap/microk8s/common/addons/community/tests/test-addons.py"
+lxc exec $NAME -- script -e -c "STRICT=\"yes\" pytest -s /var/snap/microk8s/common/addons/community/tests/test-addons.py"
 lxc exec $NAME -- microk8s reset
 lxc delete $NAME --force

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -26,10 +26,10 @@ function create_machine() {
 
   # Allow for the machine to boot and get an IP
   sleep 20
-  tar cf - ./tests | lxc exec $NAME -- tar xvf - -C /root
+  tar cf - ./tests | lxc exec $NAME -- tar xvf - -C /var/tmp
   DISTRO_DEPS_TMP="${DISTRO//:/_}"
   DISTRO_DEPS="${DISTRO_DEPS_TMP////-}"
-  lxc exec $NAME -- /bin/bash "/root/tests/lxc/install-deps/$DISTRO_DEPS"
+  lxc exec $NAME -- /bin/bash "/var/tmp/tests/lxc/install-deps/$DISTRO_DEPS"
   lxc exec $NAME -- reboot
   sleep 20
 
@@ -91,7 +91,7 @@ if [[ ${TO_CHANNEL} =~ /.*/microk8s.*snap ]]
 then
   lxc file push ${TO_CHANNEL} $NAME/tmp/microk8s_latest_amd64.snap
   lxc exec $NAME -- snap install /tmp/microk8s_latest_amd64.snap --dangerous --classic
-  lxc exec $NAME -- bash -c '/root/tests/connect-all-interfaces.sh'
+  lxc exec $NAME -- bash -c '/var/tmp/tests/connect-all-interfaces.sh'
 else
   lxc exec $NAME -- snap install microk8s --channel=${TO_CHANNEL}
 fi


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
Added a strict flag to addons testing in `test-distro.sh` so addons tests that are expected to fail are skipped
Changed workdir from `/root/` to `/var/tmp`

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
Added a strict flag to addons testing in `test-distro.sh` so addons tests that are expected to fail are skipped
Changed workdir from `/root/` to `/var/tmp`

#### Testing
<!-- Please explain how you tested your changes. -->
Manually run the `test-distro.sh` and existing tests should cover the changes.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [X] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
