### PR TITLE
Fix s390x build. gpu.yaml as it is not in our repo anymore

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -605,7 +605,6 @@ parts:
       if [ "${ARCH}" = "s390x" ]
       then
         rm actions/*.gpu.sh
-        rm actions/gpu.yaml
         rm actions/*.istio.sh
         rm actions/*.knative.sh
         rm actions/*.fluentd.sh


### PR DESCRIPTION
The gpu.yaml file was removed when we upgraded the gpu operator.

In s390x builds we are trying to delete this file and we are failing the build. This PR fixes this issue.