### PR TITLE
Cleanup stale references to removed services

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -693,7 +693,6 @@ get_container_shim_pids() {
 
 kill_all_container_shims() {
   run_with_sudo systemctl kill snap.microk8s.daemon-kubelite.service --signal=SIGKILL &>/dev/null || true
-  run_with_sudo systemctl kill snap.microk8s.daemon-kubelet.service --signal=SIGKILL &>/dev/null || true
   run_with_sudo systemctl kill snap.microk8s.daemon-containerd.service --signal=SIGKILL &>/dev/null || true
 }
 

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -226,12 +226,7 @@ restart_service() {
 
     if [ "$1" == "apiserver" ] || [ "$1" == "proxy" ] || [ "$1" == "kubelet" ] || [ "$1" == "scheduler" ] || [ "$1" == "controller-manager" ]
     then
-      if [ -e "${SNAP_DATA}/var/lock/lite.lock" ]
-      then
-        run_with_sudo preserve_env snapctl restart "microk8s.daemon-kubelite"
-      else
-        run_with_sudo preserve_env snapctl restart "microk8s.daemon-$1"
-      fi
+      run_with_sudo preserve_env snapctl restart "microk8s.daemon-kubelite"
     else
       run_with_sudo preserve_env snapctl restart "microk8s.daemon-$1"
     fi

--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -84,8 +84,7 @@ do
     #
     # Wait until the apiserver is up and is successfully responding to
     # namespace checks before we check for the registry configmap.
-    if snapctl services microk8s.daemon-apiserver | grep active &> /dev/null ||
-       snapctl services microk8s.daemon-kubelite | grep active &> /dev/null
+    if snapctl services microk8s.daemon-kubelite | grep active &> /dev/null
     then
       if [ $installed_registry_help -eq 0 ] &&
          "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" get namespace kube-public &> /dev/null

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -440,12 +440,6 @@ printf -- 'Inspecting services\n'
 svc_cluster_agent="microk8s.daemon-cluster-agent"
 svc_containerd="microk8s.daemon-containerd"
 svc_kubelite="microk8s.daemon-kubelite"
-svc_apiserver="microk8s.daemon-apiserver"
-svc_proxy="microk8s.daemon-proxy"
-svc_kubelet="microk8s.daemon-kubelet"
-svc_scheduler="microk8s.daemon-scheduler"
-svc_controller_manager="microk8s.daemon-controller-manager"
-svc_control_plane_kicker="microk8s.daemon-control-plane-kicker"
 svc_flanneld="microk8s.daemon-flanneld"
 svc_etcd="microk8s.daemon-etcd"
 svc_dqlite="microk8s.daemon-k8s-dqlite"
@@ -457,12 +451,6 @@ then
   svc_cluster_agent="snap.${svc_cluster_agent}"
   svc_containerd="snap.${svc_containerd}"
   svc_kubelite="snap.${svc_kubelite}"
-  svc_apiserver="snap.${svc_apiserver}"
-  svc_proxy="snap.${svc_proxy}"
-  svc_kubelet="snap.${svc_kubelet}"
-  svc_scheduler="snap.${svc_scheduler}"
-  svc_controller_manager="snap.${svc_controller_manager}"
-  svc_control_plane_kicker="snap.${svc_control_plane_kicker}"
   svc_flanneld="snap.${svc_flanneld}"
   svc_etcd="snap.${svc_etcd}"
   svc_dqlite="snap.${svc_dqlite}"
@@ -472,17 +460,7 @@ fi
 
 check_service $svc_cluster_agent
 check_service $svc_containerd
-if [ -e "${SNAP_DATA}/var/lock/lite.lock" ]
-then
-  check_service $svc_kubelite
-else
-  check_service $svc_apiserver
-  check_service $svc_proxy
-  check_service $svc_kubelet
-  check_service $svc_scheduler
-  check_service $svc_controller_manager
-  check_service $svc_control_plane_kicker
-fi
+check_service $svc_kubelite
 
 if ! [ -e "${SNAP_DATA}/var/lock/ha-cluster" ]
 then

--- a/scripts/wrappers/common/cluster/utils.py
+++ b/scripts/wrappers/common/cluster/utils.py
@@ -320,18 +320,12 @@ def service(operation, service_name):
     :param service_name: The service name
     :param operation: Operation to perform on the service
     """
-    if (
-        service_name == "apiserver"
-        or service_name == "proxy"
-        or service_name == "kubelet"
-        or service_name == "scheduler"
-        or service_name == "controller-manager"
-    ) and is_kubelite():
-        subprocess.check_call("snapctl {} microk8s.daemon-kubelite".format(operation).split())
+    if service_name in ["apiserver", "proxy", "kubelet", "scheduler", "controller-manager"]:
+        daemon = "microk8s.daemon-kubelite"
     else:
-        subprocess.check_call(
-            "snapctl {} microk8s.daemon-{}".format(operation, service_name).split()
-        )
+        daemon = "microk8s.daemon-{}".format(service_name)
+
+    subprocess.check_call(["snapctl", operation, daemon])
 
 
 def mark_no_cert_reissue():

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -545,12 +545,6 @@ then
   else
     snapctl start ${SNAP_NAME}.daemon-kubelite
   fi
-  snapctl stop ${SNAP_NAME}.daemon-apiserver
-  snapctl stop ${SNAP_NAME}.daemon-proxy
-  snapctl stop ${SNAP_NAME}.daemon-kubelet
-  snapctl stop ${SNAP_NAME}.daemon-controller-manager
-  snapctl stop ${SNAP_NAME}.daemon-scheduler
-  snapctl stop ${SNAP_NAME}.daemon-control-plane-kicker
 fi
 
 if ! [ -e ${SNAP_DATA}/args/kubelite ]
@@ -583,12 +577,7 @@ then
   cp ${SNAP}/default-args/k8s-dqlite ${SNAP_DATA}/args/k8s-dqlite
   cp ${SNAP}/default-args/k8s-dqlite-env ${SNAP_DATA}/args/k8s-dqlite-env
   need_api_restart=true
-  if [ -e ${SNAP_DATA}/var/lock/lite.lock ]
-  then
-    snapctl stop ${SNAP_NAME}.daemon-kubelite
-  else
-    snapctl stop ${SNAP_NAME}.daemon-apiserver
-  fi
+  snapctl stop ${SNAP_NAME}.daemon-kubelite
 
   refresh_opt_in_local_config etcd-servers unix://\${SNAP_DATA}/var/kubernetes/backend/kine.sock:12379 kube-apiserver
   $SNAP/bin/sed -i '/\-\-storage\-backend=dqlite/d' ${SNAP_DATA}/args/kube-apiserver

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -5,13 +5,7 @@ source $SNAP/actions/common/utils.sh
 
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH:/usr/bin:/usr/local/bin"
 
-if [ -e "${SNAP_DATA}/var/lock/lite.lock" ]
-then
-  snapctl stop ${SNAP_NAME}.daemon-kubelite 2>&1 || true
-else
-  snapctl stop ${SNAP_NAME}.daemon-kubelet 2>&1 || true
-fi
-snapctl stop ${SNAP_NAME}.daemon-docker 2>&1 || true
+snapctl stop ${SNAP_NAME}.daemon-kubelite 2>&1 || true
 
 # Sym link the host's /var/lib/kubelet to the Snap's.  This will be fixed with layouts when
 # this Snap is strictly confined.

--- a/upgrade-scripts/000-switch-to-calico/commit-master.sh
+++ b/upgrade-scripts/000-switch-to-calico/commit-master.sh
@@ -41,14 +41,7 @@ cp "$SNAP_DATA"/args/kube-proxy "$BACKUP_DIR/args"
 echo "Restarting kube proxy"
 refresh_opt_in_config "cluster-cidr" "10.1.0.0/16" kube-proxy
 
-if [ -e "$SNAP_DATA"/var/lock/lite.lock ]
-then
-  snapctl restart ${SNAP_NAME}.daemon-kubelite
-else
-  snapctl restart ${SNAP_NAME}.daemon-apiserver
-  snapctl restart ${SNAP_NAME}.daemon-kubelet
-  snapctl restart ${SNAP_NAME}.daemon-proxy
-fi
+snapctl restart ${SNAP_NAME}.daemon-kubelite
 
 set_service_not_expected_to_start flanneld
 snapctl stop ${SNAP_NAME}.daemon-flanneld

--- a/upgrade-scripts/000-switch-to-calico/commit-node.sh
+++ b/upgrade-scripts/000-switch-to-calico/commit-node.sh
@@ -41,13 +41,7 @@ cp "$SNAP_DATA"/args/kube-proxy "$BACKUP_DIR/args"
 echo "Restarting kube proxy"
 refresh_opt_in_config "cluster-cidr" "10.1.0.0/16" kube-proxy
 
-if [ -e "$SNAP_DATA"/var/lock/lite.lock ]
-then
-  snapctl restart ${SNAP_NAME}.daemon-kubelite
-else
-  snapctl restart ${SNAP_NAME}.daemon-kubelet
-  snapctl restart ${SNAP_NAME}.daemon-proxy
-fi
+snapctl restart ${SNAP_NAME}.daemon-kubelite
 
 set_service_not_expected_to_start flanneld
 snapctl stop ${SNAP_NAME}.daemon-flanneld

--- a/upgrade-scripts/000-switch-to-calico/rollback-master.sh
+++ b/upgrade-scripts/000-switch-to-calico/rollback-master.sh
@@ -33,14 +33,7 @@ if [ -e "$BACKUP_DIR/args/kube-apiserver" ]; then
   cp "$BACKUP_DIR"/args/kube-apiserver "$SNAP_DATA/args/"
 fi
 
-if [ -e "$SNAP_DATA"/var/lock/lite.lock ]
-then
-  snapctl restart ${SNAP_NAME}.daemon-kubelite
-else
-  snapctl restart ${SNAP_NAME}.daemon-apiserver
-  snapctl restart ${SNAP_NAME}.daemon-kubelet
-  snapctl restart ${SNAP_NAME}.daemon-proxy
-fi
+snapctl restart ${SNAP_NAME}.daemon-kubelite
 
 ${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30
 

--- a/upgrade-scripts/000-switch-to-calico/rollback-node.sh
+++ b/upgrade-scripts/000-switch-to-calico/rollback-node.sh
@@ -27,14 +27,7 @@ if [ -e "$BACKUP_DIR/args/kube-apiserver" ]; then
   cp "$BACKUP_DIR"/args/kube-apiserver "$SNAP_DATA/args/"
 fi
 
-if [ -e "$SNAP_DATA"/var/lock/lite.lock ]
-then
-  snapctl restart ${SNAP_NAME}.daemon-kubelite
-else
-  snapctl restart ${SNAP_NAME}.daemon-apiserver
-  snapctl restart ${SNAP_NAME}.daemon-kubelet
-  snapctl restart ${SNAP_NAME}.daemon-proxy
-fi
+snapctl restart ${SNAP_NAME}.daemon-kubelite
 
 echo "Restarting flannel"
 set_service_expected_to_start flanneld

--- a/upgrade-scripts/001-switch-to-dqlite/commit-master.sh
+++ b/upgrade-scripts/001-switch-to-dqlite/commit-master.sh
@@ -45,12 +45,7 @@ then
   init_cluster
 fi
 
-if [ -e "$SNAP_DATA"/var/lock/lite.lock ]
-then
-  snapctl restart ${SNAP_NAME}.daemon-kubelite
-else
-  snapctl restart ${SNAP_NAME}.daemon-apiserver
-fi
+snapctl restart ${SNAP_NAME}.daemon-kubelite
 snapctl restart ${SNAP_NAME}.daemon-k8s-dqlite
 
 run_etcd="$(is_service_expected_to_start etcd)"

--- a/upgrade-scripts/001-switch-to-dqlite/rollback-master.sh
+++ b/upgrade-scripts/001-switch-to-dqlite/rollback-master.sh
@@ -18,12 +18,7 @@ if [ -e "$BACKUP_DIR/args/kube-apiserver" ]; then
   cp "$BACKUP_DIR"/args/kube-apiserver "$SNAP_DATA/args/"
 fi
 
-if [ -e "$SNAP_DATA"/var/lock/lite.lock ]
-then
-  snapctl restart ${SNAP_NAME}.daemon-kubelite
-else
-  snapctl restart ${SNAP_NAME}.daemon-apiserver
-fi
+snapctl restart ${SNAP_NAME}.daemon-kubelite
 
 ${SNAP}/microk8s-start.wrapper
 ${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30

--- a/upgrade-scripts/001-switch-to-dqlite/rollback-node.sh
+++ b/upgrade-scripts/001-switch-to-dqlite/rollback-node.sh
@@ -16,15 +16,9 @@ fi
 echo "Restarting kube-apiserver"
 if [ -e "$BACKUP_DIR/args/kube-apiserver" ]; then
   cp "$BACKUP_DIR"/args/kube-apiserver "$SNAP_DATA/args/"
-  snapctl restart ${SNAP_NAME}.daemon-apiserver
 fi
 
-if [ -e "$SNAP_DATA"/var/lock/lite.lock ]
-then
-  snapctl restart ${SNAP_NAME}.daemon-kubelite
-else
-  snapctl restart ${SNAP_NAME}.daemon-apiserver
-fi
+snapctl restart ${SNAP_NAME}.daemon-kubelite
 
 ${SNAP}/microk8s-start.wrapper
 


### PR DESCRIPTION
### Summary

Cleanup legacy code for pre-Kubelite service names

The services are no longer used for a number of minor releases (kube control plane from 1.19, docker from 1.15), and snapctl is properly managing killing the services.