### PR TITLE
export LC_ALL and LANG to fix issues with Click

### DIFF
--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -6,6 +6,8 @@ export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 ARCH="$($SNAP/bin/uname -m)"
 export LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+export LC_ALL="${LC_ALL:-C.UTF-8}"
+export LANG="${LANG:-C.UTF-8}"
 
 source $SNAP/actions/common/utils.sh
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -4,6 +4,9 @@ set -eux
 
 source $SNAP/actions/common/utils.sh
 
+export LC_ALL="${LC_ALL:-C.UTF-8}"
+export LANG="${LANG:-C.UTF-8}"
+
 # Make sure either the install hook has run or we are refreshing an already existing snap as indicated
 # by the existence of certificates.
 if [ ! -f "${SNAP_DATA}/var/lock/installed.lock" ] && [ ! -f ${SNAP_DATA}/certs/csr.conf.template ]


### PR DESCRIPTION
### Summary

Fixes the following issue on Xenial:

```
Aug 04 14:11:24 test-xenial microk8s.daemon-apiserver-kicker[4291]: RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment.  Consult http://click.pocoo.org/python3/for mitigation steps.
Aug 04 14:11:24 test-xenial microk8s.daemon-apiserver-kicker[4291]: This system supports the C.UTF-8 locale which is recommended.
Aug 04 14:11:24 test-xenial microk8s.daemon-apiserver-kicker[4291]: You might be able to resolve your issue by exporting the
Aug 04 14:11:24 test-xenial microk8s.daemon-apiserver-kicker[4291]: following environment variables:
Aug 04 14:11:24 test-xenial microk8s.daemon-apiserver-kicker[4291]:     export LC_ALL=C.UTF-8
Aug 04 14:11:24 test-xenial microk8s.daemon-apiserver-kicker[4291]:     export LANG=C.UTF-8
```