### PR TITLE
Launcher for launch configurations handling only addons

### DIFF
--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -84,10 +84,12 @@ do
     # If no local-registry-hosting documentation has been installed,
     # install a help guide that points to the microk8s registry docs.
     #
-    # Wait until the apiserver is up and is successfully responding to
-    # namespace checks before we check for the registry configmap.
     if snapctl services microk8s.daemon-kubelite | grep active &> /dev/null
     then
+
+      # Wait until the apiserver is up and is successfully responding to
+      # namespace checks before we check for the registry configmap and/or
+      # apply the launch configuration.
       if [ $installed_registry_help -eq 0 ] &&
          "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" get namespace kube-public &> /dev/null
       then
@@ -95,8 +97,13 @@ do
         then
           use_manifest registry/registry-help apply
         fi
-
         installed_registry_help=1
+      fi
+
+      if [ -e $SNAP_COMMON/etc/launcher/configuration/config.yaml ] &&
+         $SNAP/usr/bin/python3 $SNAP/scripts/launcher.py $SNAP_COMMON/etc/launcher/configuration/config.yaml
+      then
+        mv $SNAP_COMMON/etc/launcher/configuration/config.yaml $SNAP_COMMON/etc/launcher/configuration/config.yaml.applied
       fi
     fi
 done

--- a/scripts/launcher.py
+++ b/scripts/launcher.py
@@ -39,14 +39,14 @@ properties:
 
 class Executor(ABC):
     @abstractmethod
-    def Enable(self, addon: str, args: list[str]):
+    def Enable(self, addon: str, args: list):
         """
         Enable an addon
         """
         pass
 
     @abstractmethod
-    def Disable(self, addon: str, args: list[str]):
+    def Disable(self, addon: str, args: list):
         """
         Disable an addon
         """
