### PR TITLE
Support for post-refresh, remove and reconcile hooks for addons

### DIFF
--- a/microk8s-resources/default-hooks/post-refresh.d/10-cni-reload
+++ b/microk8s-resources/default-hooks/post-refresh.d/10-cni-reload
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# if we are refreshing in a no-flanneld we need to restart the CNI pods because they mount parts of $SNAP_DATA
-if [ -e "${SNAP_DATA}/var/lock/no-flanneld" ]
-then
-  touch "${SNAP_DATA}/var/lock/cni-needs-reload"
-fi

--- a/microk8s-resources/default-hooks/post-refresh.d/10-cni-reload
+++ b/microk8s-resources/default-hooks/post-refresh.d/10-cni-reload
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# if we are refreshing in a no-flanneld we need to restart the CNI pods because they mount parts of $SNAP_DATA
+if [ -e "${SNAP_DATA}/var/lock/no-flanneld" ]
+then
+  touch "${SNAP_DATA}/var/lock/cni-needs-reload"
+fi

--- a/microk8s-resources/default-hooks/reconcile.d/10-cni-restart
+++ b/microk8s-resources/default-hooks/reconcile.d/10-cni-restart
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+. "${SNAP}/actions/common/utils.sh"
+
+KUBECTL="${SNAP}/microk8s-kubectl.wrapper"
+
+# Calico reload deployment
+if ! [ -e "${SNAP_DATA}/var/lock/no-cni-reload" ] &&
+   [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ] &&
+   [ -e "${SNAP_DATA}/var/lock/ha-cluster" ] &&
+   [ -e "${SNAP_DATA}/var/lock/cni-loaded" ] &&
+   [ -e "${SNAP_DATA}/var/lock/no-flanneld" ] &&
+   [ -e "${SNAP_DATA}/var/lock/cni-needs-reload" ]
+then
+  if ! [ -e "${SNAP_DATA}/var/lock/skip-offloading" ] &&
+     ! grep -q "ChecksumOffloadBroken" "${SNAP_DATA}/args/cni-network/cni.yaml" &&
+     "${KUBECTL}" patch felixconfigurations default --patch '{"spec":{"featureDetectOverride":"ChecksumOffloadBroken=true"}}' --type=merge
+  then
+      echo "Patched calico for offloading"
+  fi
+
+  echo "Reloading the calico CNI"
+  if (is_apiserver_ready)  &&
+      "${KUBECTL}" --request-timeout 2m describe -n kube-system daemonset.apps/calico-node &&
+      "${KUBECTL}" --request-timeout 2m describe -n kube-system deployment.apps/calico-kube-controllers &&
+      "${KUBECTL}" --request-timeout 2m rollout restart -n kube-system daemonset.apps/calico-node &&
+      "${KUBECTL}" --request-timeout 2m rollout restart -n kube-system deployment.apps/calico-kube-controllers
+  then
+    rm "${SNAP_DATA}/var/lock/cni-needs-reload"
+  fi
+fi

--- a/microk8s-resources/default-hooks/reconcile.d/10-cni-restart-cilium
+++ b/microk8s-resources/default-hooks/reconcile.d/10-cni-restart-cilium
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+. "${SNAP}/actions/common/utils.sh"
+
+KUBECTL="${SNAP}/microk8s-kubectl.wrapper"
+
+# Cilium reload deployment
+if ! [ -e "${SNAP_DATA}/var/lock/no-cni-reload" ] &&
+   ! [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ] &&
+   [ -e "${SNAP_DATA}/var/lock/no-flanneld" ] &&
+   [ -e "${SNAP_DATA}/var/lock/cni-needs-reload" ]
+then
+  echo "Reloading the cilium CNI"
+  if (is_apiserver_ready)  &&
+      "${KUBECTL}" --request-timeout 2m describe -n kube-system daemonset.apps/cilium &&
+      "${KUBECTL}" --request-timeout 2m describe -n kube-system deployment.apps/cilium-operator &&
+      "${KUBECTL}" --request-timeout 2m rollout restart -n kube-system daemonset.apps/cilium  &&
+      "${KUBECTL}" --request-timeout 2m rollout restart -n kube-system deployment.apps/cilium-operator
+  then
+    rm "${SNAP_DATA}/var/lock/cni-needs-reload"
+  fi
+fi

