### PR TITLE
Run CI tests in parallel

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -1,4 +1,4 @@
-name: Build MicroK8s snap on PR and push to master
+name: Build and test MicroK8s snap
 
 on:
   push:

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -36,35 +36,114 @@ jobs:
         with:
           name: microk8s.snap
           path: microk8s.snap
+
+  test-upgrade:
+    name: Upgrade path test
+    runs-on: ubuntu-20.04
+    needs: build
+
+    steps:
+      - name: Checking out repo
+        uses: actions/checkout@v3.0.2
       - name: Install test dependencies
         run: |
           set -x
-          sudo apt-get install python3-setuptools 
+          sudo apt-get install python3-setuptools
           sudo pip3 install --upgrade pip
           sudo pip3 install -U pytest sh
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
+      - name: Fetch snap
+        uses: actions/download-artifact@v3.0.0
+        with:
+          name: microk8s.snap
+          path: build
       - name: Running upgrade path test
         run: |
+          sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade-path.py
+
+  test-addons-core:
+    name: Test core addons
+    runs-on: ubuntu-20.04
+    needs: build
+
+    steps:
+      - name: Checking out repo
+        uses: actions/checkout@v3.0.2
+      - name: Install test dependencies
+        run: |
           set -x
-          sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade-path.py
-          sudo snap remove microk8s --purge
+          sudo apt-get install python3-setuptools
+          sudo pip3 install --upgrade pip
+          sudo pip3 install -U pytest sh
+          sudo apt-get -y install open-iscsi
+          sudo systemctl enable iscsid
+      - name: Fetch snap
+        uses: actions/download-artifact@v3.0.0
+        with:
+          name: microk8s.snap
+          path: build
       - name: Running addons tests
         run: |
           set -x
-          sudo snap install *.snap --classic --dangerous
+          sudo snap install build/microk8s.snap --classic --dangerous
           ./tests/smoke-test.sh
           export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"
-          (cd tests; pytest -s verify-branches.py)
           sudo -E bash -c "cd /var/snap/microk8s/common/addons/core/tests; pytest -s -ra test-addons.py"
+
+  test-addons-community:
+    name: Test community addons
+    runs-on: ubuntu-20.04
+    needs: build
+
+    steps:
+      - name: Checking out repo
+        uses: actions/checkout@v3.0.2
+      - name: Install test dependencies
+        run: |
+          set -x
+          sudo apt-get install python3-setuptools
+          sudo pip3 install --upgrade pip
+          sudo pip3 install -U pytest sh
+          sudo apt-get -y install open-iscsi
+          sudo systemctl enable iscsid
+      - name: Fetch snap
+        uses: actions/download-artifact@v3.0.0
+        with:
+          name: microk8s.snap
+          path: build
+      - name: Running addons tests
+        run: |
+          set -x
+          sudo snap install build/microk8s.snap --classic --dangerous
           sudo microk8s enable community
           sudo -E bash -c "cd /var/snap/microk8s/common/addons/community/tests; pytest -s -ra test-addons.py"
-          sudo snap remove microk8s --purge
+
+  test-addons-core-upgrade:
+    name: Test core addons upgrade
+    runs-on: ubuntu-20.04
+    needs: build
+
+    steps:
+      - name: Checking out repo
+        uses: actions/checkout@v3.0.2
+      - name: Install test dependencies
+        run: |
+          set -x
+          sudo apt-get install python3-setuptools
+          sudo pip3 install --upgrade pip
+          sudo pip3 install -U pytest sh
+          sudo apt-get -y install open-iscsi
+          sudo systemctl enable iscsid
+      - name: Fetch snap
+        uses: actions/download-artifact@v3.0.0
+        with:
+          name: microk8s.snap
+          path: build
       - name: Running upgrade tests
         run: |
           set -x
-          sudo snap install *.snap --classic --dangerous
+          sudo snap install build/microk8s.snap --classic --dangerous
           export UNDER_TIME_PRESSURE="True"
-          sudo -E bash -c "cd /var/snap/microk8s/common/addons/core/ ; UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade.py"
-          sudo snap remove microk8s --purge
+          sudo -E bash -c "cd /var/snap/microk8s/common/addons/core/ ; UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade.py"

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,7 +1,6 @@
 name: Lint Code
 
 on:
-  - push
   - pull_request
 
 jobs:

--- a/.github/workflows/check-unit-tests.yml
+++ b/.github/workflows/check-unit-tests.yml
@@ -1,7 +1,6 @@
 name: Unit Tests
 
 on:
-  - push
   - pull_request
 
 jobs:

--- a/.github/workflows/check-unit-tests.yml
+++ b/.github/workflows/check-unit-tests.yml
@@ -17,8 +17,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install tox --fix-missing
+          sudo pip3 install -U pytest sh
       - name: Check Units
         run: |
           tox -e scripts
           tox -e wrappers
           tox -e cluster
+      - name: Verify branches
+        run: |
+          pytest -s ./tests/verify-branches.py


### PR DESCRIPTION
### Summary

Update GitHub actions workflow for building and testing the MicroK8s snap.

The build step and each test runs in a separate job, so that it is easier to see which jobs are failing. Further, the tests are now running in parallel (instead of running sequentially and manually removing-reinstalling the snap multiple times), reducing the total CI time from sum(T_tests) to max(T_tests).

To be merged after https://github.com/canonical/microk8s/pull/3406, since there will be conflicts