### PR TITLE
Handle brnaches that changed names for local repos

### DIFF
--- a/scripts/wrappers/addons.py
+++ b/scripts/wrappers/addons.py
@@ -11,7 +11,7 @@ import click
 import jsonschema
 import yaml
 
-from common.utils import get_current_arch, snap_common, get_group
+from common.utils import get_current_arch, snap_common, get_group, snap
 
 GIT = os.path.expandvars("$SNAP/git.wrapper")
 
@@ -211,10 +211,28 @@ def update(name: str):
         click.echo("Error: built-in repository '{}' cannot be updated".format(name), err=True)
         sys.exit(1)
 
-    commit_before_pull = git_current_commit(repo_dir)
-
     click.echo("Updating repository {}".format(name))
-    subprocess.check_call([GIT, "pull"], cwd=repo_dir)
+    remote_url = subprocess.check_output(
+        [GIT, "remote", "get-url", "origin"], cwd=repo_dir, stderr=subprocess.DEVNULL
+    ).decode()
+    if remote_url.startswith(snap()):
+        # This is a repository that we have in the snap.
+        # If the branch name we follow has not changed a simple git pull is enough
+        # If the branch name changed we need to git repo add --force
+        followed_branch_name = subprocess.check_output(
+            [GIT, "rev-parse",  "--abbrev-ref", "HEAD"], cwd=repo_dir, stderr=subprocess.DEVNULL
+        ).decode()
+        snapped_branch_name = subprocess.check_output(
+            [GIT, "rev-parse",  "--abbrev-ref", "HEAD"], cwd=remote_url, stderr=subprocess.DEVNULL
+        ).decode()
+        if followed_branch_name != snapped_branch_name:
+            add(name, remote_url, None, True)
+        else:
+            commit_before_pull = git_current_commit(repo_dir)
+            subprocess.check_call([GIT, "pull"], cwd=repo_dir)
+    else:
+        commit_before_pull = git_current_commit(repo_dir)
+        subprocess.check_call([GIT, "pull"], cwd=repo_dir)
 
     try:
         validate_addons_repo(repo_dir)

--- a/scripts/wrappers/addons.py
+++ b/scripts/wrappers/addons.py
@@ -214,8 +214,8 @@ def update(name: str):
     click.echo("Updating repository {}".format(name))
     remote_url = subprocess.check_output(
         [GIT, "remote", "get-url", "origin"], cwd=repo_dir, stderr=subprocess.DEVNULL
-    ).decode()
-    if remote_url.startswith(snap()):
+    ).decode().strip()
+    if remote_url.startswith(str(snap().parent)):
         # This is a repository that we have in the snap.
         # If the branch name we follow has not changed a simple git pull is enough
         # If the branch name changed we need to git repo add --force
@@ -226,7 +226,9 @@ def update(name: str):
             [GIT, "rev-parse", "--abbrev-ref", "HEAD"], cwd=remote_url, stderr=subprocess.DEVNULL
         ).decode()
         if followed_branch_name != snapped_branch_name:
-            add(name, remote_url, None, True)
+            shutil.rmtree(repo_dir)
+            subprocess.check_call([GIT, "clone", remote_url, repo_dir])
+            subprocess.check_call(["chgrp", get_group(), "-R", repo_dir])
         else:
             commit_before_pull = git_current_commit(repo_dir)
             subprocess.check_call([GIT, "pull"], cwd=repo_dir)

--- a/scripts/wrappers/addons.py
+++ b/scripts/wrappers/addons.py
@@ -220,10 +220,10 @@ def update(name: str):
         # If the branch name we follow has not changed a simple git pull is enough
         # If the branch name changed we need to git repo add --force
         followed_branch_name = subprocess.check_output(
-            [GIT, "rev-parse",  "--abbrev-ref", "HEAD"], cwd=repo_dir, stderr=subprocess.DEVNULL
+            [GIT, "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo_dir, stderr=subprocess.DEVNULL
         ).decode()
         snapped_branch_name = subprocess.check_output(
-            [GIT, "rev-parse",  "--abbrev-ref", "HEAD"], cwd=remote_url, stderr=subprocess.DEVNULL
+            [GIT, "rev-parse", "--abbrev-ref", "HEAD"], cwd=remote_url, stderr=subprocess.DEVNULL
         ).decode()
         if followed_branch_name != snapped_branch_name:
             add(name, remote_url, None, True)

--- a/scripts/wrappers/addons.py
+++ b/scripts/wrappers/addons.py
@@ -169,7 +169,7 @@ def pull_and_validate(name: str, repo_dir: Path):
         sys.exit(1)
 
 
-def clone_and_validate(repo_dir: Path, remote_url:str):
+def clone_and_validate(repo_dir: Path, remote_url: str):
     if repo_dir.exists():
         shutil.rmtree(repo_dir)
     subprocess.check_call([GIT, "clone", remote_url, repo_dir])

--- a/scripts/wrappers/addons.py
+++ b/scripts/wrappers/addons.py
@@ -169,7 +169,7 @@ def pull_and_validate(name: str, repo_dir: Path):
         sys.exit(1)
 
 
-def clone_and_validate(repo_dir: Path, remote_url: str):
+def clone_and_validate(remote_url: str, repo_dir: Path):
     if repo_dir.exists():
         shutil.rmtree(repo_dir)
     subprocess.check_call([GIT, "clone", remote_url, repo_dir])


### PR DESCRIPTION
#### Summary
The core and community addons repositories are packaged inside the $SNAP. When these repos are added they are git cloned under $SNAP_COMMON following the branch the repo has in the $SNAP. The branch of the repo in the $SNAP may change as we ship new releases ie, main, 1.24, 1.25 etc. This change will cause the `git pull` performed in the `microk8s addons repo update` to fail because the branch name we follow disappeared. In this case we need to re-add the repository. 

Fixes: https://github.com/canonical/microk8s/issues/3392

#### Changes
Update the `microk8s addons repo update` command to be able to detect if the name of the branch a repository followed has changed.

#### Testing
To reproduce:
```
sudo snap install microk8s --channel=latest/edge --classic
sudo snap refresh microk8s --channel=1.24/stable
sudo microk8s addons repo update core
```

#### Possible Regressions
Any changes the user had done in the repo will be overwritten if the repository is re-added.