--- a/microk8s-resources/default-hooks/reconcile.d/90-calico-apply
+++ b/microk8s-resources/default-hooks/reconcile.d/90-calico-apply
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+. "${SNAP}/actions/common/utils.sh"
+
+KUBECTL="${SNAP}/microk8s-kubectl.wrapper"
+
+if [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ] &&
+   [ -e "${SNAP_DATA}/var/lock/ha-cluster" ] &&
+   ! [ -e "${SNAP_DATA}/var/lock/cni-loaded" ]
+then
+  echo "Setting up the CNI"
+  if (is_apiserver_ready) && "${KUBECTL}" apply -f "${SNAP_DATA}/args/cni-network/cni.yaml"
+  then
+    touch "${SNAP_DATA}/var/lock/cni-loaded"
+  fi
+fi

--- a/microk8s-resources/default-hooks/remove.d/10-cni-link
+++ b/microk8s-resources/default-hooks/remove.d/10-cni-link
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+. "${SNAP}/actions/common/utils.sh"
+
+if ! is_strict || (is_strict && snapctl is-connected network-control)
+then
+  for link in cni0 calico.vxlan
+  do
+    if "${SNAP}/sbin/ip" link show "${link}"
+    then
+      "${SNAP}/sbin/ip" link delete "${link}" || true
+    fi
+  done
+fi

--- a/microk8s-resources/default-hooks/remove.d/10-cni-link-cilium
+++ b/microk8s-resources/default-hooks/remove.d/10-cni-link-cilium
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+. "${SNAP}/actions/common/utils.sh"
+
+if ! is_strict || (is_strict && snapctl is-connected network-control)
+then
+  for link in cilium_host cilium_vxlan
+  do
+    if "${SNAP}/sbin/ip" link show "${link}"
+    then
+      "${SNAP}/sbin/ip" link delete "${link}" || true
+    fi
+  done
+fi

--- a/microk8s-resources/default-hooks/remove.d/20-cni-netns
+++ b/microk8s-resources/default-hooks/remove.d/20-cni-netns
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. "${SNAP}/actions/common/utils.sh"
+
+if ! is_strict || (is_strict && snapctl is-connected network-control)
+then
+  for ns in `"${SNAP}/sbin/ip" netns list | grep "^cni-" | awk '{print $1}'`
+  do
+    "${SNAP}/sbin/ip" netns delete "${ns}" || true
+  done
+fi

--- a/microk8s-resources/default-hooks/remove.d/90-containers
+++ b/microk8s-resources/default-hooks/remove.d/90-containers
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+. "${SNAP}/actions/common/utils.sh"
+
+if is_strict
+then
+  remove_all_containers
+else
+  kill_all_container_shims
+fi

--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -76,59 +76,8 @@ do
       fi
     fi
 
-    if [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ] &&
-       [ -e "${SNAP_DATA}/var/lock/ha-cluster" ] &&
-       ! [ -e "${SNAP_DATA}/var/lock/cni-loaded" ]
-    then
-      echo "Setting up the CNI"
-      if (is_apiserver_ready)  &&
-         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m apply -f "${SNAP_DATA}/args/cni-network/cni.yaml"
-      then
-        touch "${SNAP_DATA}/var/lock/cni-loaded"
-      fi
-    fi
-
-    # Calico reload deployment
-    if ! [ -e "${SNAP_DATA}/var/lock/no-cni-reload" ] &&
-       [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ] &&
-       [ -e "${SNAP_DATA}/var/lock/ha-cluster" ] &&
-       [ -e "${SNAP_DATA}/var/lock/cni-loaded" ] &&
-       [ -e "${SNAP_DATA}/var/lock/no-flanneld" ] &&
-       [ -e "${SNAP_DATA}/var/lock/cni-needs-reload" ]
-    then
-      echo "Reloading the calico CNI"
-      if (is_apiserver_ready)  &&
-          if ! [ -e "${SNAP_DATA}/var/lock/skip-offloading" ] &&
-             ! grep -q "ChecksumOffloadBroken" "${SNAP_DATA}/args/cni-network/cni.yaml" &&
-             "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" patch felixconfigurations default --patch '{"spec":{"featureDetectOverride":"ChecksumOffloadBroken=true"}}' --type=merge
-          then
-              echo "Patched calico for offloading"
-          fi
-         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m describe -n kube-system daemonset.apps/calico-node &&
-         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m describe -n kube-system deployment.apps/calico-kube-controllers &&
-         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m rollout restart -n kube-system daemonset.apps/calico-node &&
-         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m rollout restart -n kube-system deployment.apps/calico-kube-controllers
-      then
-        rm "${SNAP_DATA}/var/lock/cni-needs-reload"
-      fi
-    fi
-
-    # Cilium reload deployment
-    if ! [ -e "${SNAP_DATA}/var/lock/no-cni-reload" ] &&
-       ! [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ] &&
-       [ -e "${SNAP_DATA}/var/lock/no-flanneld" ] &&
-       [ -e "${SNAP_DATA}/var/lock/cni-needs-reload" ]
-    then
-      echo "Reloading the cilium CNI"
-      if (is_apiserver_ready)  &&
-         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m describe -n kube-system daemonset.apps/cilium &&
-         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m describe -n kube-system deployment.apps/cilium-operator &&
-         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m rollout restart -n kube-system daemonset.apps/cilium  &&
-         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m rollout restart -n kube-system deployment.apps/cilium-operator
-      then
-        rm "${SNAP_DATA}/var/lock/cni-needs-reload"
-      fi
-    fi
+    # Run reconcile hooks
+    $SNAP/usr/bin/python3 $SNAP/scripts/run-lifecycle-hooks.py reconcile || true
 
     # If no local-registry-hosting documentation has been installed,
     # install a help guide that points to the microk8s registry docs.

