### PR TITLE
Ignore --hostname-override from kubelet arguments when joining

### DIFF
--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -559,6 +559,16 @@ def update_kubelet_node_ip(args_string, hostname_override):
         set_arg("--node-ip", hostname_override, "kubelet")
 
 
+def update_kubelet_hostname_override(args_string):
+    """
+    Remove the kubelet --hostname-override argument if it was set on the node that we join.
+
+    :param args_string: the kubelet arguments
+    """
+    if "--hostname-override" in args_string:
+        set_arg("--hostname-override", None, "kubelet")
+
+
 def replace_admin_token(token):
     """
     Replaces the admin token in the known tokens
@@ -816,6 +826,7 @@ def join_dqlite_worker_node(info, master_ip, master_port, token):
 
     store_base_kubelet_args(info["kubelet_args"])
     update_kubelet_node_ip(info["kubelet_args"], hostname_override)
+    update_kubelet_hostname_override(info["kubelet_args"])
     update_cert_auth_kubeproxy(token, info["ca"], master_ip, master_port, hostname_override)
     update_cert_auth_kubelet(token, info["ca"], master_ip, master_port)
 


### PR DESCRIPTION
Closes #3431 

Needs backporting to all supported MicroK8s tracks.