@@ -58,12 +58,12 @@ class EchoCommander(Executor):
     The class just prints out the commands to be executed. It is used for dry runs and debugging.
     """
 
-    def Enable(self, addon: str, args: list[str]):
-        args_str = "" if args is None else " ".join(args)
+    def Enable(self, addon: str, args: list):
+        args_str = " ".join(args)
         click.echo(f"microk8s enable {addon} {args_str}")
 
-    def Disable(self, addon: str, args: list[str]):
-        args_str = "" if args is None else " ".join(args)
+    def Disable(self, addon: str, args: list):
+        args_str = " ".join(args)
         click.echo(f"microk8s disable {addon} {args_str}")
 
 
@@ -77,23 +77,22 @@ class CliCommander(Executor):
         self.enable_cmd = os.path.expandvars("$SNAP/microk8s-enable.wrapper")
         self.disable_cmd = os.path.expandvars("$SNAP/microk8s-disable.wrapper")
 
-    def Enable(self, addon: str, args: list[str]):
-        args_str = "" if args is None else " ".join(args)
+    def Enable(self, addon: str, args: list):
+        args_str = " ".join(args)
         click.echo(f"microk8s enable {addon} {args_str}")
         command = [self.enable_cmd, addon]
-        if args:
-            command.append(args)
+        if len(args) > 0:
+            command = command + args
         output = check_output(command)
         click.echo(output)
 
-    def Disable(self, addon: str, args: list[str]):
-        args_str = "" if args is None else " ".join(args)
+    def Disable(self, addon: str, args: list):
+        args_str = " ".join(args)
         click.echo(f"microk8s enable {addon} {args_str}")
         command = [self.disable_cmd, addon]
-        if args:
-            command.append(args)
+        if len(args) > 0:
+            command = command + args
         output = check_output(command)
-        args_str = "" if args is None else " ".join(args)
         click.echo(output)
 
 
@@ -132,7 +131,7 @@ def launcher(configuration: str, dry):
         executor = CliCommander()
 
     for addon in cfg["addons"]:
-        args = None
+        args = []
         if "args" in addon.keys():
             args = addon["args"]
         if "status" in addon.keys() and addon["status"] == "disable":

--- a/scripts/launcher.py
+++ b/scripts/launcher.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+
+import click
+import yaml
+import os
+import sys
+
+from subprocess import check_output
+from jsonschema import validate
+from abc import ABC, abstractmethod
+
+
+# The schema of the configuration files we can handle
+schema = """
+type: object
+properties:
+    addons:
+        description: "List of addons"
+        type: array
+        items:
+            type: object
+            properties:
+                name:
+                    description: "Name of the addon"
+                    type: string
+                status:
+                    description: "Should the addon be enabled or disabled"
+                    enum:
+                    - enable
+                    - disable
+                args:
+                    description: "Arguments for the addon"
+                    type: array
+                    items:
+                        type: string
+            required: ["name"]
+"""
+
+
+class Executor(ABC):
+    @abstractmethod
+    def Enable(self, addon: str, args: list[str]):
+        """
+        Enable an addon
+        """
+        pass
+
+    @abstractmethod
+    def Disable(self, addon: str, args: list[str]):
+        """
+        Disable an addon
+        """
+        pass
+
+
+class EchoCommander(Executor):
+    """
+    The class just prints out the commands to be executed. It is used for dry runs and debugging.
+    """
+
+    def Enable(self, addon: str, args: list[str]):
+        args_str = "" if args is None else " ".join(args)
+        click.echo(f"microk8s enable {addon} {args_str}")
+
+    def Disable(self, addon: str, args: list[str]):
+        args_str = "" if args is None else " ".join(args)
+        click.echo(f"microk8s disable {addon} {args_str}")
+
+
+class CliCommander(Executor):
+    """
+    This Executor calls the microk8s wrappers to apply the configuration.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.enable_cmd = os.path.expandvars("$SNAP/microk8s-enable.wrapper")
+        self.disable_cmd = os.path.expandvars("$SNAP/microk8s-disable.wrapper")
+
+    def Enable(self, addon: str, args: list[str]):
+        args_str = "" if args is None else " ".join(args)
+        click.echo(f"microk8s enable {addon} {args_str}")
+        command = [self.enable_cmd, addon]
+        if args:
+            command.append(args)
+        output = check_output(command)
+        click.echo(output)
+
+    def Disable(self, addon: str, args: list[str]):
+        args_str = "" if args is None else " ".join(args)
+        click.echo(f"microk8s enable {addon} {args_str}")
+        command = [self.disable_cmd, addon]
+        if args:
+            command.append(args)
+        output = check_output(command)
+        args_str = "" if args is None else " ".join(args)
+        click.echo(output)
+
+
+@click.command("launcher")
+@click.argument("configuration")
+@click.option(
+    "--dry",
+    is_flag=True,
+    required=False,
+    default=False,
+    help="Do nothing, just print the commands to be executed. (default: false)",
+)
+def launcher(configuration: str, dry):
+    """
+    Setup MicroK8s based on the provided CONFIGURATION
+
+    CONFIGURATION is a yaml file
+    """
+
+    if not os.path.exists(configuration):
+        sys.stderr.write("Please provide a yaml configuration file.\n")
+        sys.exit(1)
+
+    with open(configuration, "r") as stream:
+        try:
+            cfg = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            sys.stderr.write(exc)
+            sys.stderr.write("Please provide a valid yaml configuration file.\n")
+            sys.exit(2)
+
+    validate(cfg, yaml.safe_load(schema))
+    if dry:
+        executor = EchoCommander()
+    else:
+        executor = CliCommander()
+
+    for addon in cfg["addons"]:
+        args = None
+        if "args" in addon.keys():
+            args = addon["args"]
+        if "status" in addon.keys() and addon["status"] == "disable":
+            executor.Disable(addon["name"], args)
+        else:
+            executor.Enable(addon["name"], args)
+
+
+if __name__ == "__main__":
+    launcher()

--- a/snap/hooks/connect-plug-configuration
+++ b/snap/hooks/connect-plug-configuration
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eux
+
+mkdir -p $SNAP_COMMON/etc/
+cp -R $SNAP/etc/launcher $SNAP_COMMON/etc/

--- a/snap/hooks/disconnect-plug-configuration
+++ b/snap/hooks/disconnect-plug-configuration
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux
+
+rm -rf $SNAP_COMMON/etc/launcher

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -807,3 +807,9 @@ hooks:
       - network
       - network-bind
       - network-control
+  connect-plug-configuration:
+    plugs:
+      - configuration
+  disconnect-plug-configuration:
+    plugs:
+      - configuration

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -186,7 +186,6 @@ parts:
       - net-tools
       - openssl
       - procps
-      - python3-jsonschema
       - sed
       - socat
       - squashfs-tools

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -613,6 +613,10 @@ plugs:
     interface: personal-files
     write:
       - $HOME/.config/helm
+  configuration:
+    interface: content
+    content: configuration
+    target: $SNAP/etc/launcher
 
 slots:
   microk8s:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -186,6 +186,7 @@ parts:
       - net-tools
       - openssl
       - procps