--- a/scripts/kill-host-pods.py
+++ b/scripts/kill-host-pods.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import os
+
+import click
+
+CTR = os.path.expandvars("$SNAP/microk8s-ctr.wrapper")
+KUBECTL = [
+    "{}/kubectl".format(os.getenv("SNAP")),
+    "--kubeconfig={}/credentials/kubelet.config".format(os.getenv("SNAP_DATA")),
+]
+
+
+@click.command("kill-host-pods")
+@click.argument("selector", nargs=-1)
+@click.option("--dry-run", is_flag=True, default=False)
+def main(selector: list, dry_run: bool):
+    """
+    Delete pods running on the local node based on Kubernetes selectors.
+
+    Example usage:
+
+    $ ./kill-host-pods.py -- -n kube-system -l k8s-app=calico-node
+    """
+    containers = subprocess.check_output([CTR, "container", "ls", "-q"]).decode().split("\n")
+    out = subprocess.check_output([*KUBECTL, "get", "pod", "-o", "json", *selector])
+
+    pods = json.loads(out)
+    for pod in pods["items"]:
+        must_delete = False
+        for container in pod["status"]["containerStatuses"] or []:
+            try:
+                _, container_id = container["containerID"].split("containerd://", 2)
+                if container_id in containers:
+                    must_delete = True
+                    break
+            except (KeyError, ValueError, TypeError, AttributeError):
+                continue
+
+        if must_delete:
+            meta = pod["metadata"]
+            cmd = [*KUBECTL, "delete", "pod", "-n", meta["namespace"], meta["name"]]
+            if dry_run:
+                cmd = ["echo", *cmd]
+
+            subprocess.check_call(cmd)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run-lifecycle-hooks.py
+++ b/scripts/run-lifecycle-hooks.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import os
+import click
+import subprocess
+
+SNAP_COMMON = Path(os.getenv("SNAP_COMMON"))
+TIMEOUT = 120
+
+
+@click.command("run-lifecycle-hooks")
+@click.argument("hook")
+def main(hook: str):
+    hooks_dir = SNAP_COMMON / "hooks" / f"{hook}.d"
+    hooks = os.listdir(hooks_dir)
+    for hook in sorted(hooks):
+        try:
+            if not (os.stat(hooks_dir / hook).st_mode & 0o100):
+                # ignore non-executable files
+                continue
+
+            subprocess.run([hooks_dir / hook], timeout=TIMEOUT)
+        except (subprocess.CalledProcessError, OSError):
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -609,6 +609,12 @@ then
   enable_snap
 fi
 
+# if we are refreshing in a no-flanneld we need to restart the CNI pods because they mount parts of $SNAP_DATA
+if [ -e "${SNAP_DATA}/var/lock/no-flanneld" ]
+then
+  touch "${SNAP_DATA}/var/lock/cni-needs-reload"
+fi
+
 # Restart reconfigured services
 if ${need_api_restart} ||
    ${need_proxy_restart} ||

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -180,6 +180,12 @@ then
 
 fi
 
+# Install default-hooks
+if ! [ -d "${SNAP_COMMON}/hooks" ]
+then
+  cp -r --preserve=mode ${SNAP}/microk8s-resources/default-hooks ${SNAP_COMMON}/hooks
+fi
+
 # Make sure the server certificate includes the IP we are using
 if [ "$(produce_certs)" == "1" ]
 then
