### PR TITLE
Clean Kubernetes version reported by kubectl and kubelet

### DIFF
--- a/build-scripts/build-component.sh
+++ b/build-scripts/build-component.sh
@@ -41,6 +41,11 @@ fi
 cd "${COMPONENT_BUILD_DIRECTORY}"
 git config user.name "MicroK8s builder bot"
 git config user.email "microk8s-builder-bot@canonical.com"
+
+if [ -e "${COMPONENT_DIRECTORY}/pre-patch.sh" ]; then
+  bash -xe "${COMPONENT_DIRECTORY}/pre-patch.sh"
+fi
+
 if echo "${GIT_TAG}" | grep -e rc -e alpha -e beta; then
   if [ -d "${COMPONENT_DIRECTORY}/pre-patches" ]; then
     for patch in "${COMPONENT_DIRECTORY}"/pre-patches/*; do

--- a/build-scripts/components/README.md
+++ b/build-scripts/components/README.md
@@ -7,8 +7,10 @@ The directory structure looks like this:
 ```
 build-scripts/
     build-component.sh              <-- runs as `build-component.sh $component_name`
-                                        checks out the git repository, applies the specified
-                                        patches, then runs the `build.sh` step for the component
+                                        - checks out the git repository
+                                        - runs the `pre-patch.sh` script (if any)
+                                        - applies the patches (if any)
+                                        - runs the `build.sh` script to build the component
     component/
         $component_name/
             repository              <-- git repository to clone
@@ -16,6 +18,8 @@ build-scripts/
             build.sh                <-- runs as `build.sh $output $version`
                                         first argument is the output directory where
                                         binaries should be placed, second is the component version
+            pre-patch.sh            <-- runs as `pre-patch.sh`. takes any action needed before applying
+                                        the component patches
             patches/
                 ...                 <-- list of patches to apply after checkout (for stable versions)
             pre-patches/

--- a/build-scripts/components/kubernetes/build.sh
+++ b/build-scripts/components/kubernetes/build.sh
@@ -2,6 +2,8 @@
 
 INSTALL="${1}"
 
+export KUBE_GIT_VERSION_FILE="${PWD}/.version.sh"
+
 for app in kubectl kubelite; do
   make WHAT="cmd/${app}" KUBE_STATIC_OVERRIDES=kubelite
   cp _output/bin/"${app}" "${INSTALL}/${app}"

--- a/build-scripts/components/kubernetes/pre-patch.sh
+++ b/build-scripts/components/kubernetes/pre-patch.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -x
+
+# Ensure clean Kubernetes version
+KUBE_ROOT="${PWD}"
+source "${KUBE_ROOT}/hack/lib/version.sh"
+kube::version::get_version_vars
+kube::version::save_version_vars "${PWD}/.version.sh"


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

Ensure that kubectl and kubelet report a clean Kubernetes version.

Before:

```
$ microk8s kubectl get node
NAME   STATUS   ROLES    AGE     VERSION
node   Ready    <none>   5d18h   v1.24.3-2+63243a96d1c393
```

After:

```
$ microk8s kubectl get node
NAME   STATUS   ROLES    AGE     VERSION
node   Ready    <none>   5d18h   v1.24.3
```

Optionally, we could add `+uk8s1` suffix, but we have decided against it at the moment.

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

- Add an optional `pre-patch.sh` step when building components.
- Use kubernetes machinery to save the source version prior to the kubelite patches.

#### Testing
<!-- Please explain how you tested your changes. -->

Verify output of `kubectl version` and `kubectl get node` (contains version reported by the kubelet)

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

There should not be any. This ensures the Kubernetes version is a valid semantic version string.