+      - python3-jsonschema
       - sed
       - socat
       - squashfs-tools

--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -455,7 +455,9 @@ class TestCluster(object):
             lock_files = vm.run("ls /var/snap/microk8s/current/var/lock/")
             assert "no-cert-reissue" in lock_files.decode()
 
-    @pytest.mark.skipif(get_arch() != "amd64", reason="Launch configuration test is only available in AMD64")
+    @pytest.mark.skipif(
+        get_arch() != "amd64", reason="Launch configuration test is only available in AMD64"
+    )
     def test_launch_configuration(self):
         """
         Test launch configurations by installing the demo snap and connecting the content interface
@@ -479,4 +481,3 @@ class TestCluster(object):
                 if attempt == 50:
                     raise
         vm.run("snap disconnect microk8s:configuration content-demo-microk8s:configuration")
-

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -1,0 +1,39 @@
+import os
+from unittest.mock import patch
+from click.testing import CliRunner
+from launcher import launcher as command
+
+
+class TestLauncher(object):
+    def setup_class(self):
+        dirname, filename = os.path.split(os.path.abspath(__file__))
+        self._invalid_yaml = os.path.join(dirname, "yamls/invalid-launcher.yaml")
+        self._valid_yaml = os.path.join(dirname, "yamls/valid-launcher.yaml")
+
+    def test_launcher(self):
+        """
+        Test that we can handle a valid configuration file
+        """
+        runner = CliRunner()
+        result = runner.invoke(command, [self._valid_yaml, "--dry"])
+        assert result.exit_code == 0
+        assert "enable dns" in result.output
+        assert "disable ingress" in result.output
+        assert "enable foo --arg-a=A --arg-b=B" in result.output
+
+    def test_launcher_invalid(self):
+        """
+        Test that we fail on an invalid configuration file
+        """
+        runner = CliRunner()
+        result = runner.invoke(command, [self._invalid_yaml, "--dry"])
+        assert result.exit_code == 1
+
+    @patch("launcher.check_output")
+    def test_cli_launcher(self, mock_check_output):
+        """
+        Test that we really call subprocess check_output
+        """
+        runner = CliRunner()
+        runner.invoke(command, [self._valid_yaml])
+        assert mock_check_output.call_count == 3

--- a/tests/unit/yamls/invalid-launcher.yaml
+++ b/tests/unit/yamls/invalid-launcher.yaml
@@ -1,0 +1,5 @@
+wrongsection:
+    - name: dns
+      status: enabled
+    - name: ingress
+      status: disabled

--- a/tests/unit/yamls/invalid-launcher.yaml
+++ b/tests/unit/yamls/invalid-launcher.yaml
@@ -1,5 +1,5 @@
 wrongsection:
-    - name: dns
-      status: enabled
-    - name: ingress
-      status: disabled
+  - name: dns
+    status: enabled
+  - name: ingress
+    status: disabled

--- a/tests/unit/yamls/valid-launcher.yaml
+++ b/tests/unit/yamls/valid-launcher.yaml
@@ -1,0 +1,10 @@
+addons:
+  - name: dns
+    status: enable
+  - name: ingress
+    status: disable
+  - name: foo
+    status: enable
+    args:
+      - "--arg-a=A"
+      - "--arg-b=B"

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ passenv =
     MK8S_*
 deps =
     black ==21.4b2
-    click==7.0
+    click==7.1.2
     flake8
     flake8-colors
     pep8-naming
@@ -26,6 +26,7 @@ commands =
 [testenv:scripts]
 setenv = PYTHONPATH={toxinidir}/scripts
 commands =
+    pytest -s tests/unit/test_launcher.py {posargs}
     pytest -s tests/unit/test_upgrade_calico_cni.py {posargs}
 
 [testenv:wrappers]

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ setenv = PYTHONPATH={toxinidir}/scripts/wrappers
 commands =
     pytest -s tests/unit/ \ 
         --ignore=tests/unit/test_upgrade_calico_cni.py \
+        --ignore=tests/unit/test_launcher.py \
         --ignore-glob=tests/unit/cluster/* {posargs}
 
 [testenv:cluster]


### PR DESCRIPTION
#### Summary
Allow for launch configurations in yaml

#### Changes
- A launcher python script that can handle configurations with a certain schema.
- Content interface.
- Unit and integration tests.

#### Testing
Unit tests: `tox -e scripts`
Integration tests: `sudo -E ./tests/test-distro.sh ubuntu:18.04 latest/strict latest/edge/MK-735`
