### PR TITLE
[Backport 1.22] Ignore --hostname-override kubelet flag when joining a cluster

### DIFF
--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -951,6 +951,16 @@ def update_kubelet_node_ip(args_string, hostname_override):
         set_arg("--node-ip", hostname_override, "kubelet")
 
 
+def update_kubelet_hostname_override(args_string):
+    """
+    Remove the kubelet --hostname-override argument if it was set on the node that we join.
+
+    :param args_string: the kubelet arguments
+    """
+    if "--hostname-override" in args_string:
+        set_arg("--hostname-override", None, "kubelet")
+
+
 def join_dqlite(connection_parts, verify=False):
     """
     Configure node to join a dqlite cluster.
@@ -1008,6 +1018,7 @@ def join_dqlite(connection_parts, verify=False):
     create_admin_kubeconfig(info["ca"], info["admin_token"])
     store_base_kubelet_args(info["kubelet_args"])
     update_kubelet_node_ip(info["kubelet_args"], hostname_override)
+    update_kubelet_hostname_override(info["kubelet_args"])
     store_callback_token(info["callback_token"])
 
     update_dqlite(info["cluster_cert"], info["cluster_key"], info["voters"], hostname_override)
@@ -1030,6 +1041,7 @@ def join_etcd(connection_parts, verify=True):
     callback_token = generate_callback_token()
     info = get_connection_info(master_ip, master_port, token, callback_token=callback_token)
     store_base_kubelet_args(info["kubelet_args"])
+    update_kubelet_hostname_override(info["kubelet_args"])
     hostname_override = None
     if "hostname_override" in info:
         hostname_override = info["hostname_override"]


### PR DESCRIPTION
Backport #3434 and #3441 to 1.22 branch