### PR TITLE
Follow improvements for snapcraft build pipeline

### DIFF
--- a/build-scripts/addon-repositories.sh
+++ b/build-scripts/addon-repositories.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-ADDONS_REPOS="
-core,${CORE_ADDONS_REPO:-https://github.com/canonical/microk8s-core-addons},${CORE_ADDONS_REPO_BRANCH:-main}
-community,${COMMUNITY_ADDONS_REPO:-https://github.com/canonical/microk8s-community-addons},${COMMUNITY_ADDONS_REPO_BRANCH:-main}
-"
-ADDONS_REPOS_ENABLED="core"

--- a/build-scripts/addons/repositories.sh
+++ b/build-scripts/addons/repositories.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -x
+
+# List of addon repositories to bundle in the snap
+# (name),(repository),(reference)
+ADDONS_REPOS="
+core,https://github.com/canonical/microk8s-core-addons,main
+community,https://github.com/canonical/microk8s-community-addons,main
+"
+
+# List of addon repositories to automatically enable
+ADDONS_REPOS_ENABLED="core"
+
+INSTALL="${1}"
+if [ -d "${INSTALL}/addons" ]; then
+  rm -rf "${INSTALL}/addons"
+fi
+if [ -d addons ]; then
+  rm -rf addons
+fi
+
+IFS=';'
+echo "${ADDONS_REPOS}" | while read line; do
+  if [ -z "${line}" ];
+    then continue
+  fi
+  name="$(echo ${line} | cut -f1 -d',')"
+  repository="$(echo ${line} | cut -f2 -d',')"
+  reference="$(echo ${line} | cut -f3 -d',')"
+  git clone "${repository}" -b "${reference}" "addons/${name}"
+done
+echo "${ADDONS_REPOS_ENABLED}" > addons/.auto-add
+
+cp -r "addons" "${INSTALL}/addons"

--- a/build-scripts/build-component.sh
+++ b/build-scripts/build-component.sh
@@ -60,4 +60,4 @@ if [ "x${STRICT}" == "xtrue" ] && [ -d "${COMPONENT_DIRECTORY}/strict-patches" ]
     done
 fi
 
-bash -xe "${COMPONENT_DIRECTORY}/build.sh" "${INSTALL_DIRECTORY}"
+bash -xe "${COMPONENT_DIRECTORY}/build.sh" "${INSTALL_DIRECTORY}" "${GIT_TAG}"

--- a/build-scripts/components/README.md
+++ b/build-scripts/components/README.md
@@ -13,9 +13,9 @@ build-scripts/
         $component_name/
             repository              <-- git repository to clone
             version.sh              <-- prints the repository tag or commit to checkout
-            build.sh                <-- runs as `build.sh $output`
+            build.sh                <-- runs as `build.sh $output $version`
                                         first argument is the output directory where
-                                        binaries should be placed.
+                                        binaries should be placed, second is the component version
             patches/
                 ...                 <-- list of patches to apply after checkout (for stable versions)
             pre-patches/

--- a/build-scripts/components/cni/build.sh
+++ b/build-scripts/components/cni/build.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
 
+VERSION="${2}"
+
 INSTALL="${1}/opt/cni/bin"
 mkdir -p "${INSTALL}"
 
-./build_linux.sh
+# these would very tedious to apply with a patch
+go get github.com/docker/docker/pkg/reexec
+go mod vendor
+sed -i 's/^package main/package plugin_main/' plugins/*/*/*.go
+sed -i 's/^func main()/func Main()/' plugins/*/*/*.go
 
-cp bin/* "${INSTALL}/"
+export CGO_ENABLED=0
+
+go build -o cni -ldflags "-s -w -extldflags -static -X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=${VERSION}" ./cni.go
+
+cp cni "${INSTALL}/"
+for plugin in dhcp host-local static bridge host-device ipvlan loopback macvlan ptp vlan bandwidth flannel firewall portmap sbr tuning vrf; do
+  ln -f -s ./cni "${INSTALL}/${plugin}"
+done

--- a/build-scripts/components/cni/patches/0001-single-entrypoint-for-cni-tools.patch
+++ b/build-scripts/components/cni/patches/0001-single-entrypoint-for-cni-tools.patch
@@ -1,0 +1,74 @@
+From 91f16e8232437292eab8308250ca5d73ea9c4753 Mon Sep 17 00:00:00 2001
+From: Angelos Kolaitis <neoaggelos@gmail.com>
+Date: Fri, 22 Jul 2022 18:41:36 +0300
+Subject: [PATCH] single entrypoint for cni tools
+
+---
+ cni.go | 56 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 56 insertions(+)
+ create mode 100644 cni.go
+
+diff --git a/cni.go b/cni.go
+new file mode 100644
+index 0000000..93828f9
+--- /dev/null
++++ b/cni.go
+@@ -0,0 +1,56 @@
++package main
++
++import (
++	"os"
++	"path/filepath"
++
++	"github.com/docker/docker/pkg/reexec"
++
++	ipam_dhcp "github.com/containernetworking/plugins/plugins/ipam/dhcp"
++	ipam_host_local "github.com/containernetworking/plugins/plugins/ipam/host-local"
++	ipam_static "github.com/containernetworking/plugins/plugins/ipam/static"
++
++	main_bridge "github.com/containernetworking/plugins/plugins/main/bridge"
++	main_host_device "github.com/containernetworking/plugins/plugins/main/host-device"
++	main_ipvlan "github.com/containernetworking/plugins/plugins/main/ipvlan"
++	main_loopback "github.com/containernetworking/plugins/plugins/main/loopback"
++	main_macvlan "github.com/containernetworking/plugins/plugins/main/macvlan"
++	main_ptp "github.com/containernetworking/plugins/plugins/main/ptp"
++	main_vlan "github.com/containernetworking/plugins/plugins/main/vlan"
++
++	meta_bandwidth "github.com/containernetworking/plugins/plugins/meta/bandwidth"
++	meta_flannel "github.com/containernetworking/plugins/plugins/meta/flannel"
++	meta_firewall "github.com/containernetworking/plugins/plugins/meta/firewall"
++	meta_portmap "github.com/containernetworking/plugins/plugins/meta/portmap"
++	meta_sbr "github.com/containernetworking/plugins/plugins/meta/sbr"
++	meta_tuning "github.com/containernetworking/plugins/plugins/meta/tuning"
++	meta_vrf "github.com/containernetworking/plugins/plugins/meta/vrf"
++)
++
++func main() {
++	os.Args[0] = filepath.Base(os.Args[0])
++	if reexec.Init() {
++		return
++	}
++	panic("invalid entrypoint name")
++}
++
++func init() {
++	reexec.Register("dhcp", ipam_dhcp.Main)
++	reexec.Register("host-local", ipam_host_local.Main)
++	reexec.Register("static", ipam_static.Main)
++	reexec.Register("bridge", main_bridge.Main)
++	reexec.Register("host-device", main_host_device.Main)
++	reexec.Register("ipvlan", main_ipvlan.Main)
++	reexec.Register("loopback", main_loopback.Main)
++	reexec.Register("macvlan", main_macvlan.Main)
++	reexec.Register("ptp", main_ptp.Main)
++	reexec.Register("vlan", main_vlan.Main)
++	reexec.Register("bandwidth", meta_bandwidth.Main)
++	reexec.Register("flannel", meta_flannel.Main)
++	reexec.Register("firewall", meta_firewall.Main)
++	reexec.Register("portmap", meta_portmap.Main)
++	reexec.Register("sbr", meta_sbr.Main)
++	reexec.Register("tuning", meta_tuning.Main)
++	reexec.Register("vrf", meta_vrf.Main)
++}
+--
+2.25.1

--- a/build-scripts/components/helm/build.sh
+++ b/build-scripts/components/helm/build.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+VERSION="${2}"
+
 INSTALL="${1}"
 mkdir -p "${INSTALL}/bin"
 
-make
+make VERSION="${VERSION}"
 cp bin/helm "${INSTALL}/bin/helm"
 
 ./bin/helm completion bash \

--- a/build-scripts/components/kubernetes/build.sh
+++ b/build-scripts/components/kubernetes/build.sh
@@ -2,8 +2,8 @@
 
 INSTALL="${1}"
 
-for app in kubelite kubectl; do
-  make WHAT="cmd/${app}"
+for app in kubectl kubelite; do
+  make WHAT="cmd/${app}" KUBE_STATIC_OVERRIDES=kubelite
   cp _output/bin/"${app}" "${INSTALL}/${app}"
 done
 

--- a/build-scripts/components/migrator/build.sh
+++ b/build-scripts/components/migrator/build.sh
@@ -3,6 +3,8 @@
 INSTALL="${1}/bin"
 mkdir -p "${INSTALL}"
 
+export CGO_ENABLED=0
+
 go build -ldflags "-s -w" -o migrator ./main.go
 
 cp migrator "${INSTALL}/migrator"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -315,33 +315,8 @@ parts:
 
   microk8s-addons:
     plugin: nil
-    build-attributes: [no-patchelf]
-    source: build-scripts/
-    override-build: |
-      set -eux
-
-      . ./addon-repositories.sh
-
-      if [ -d "${SNAPCRAFT_PART_INSTALL}" ]; then
-        rm -rf "${SNAPCRAFT_PART_INSTALL}/*"
-      fi
-      if [ -d addons ]; then
-        rm -rf addons
-      fi
-
-      IFS=';'
-      echo "${ADDONS_REPOS}" | while read line; do
-        if [ -z "${line}" ];
-          then continue
-        fi
-        name="$(echo ${line} | cut -f1 -d',')"
-        repository="$(echo ${line} | cut -f2 -d',')"
-        reference="$(echo ${line} | cut -f3 -d',')"
-        git clone "${repository}" -b "${reference}" "addons/${name}"
-      done
-      echo "${ADDONS_REPOS_ENABLED}" > addons/.auto-add
-
-      cp -r "addons" "${SNAPCRAFT_PART_INSTALL}/addons"
+    source: build-scripts/addons
+    override-build: ./repositories.sh "${SNAPCRAFT_PART_INSTALL}"
 
   microk8s-scripts:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: microk8s
-adopt-info: kubernetes
+adopt-info: kubernetes-version
 summary: Kubernetes for workstations and appliances
 description: |-
   MicroK8s is a small, fast, secure, single node Kubernetes that installs on
@@ -148,10 +148,10 @@ parts:
 
   raft:
     after: [build-deps]
-    source: build-scripts/
+    source: build-scripts/components/raft
     build-attributes: [no-patchelf]
     plugin: nil
-    override-build: ./build-component.sh raft
+    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh raft
     stage-packages:
       - libuv1
     stage:
@@ -160,69 +160,72 @@ parts:
 
   sqlite:
     after: [build-deps]
-    source: build-scripts/
+    source: build-scripts/components/sqlite
     build-attributes: [no-patchelf]
     plugin: nil
-    override-build: ./build-component.sh sqlite
+    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh sqlite
 
   dqlite:
     after: [sqlite, raft]
-    source: build-scripts/
+    source: build-scripts/components/dqlite
     build-attributes: [no-patchelf]
     plugin: nil
-    override-build: ./build-component.sh dqlite
+    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh dqlite
 
   dqlite-client:
     after: [dqlite]
     plugin: nil
-    source: build-scripts/
-    override-build: ./build-component.sh dqlite-client
+    source: build-scripts/components/dqlite-client
+    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh dqlite-client
 
   k8s-dqlite:
     after: [dqlite]
-    source: build-scripts/
+    source: build-scripts/components/k8s-dqlite
     plugin: nil
-    override-build: ./build-component.sh k8s-dqlite
+    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh k8s-dqlite
 
   etcd:
     after: [build-deps]
     plugin: nil
-    source: build-scripts/
-    override-build: ./build-component.sh etcd
+    source: build-scripts/components/etcd
+    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh etcd
 
   traefik:
     after: [build-deps]
     plugin: nil
-    source: build-scripts/
-    override-build: ./build-component.sh traefik
+    source: build-scripts/components/traefik
+    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh traefik
     build-attributes: [no-patchelf]
 
   cni:
     after: [build-deps]
     plugin: nil
-    source: build-scripts/
-    override-build: ./build-component.sh cni
+    source: build-scripts/components/cni
+    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh cni
 
   flanneld:
     after: [build-deps]
     plugin: nil
-    source: build-scripts/
-    override-build: ./build-component.sh flanneld
+    source: build-scripts/components/flanneld
+    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh flanneld
 
   kubernetes:
     after: [build-deps]
     plugin: nil
     build-attributes: [no-patchelf]
-    source: build-scripts/
-    override-build: |
-      ./build-component.sh kubernetes
-      snapcraftctl set-version "$(components/kubernetes/version.sh)"
+    source: build-scripts/components/kubernetes
+    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh kubernetes
+
+  kubernetes-version:
+    plugin: nil
+    source: build-scripts/components/kubernetes
+    override-build: snapcraftctl set-version "$(./version.sh)"
 
   helm:
     after: [build-deps]
     plugin: nil
-    source: build-scripts/
-    override-build: ./build-component.sh helm
+    source: build-scripts/components/helm
+    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh helm
 
   libmnl:
     after: [build-deps]
@@ -246,14 +249,14 @@ parts:
   migrator:
     after: [build-deps]
     plugin: nil
-    source: build-scripts/
-    override-build: ./build-component.sh migrator
+    source: build-scripts/components/migrator
+    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh migrator
 
   containerd:
     after: [runc]
     plugin: nil
-    source: build-scripts/
-    override-build: ./build-component.sh containerd
+    source: build-scripts/components/containerd
+    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh containerd
     build-attributes: [no-patchelf]
     stage-packages:
       - libnss-myhostname
@@ -270,9 +273,9 @@ parts:
 
   runc:
     after: [iptables, build-deps]
-    source: build-scripts/
+    source: build-scripts/components/runc
     plugin: nil
-    override-build: ./build-component.sh runc
+    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh runc
 
   bash-utils:
     plugin: nil
@@ -307,8 +310,8 @@ parts:
     after: [build-deps]
     build-attributes: [no-patchelf]
     plugin: nil
-    source: build-scripts/
-    override-build: ./build-component.sh cluster-agent
+    source: build-scripts/components/cluster-agent
+    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh cluster-agent
 
   microk8s-addons:
     plugin: nil
@@ -387,8 +390,8 @@ parts:
   microk8s-completion:
     after: [build-deps]
     plugin: nil
-    source: build-scripts/
-    override-build: ./build-component.sh microk8s-completion
+    source: build-scripts/components/microk8s-completion
+    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh microk8s-completion
 
   python-requirements:
     plugin: python

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -273,6 +273,7 @@ parts:
   runc:
     after: [iptables, build-deps]
     source: build-scripts/components/runc
+    build-attributes: [no-patchelf]
     plugin: nil
     override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh runc
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -212,7 +212,6 @@ parts:
   kubernetes:
     after: [build-deps]
     plugin: nil
-    build-attributes: [no-patchelf]
     source: build-scripts/components/kubernetes
     override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh kubernetes
 


### PR DESCRIPTION
### Summary

Follow up PR for #3324 

### Changes

- Move logic of initializing addon repositories out of snapcraft.yaml
- Specify the build directory for each component, which prevents rebuilding all components when a single one is changed
- Build kubelite with CGO_ENABLED=0
- Build go-migrator with CGO_ENABLED=0
- Move `snapcraftctl set-version` in a separate build step for simplicity
- Ensure runc (which requires CGO) has `build-attributes: [no-patchelf]` set
- Remove `build-attributes: [no-patchelf]` from parts that do not need it (microk8s-addons, kubernetes)
- Build the containernetwork plugins into a single binary, further reducing the installation size (cni tools reduced from 65MB to 8MB).