@@ -207,26 +213,6 @@ then
   echo "Patching 1.15 allow-privileged"
   "${SNAP}/bin/sed" -i '/allow-privileged/d' ${SNAP_DATA}/args/kubelet
     need_kubelet_restart=true
-fi
-
-if ([ -f "$SNAP_USER_COMMON/istio-auth.lock" ] || [ -f "$SNAP_USER_COMMON/istio-auth.lock" ]) && ! [ -f "$SNAP_DATA/bin/istioctl" ]
-then
-  ISTIO_VERSION="v1.0.5"
-  echo "Fetching istioctl version $ISTIO_VERSION."
-  ISTIO_ERSION=$(echo $ISTIO_VERSION | sed 's/v//g')
-  mkdir -p "${SNAP_DATA}/tmp/istio"
-  (cd "${SNAP_DATA}/tmp/istio"
-  fetch_as https://github.com/istio/istio/releases/download/${ISTIO_ERSION}/istio-${ISTIO_ERSION}-linux.tar.gz "$SNAP_DATA/tmp/istio/istio.tar.gz"
-  gzip -d "$SNAP_DATA/tmp/istio/istio.tar.gz"
-  tar -xvf "$SNAP_DATA/tmp/istio/istio.tar")
-  mkdir -p "$SNAP_DATA/bin/"
-  mv "$SNAP_DATA/tmp/istio/istio-${ISTIO_ERSION}/bin/istioctl" "$SNAP_DATA/bin/"
-  chmod +x "$SNAP_DATA/bin/istioctl"
-  mkdir -p "$SNAP_DATA/actions/istio/"
-  cp "$SNAP_DATA/tmp/istio/istio-${ISTIO_ERSION}"/install/kubernetes/helm/istio/templates/crds.yaml "$SNAP_DATA/actions/istio/"
-  mv "$SNAP_DATA/tmp/istio/istio-${ISTIO_ERSION}/install/kubernetes/istio-demo-auth.yaml" "$SNAP_DATA/actions/istio/"
-  mv "$SNAP_DATA/tmp/istio/istio-${ISTIO_ERSION}/install/kubernetes/istio-demo.yaml" "$SNAP_DATA/actions/istio/"
-  rm -rf "$SNAP_DATA/tmp/istio"
 fi
 
 if ! [ -f "$SNAP_DATA/credentials/kubelet.config" ]
@@ -358,7 +344,7 @@ then
   mv ${CD_TOML_TMP} ${CD_TOML}
 fi
 
-for dir in ${SNAP_COMMON}/plugins ${SNAP_COMMON}/addons ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock ${SNAP_DATA}/tmp/
+for dir in ${SNAP_COMMON}/plugins ${SNAP_COMMON}/addons ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock ${SNAP_DATA}/tmp/ ${SNAP_COMMON}/hooks
 do
   chmod -R ug+rwX ${dir}
   chmod -R o-rwX ${dir}
@@ -374,7 +360,7 @@ fi
 
 if getent group ${group} >/dev/null 2>&1
 then
-  chgrp ${group} -R ${SNAP_COMMON}/plugins ${SNAP_COMMON}/addons ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock/ ${SNAP_DATA}/var/kubernetes/backend/ ${SNAP_DATA}/tmp/ || true
+  chgrp ${group} -R ${SNAP_COMMON}/plugins ${SNAP_COMMON}/addons ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock/ ${SNAP_DATA}/var/kubernetes/backend/ ${SNAP_DATA}/tmp/ ${SNAP_COMMON}/hooks || true
 fi
 
 if ! is_strict
@@ -489,13 +475,6 @@ if ! grep '\-\-enable\-v2' ${SNAP_DATA}/args/etcd
 then
   refresh_opt_in_config enable-v2 true etcd
   snapctl restart ${SNAP_NAME}.daemon-etcd
-fi
-
-if [ -L "${SNAP_DATA}/bin/cilium" ]
-then
-  echo "Cilium is enabled we need to reconfigure it."
-  rm -rf $SNAP_DATA/bin/cilium*
-  ${SNAP}/actions/enable.cilium.sh
 fi
 
 if [ -e ${SNAP_DATA}/var/lock/clustered.lock ]
@@ -647,41 +626,4 @@ fi
 if ${need_cluster_agent_restart}
 then
   snapctl restart ${SNAP_NAME}.daemon-cluster-agent
