### PR TITLE
update flanneld to v0.15.1 and remove unused backends

### DIFF
--- a/build-scripts/components/flanneld/build.sh
+++ b/build-scripts/components/flanneld/build.sh
@@ -3,17 +3,9 @@
 INSTALL="${1}/opt/cni/bin"
 mkdir -p "${INSTALL}"
 
-# TODO(neoaggelos): update to a non-ancient version of flanneld that we can actually build
-FLANNELD_VERSION="v0.11.0"
-ARCH="${ARCH:-`dpkg --print-architecture`}"
-if [ "$ARCH" = "ppc64el" ]; then
-  ARCH="ppc64le"
-elif [ "$ARCH" = "armhf" ]; then
-  ARCH="arm"
-fi
-mkdir -p download
-cd download
-curl -LO https://github.com/coreos/flannel/releases/download/${FLANNELD_VERSION}/flannel-${FLANNELD_VERSION}-linux-${ARCH}.tar.gz
-tar xvzf flannel-*.tar.gz
+VERSION="${2}"
 
-cp flanneld "${INSTALL}/flanneld"
+export CGO_ENABLED=0
+go build -o dist/flanneld -ldflags "-s -w -X github.com/flannel-io/flannel/version.Version=${VERSION} -extldflags -static"
+
+cp dist/flanneld "${INSTALL}/flanneld"

--- a/build-scripts/components/flanneld/patches/0001-disable-udp-backend.patch
+++ b/build-scripts/components/flanneld/patches/0001-disable-udp-backend.patch
@@ -1,0 +1,25 @@
+From 1be61878980de11932c1efc7cf4652904dfc3515 Mon Sep 17 00:00:00 2001
+From: MicroK8s builder bot <microk8s-builder-bot@canonical.com>
+Date: Mon, 1 Aug 2022 18:31:03 +0300
+Subject: [PATCH] disable udp backend
+
+---
+ main.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/main.go b/main.go
+index 4fd8f7f..0b3cc1c 100644
+--- a/main.go
++++ b/main.go
+@@ -55,7 +55,7 @@ import (
+ 	_ "github.com/flannel-io/flannel/backend/ipip"
+ 	_ "github.com/flannel-io/flannel/backend/ipsec"
+ 	_ "github.com/flannel-io/flannel/backend/tencentvpc"
+-	_ "github.com/flannel-io/flannel/backend/udp"
++	// _ "github.com/flannel-io/flannel/backend/udp"
+ 	_ "github.com/flannel-io/flannel/backend/vxlan"
+ )
+ 
+-- 
+2.34.1
+

--- a/build-scripts/components/flanneld/version.sh
+++ b/build-scripts/components/flanneld/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v0.11.0"
+echo "v0.15.1"


### PR DESCRIPTION
### Summary

Update flannel to version 0.15.1 and build from source instead of pulling in binaries.

### Changes

- Build flannel from source
- Update flannel to version 0.15.1