### PR TITLE
Do not fail install of credentials directory already exists

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -35,7 +35,7 @@ cp ${SNAP}/certs/csr.conf.template ${SNAP_DATA}/certs/csr.conf.template
 produce_certs
 rm -rf .srl
 
-mkdir ${SNAP_DATA}/credentials
+mkdir -p ${SNAP_DATA}/credentials
 ca_data=$(cat ${SNAP_DATA}/certs/ca.crt | ${SNAP}/usr/bin/base64 -w 0)
 
 # Create the known tokens


### PR DESCRIPTION
This might happen if Juju is installed, due to the content interface. Fixes https://github.com/canonical/microk8s/issues/3455

### Notes

- Backport to `strict` branch after merge

cc @mthaddon 