### PR TITLE
Add GitHub action to update list of images

### DIFF
--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -1,0 +1,35 @@
+name: Update list of images
+
+on:
+  - workflow_dispatch
+  - schedule:
+      - cron: "0 10 * * *"
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - { branch: master, channel: latest/edge }
+          - { branch: 1.24, channel: 1.24 }
+          - { branch: 1.23, channel: 1.23 }
+          - { branch: 1.22, channel: 1.22 }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
+        with:
+          ref: ${{ matrix.branch }}
+      - name: Update image list
+        run: |
+          ./build-scripts/update-images.sh ${{ matrix.channel }} build-scripts/images.txt
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: update list of images used by ${{ matrix.channel }}
+          title: "[${{ matrix.branch }}] Update MicroK8s images"
+          body: update list of images used by ${{ matrix.channel }}
+          reviewers: neoaggelos,ktsakalozos
+          branch: auto-update-images/${{ matrix.branch }}
+          delete-branch: true
+          base: ${{ matrix.branch }}

--- a/build-scripts/update-images.sh
+++ b/build-scripts/update-images.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -x
+
+## Description:
+#
+# Install MicroK8s from a specific channel and update the list of images required by MicroK8s
+# and the core addons.
+#
+## Example:
+#
+# $ ./build-scripts/update-images.sh latest/edge build-scripts/images.txt
+
+sudo snap install microk8s --classic --channel $1
+sudo microk8s status --wait-ready
+
+sudo microk8s addons repo add core https://github.com/canonical/microk8s-core-addons --force
+sudo microk8s enable storage ingress metrics-server dns
+
+sudo microk8s kubectl apply -f - <<EOF
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: my-pvc
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: { requests: { storage: 5Gi } }
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  volumes:
+    - name: pvc
+      persistentVolumeClaim:
+        claimName: my-pvc
+  containers:
+    - name: nginx
+      image: nginx
+      ports:
+        - containerPort: 80
+      volumeMounts:
+        - name: pvc
+          mountPath: /usr/share/nginx/html
+EOF
+
+while ! sudo microk8s kubectl wait --for=condition=ready pod/nginx; do
+  sudo microk8s kubectl get pod,pvc -A
+  sleep 3
+done
+
+sudo microk8s ctr image ls -q | grep -v sha256 | grep -v nginx:latest | sort > $2


### PR DESCRIPTION
Add GitHub action to update list of images used by MicroK8s on a schedule.

The action installs MicroK8s from the requested track, enables some core addons, prints the list of images that are used and then creates a pull request for the respective branch on the microk8s repo.

This way, `build-scripts/images.txt` is the source of truth of the images required by MicroK8s for each release.