### PR TITLE
Do not create microk8s as a systemgroup

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -367,7 +367,7 @@ group=$(get_microk8s_group)
 # Try to create the snap_microk8s group. Do not fail the installation if something goes wrong
 if ! getent group ${group} >/dev/null 2>&1
 then
-  groupadd --system ${group} || true
+  groupadd ${group} || true
 fi
 
 if getent group ${group} >/dev/null 2>&1


### PR DESCRIPTION
#### Summary
We do not need to have microk8s as a system group.

Closes https://github.com/canonical/microk8s/issues/3373

#### Changes
Do not create microk8s as a system group in configure hook

#### Testing
Manual testing

#### Possible Regressions
None. System groups are just a convnetion.