-fi
-
-# if we are refreshing in a no-flanneld we need to restart the CNI pods because they mount parts of $SNAP_DATA
-if [ -e "${SNAP_DATA}/var/lock/no-flanneld" ]
-then
-  touch "${SNAP_DATA}/var/lock/cni-needs-reload"
-fi
-
-if ! is_strict &&
-   [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ] &&
-   [ -e "${SNAP_DATA}/var/lock/ha-cluster" ] &&
-   ! [ -e "${SNAP_DATA}/var/lock/clustered.lock" ]
-then
-  echo "Setting up the CNI"
-  start_timer="$(date +%s)"
-  # Wait up to two minutes for the apiserver to come up.
-  # TODO: this polling is not good enough. We should find a new way to ensure the apiserver is up.
-  timeout="120"
-  KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
-  while ! (is_apiserver_ready)
-  do
-    sleep 5
-    now="$(date +%s)"
-    if [[ "$now" > "$(($start_timer + $timeout))" ]] ; then
-      break
-    fi
-  done
-
-  # if the API server came up try to load the CNI manifest
-  now="$(date +%s)"
-  if [[ "$now" < "$(($start_timer + $timeout))" ]] ; then
-    if (is_apiserver_ready) &&
-        $KUBECTL apply -f "${SNAP_DATA}/args/cni-network/cni.yaml"
-    then
-      touch "${SNAP_DATA}/var/lock/cni-loaded"
-    fi
-  fi
 fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -90,7 +90,10 @@ $SNAP/bin/sed -i '/username/d' ${SNAP_DATA}/credentials/proxy.config
 $SNAP/bin/sed -i 's/AUTHTYPE/token/g' ${SNAP_DATA}/credentials/proxy.config
 $SNAP/bin/sed -i 's/PASSWORD/'"${proxy_token}"'/g' ${SNAP_DATA}/credentials/proxy.config
 
-for dir in ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/
+# Install default-hooks
+cp -r --preserve=mode ${SNAP}/microk8s-resources/default-hooks ${SNAP_COMMON}/hooks
+
+for dir in ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_COMMON}/hooks
 do
   chmod -R ug+rwX ${dir}
   chmod -R o-rwX ${dir}

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Run post-refresh hooks
+$SNAP/usr/bin/python3 $SNAP/scripts/run-lifecycle-hooks.py post-refresh || true

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -52,32 +52,5 @@ rm -rf ${SNAP_COMMON}/run/containerd/* || true
 (cat /proc/mounts | grep ${SNAP_COMMON}/var/run/docker | cut -d ' ' -f 2 | xargs umount) || true
 (cat /proc/mounts | grep ${SNAP_COMMON}/var/lib/kubelet | cut -d ' ' -f 2 | xargs umount) || true
 
-if ! is_strict || (is_strict && snapctl is-connected network-control) 
-  then
-  for link in cni0 cilium_vxlan
-  do
-    if ${SNAP}/sbin/ip link show ${link}
-    then
-      ${SNAP}/sbin/ip link delete ${link}
-    fi
-  done
-fi
-
-if is_strict
-then
-  remove_all_containers
-else
-  kill_all_container_shims
-fi
-
-# Cleanup calico interface.
-if "${SNAP}/sbin/ip" link show vxlan.calico
-then
-  "${SNAP}/sbin/ip" link delete vxlan.calico || true
-fi
-
-# Cleanup cni network namespaces.
-for ns in `"${SNAP}/sbin/ip" netns list | grep "^cni-" | awk '{print $1}'`
-do
-  $SNAP/sbin/ip netns delete "${ns}" || true
-done
+# Run remove hooks
+$SNAP/usr/bin/python3 $SNAP/scripts/run-lifecycle-hooks.py remove || true


### PR DESCRIPTION
### Summary

Support adding custom hooks for `post-refresh`, `reconcile` and `remove` lifecycle events. This allows us to extend the add-on ecosystem with much richer addons, like addons that manage the complete lifecycle of custom CNIs, for example https://github.com/canonical/microk8s-core-addons/pull/28

### Changes

- Move addon specific code out of the configure hook. Take this change to also remove obsolete code.
- Move hard-coded calico and cilium CNI refresh hooks out of apiservice-kicker and into reconcile hooks.

### Testing

Tested along with https://github.com/canonical/microk8s-core-addons/pull/28
```
sudo snap install microk8s --classic --channel latest/edge/hooks
```