### PR TITLE
Fix printing of available commands from addons

### DIFF
--- a/microk8s-resources/wrappers/microk8s.wrapper
+++ b/microk8s-resources/wrappers/microk8s.wrapper
@@ -12,10 +12,10 @@ function help() {
     echo -e "\tinspect"
     plugins="$(find ${SNAP_COMMON}/plugins/* 2> /dev/null)"
     if [ ! -z "$plugins" ]; then
-	    echo "Available subcommands from addons are:"
-	    for i in "$plugins" ; do
-		    echo -e "\t$(basename ${i})"
-	    done
+            echo "Available subcommands from addons are:"
+            for i in "${SNAP_COMMON}/plugins/"*; do
+                echo -e "\t$(basename "${i}")"
+            done
     fi
 }
 


### PR DESCRIPTION
Small fix for the following issue:

```
ubuntu@dev:/var/snap/microk8s/common/plugins$ microk8s > /dev/null
basename: extra operand ‘/var/snap/microk8s/common/plugins/c’
Try 'basename --help' for more information.
ubuntu@dev:/var/snap/microk8s/common/plugins$ ls
a  b  c
```