### PR TITLE
[Backport 1.23] Update hostpath-provisioner to 1.3.0

### DIFF
--- a/microk8s-resources/actions/storage.yaml
+++ b/microk8s-resources/actions/storage.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: microk8s-hostpath
       containers:
         - name: hostpath-provisioner
-          image: cdkbot/hostpath-provisioner:1.1.0
+          image: cdkbot/hostpath-provisioner:1.3.0
           env:
             - name: NODE_NAME
               valueFrom:


### PR DESCRIPTION
Backport https://github.com/canonical/microk8s-core-addons/pull/73 to 1.23