### PR TITLE
Clear old posibly failed state of strict deployments

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -22,6 +22,10 @@ then
   echo "Checking snap interfaces..."
 
   check_snap_interfaces # Check for interfaces but do not start until this script has run.
+else
+  # In classic we do not make use of the status flag. Here we clean any "blocked" message that may have
+  # come from a failed strict deployment
+  snapctl set-health okay
 fi
 
 need_api_restart=false

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 [testenv:lint]
 commands =
     flake8 --max-line-length=120 --ignore=C901,N801,N802,N803,N806,N816,W503,E203
-    codespell --ignore-words-list="aks" --quiet-level=2 --skip="*.patch,*.spec,.tox_env,.git"
+    codespell --ignore-words-list="aks" --quiet-level=2 --skip="*.patch,*.spec,.tox_env,.git,*.nsi"
     black --diff --check --exclude "/(\.eggs|\.git|\.tox|\.venv|\.build|dist|charmhelpers|mod)/" .
 
 [testenv:scripts]


### PR DESCRIPTION
#### Summary
In classic we do not set any state, so if you had a strict deployment and you did not connect all interfaces the message you get is "blocked: please connect some interfaces". This message persists removals and re-installations of the snap. In this PR the classic snap sets the status message so it cleans any old one.
