### PR TITLE
Improve check for cgroup2 availability

### DIFF
--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -53,7 +53,7 @@ RUNTIME="runc"
 RUNTIME_TYPE="io.containerd.runc.v1"
 SNAPSHOTTER=$(snapshotter)
 
-if mount | grep -q 'cgroup2 on /sys/fs/cgroup'; then
+if mount -t cgroup2 | grep -q 'type cgroup2'; then
   RUNTIME_TYPE="io.containerd.runc.v2"
 fi
 


### PR DESCRIPTION
The cgroup2 mount may sometimes appear as:

```
$ mount -t cgroup2
none on /sys/fs/cgroup type cgroup2 (rw,nosuid,nodev,noexec,relatime)
```
