### PR TITLE
fix cluster agent core dump

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -201,6 +201,7 @@ parts:
     after: [build-deps]
     plugin: nil
     source: build-scripts/components/cluster-agent
+    build-attributes: [no-patchelf]
     override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh cluster-agent
 
   microk8s-addons:


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->
May Fix #3376 
#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
This fixes the cluster-agent core dump when starting in snap.

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
Simply added `no-patchelf` build attribute on `cluster-agent` in `snapcraft.yaml`

#### Testing
<!-- Please explain how you tested your changes. -->
Rebuilt the snap and install.

``` console
Aug 07 14:12:18 norse systemd[1]: Started Service for snap application microk8s.daemon-cluster-agent.
Aug 07 14:12:20 norse microk8s.daemon-cluster-agent[371151]: 2022/08/07 14:12:20 Starting cluster agent on https://0.0.0.0:25000
```
Cluster agent started happily.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->
Can't think of anything.

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.


#### Notes
<!-- Please add any other information that you think may be relevant -->
