### PR TITLE
[1.22] Fix build failures on arm64 and s390x

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -504,7 +504,6 @@ parts:
       then
         # Some actions are only available on amd64
         rm actions/*.gpu.sh
-        rm "actions/gpu.yaml"
         rm actions/*.istio.sh
         rm actions/*.knative.sh
         rm actions/*.fluentd.sh


### PR DESCRIPTION

Build failure log (https://launchpad.net/~microk8s-dev/+snap/microk8s-1.22/+build/1810946/+files/buildlog_snap_ubuntu_bionic_arm64_microk8s-1.22_BUILDING.txt.gz):

```
+ rm actions/gpu.yaml
rm: cannot remove 'actions/gpu.yaml': No such file or directory
Failed to run 'override-build': Exit code was 1.
```