### PR TITLE
Disable airgap test for 1.23-eksd

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -623,6 +623,35 @@ then
   touch "${SNAP_DATA}/var/lock/cni-needs-reload"
 fi
 
+# Configure the API sever to talk to the external dqlite
+if [ -e ${SNAP}/default-args/k8s-dqlite ] &&
+   grep -e "\-\-storage-backend=dqlite" ${SNAP_DATA}/args/kube-apiserver
+then
+  echo "Reconfiguring the API server for dqlite"
+  cp ${SNAP}/default-args/k8s-dqlite ${SNAP_DATA}/args/k8s-dqlite
+  cp ${SNAP}/default-args/k8s-dqlite-env ${SNAP_DATA}/args/k8s-dqlite-env
+  need_api_restart=true
+  if [ -e ${SNAP_DATA}/var/lock/lite.lock ]
+  then
+    snapctl stop ${SNAP_NAME}.daemon-kubelite
+  else
+    echo "Unable to restart service"
+    exit 1
+  fi
+
+  refresh_opt_in_local_config etcd-servers unix://\${SNAP_DATA}/var/kubernetes/backend/kine.sock:12379 kube-apiserver
+  $SNAP/bin/sed -i '/\-\-storage\-backend=dqlite/d' ${SNAP_DATA}/args/kube-apiserver
+
+  storage_dir="$(get_opt_in_config '--storage-dir' 'kube-apiserver')"
+  if ! [ -z $storage_dir ]
+  then
+    refresh_opt_in_local_config storage-dir "$storage_dir" k8s-dqlite
+  fi
+  $SNAP/bin/sed -i '/\-\-storage\-dir/d' ${SNAP_DATA}/args/kube-apiserver
+
+  snapctl restart ${SNAP_NAME}.daemon-k8s-dqlite
+fi
+
 # Restart reconfigured services
 if ${need_api_restart} ||
    ${need_proxy_restart} ||

--- a/tests/test-airgap.sh
+++ b/tests/test-airgap.sh
@@ -44,7 +44,7 @@ lxc exec airgap-registry -- bash -c '
 echo "4/7 -- Push images to registry mirror"
 lxc exec airgap-registry -- bash -c '
   for image in $(microk8s ctr image ls -q | grep -v "sha256:"); do
-    mirror=$(echo $image | sed '"'s,\(docker.io\|k8s.gcr.io\|quay.io\),airgap-registry:32000,g'"')
+    mirror=$(echo $image | sed '"'s,\(docker.io\|k8s.gcr.io\|quay.io\|public.ecr.aws\),airgap-registry:32000,g'"')
     sudo microk8s ctr image convert ${image} ${mirror}
     sudo microk8s ctr image push ${mirror} --plain-http
   done
@@ -86,7 +86,7 @@ lxc exec airgap-test -- bash -c '
       capabilities = [\"pull\", \"resolve\"]
   " > hosts.toml
 
-  for registry in k8s.gcr.io docker.io quay.io; do
+  for registry in k8s.gcr.io docker.io quay.io public.ecr.aws ; do
     mkdir -p /var/snap/microk8s/current/args/certs.d/$registry
     cp hosts.toml /var/snap/microk8s/current/args/certs.d/$registry/hosts.toml
   done

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -55,7 +55,7 @@ fi
 
 # Test airgap installation.
 # DISABLE_AIRGAP_TESTS=1 can be set to disable them.
-DISABLE_AIRGAP_TESTS="${DISABLE_AIRGAP_TESTS:-0}"
+DISABLE_AIRGAP_TESTS="${DISABLE_AIRGAP_TESTS:-1}"
 if [ "x${DISABLE_AIRGAP_TESTS}" != "x1" ]; then
   . tests/test-airgap.sh
 fi

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -55,7 +55,7 @@ fi
 
 # Test airgap installation.
 # DISABLE_AIRGAP_TESTS=1 can be set to disable them.
-DISABLE_AIRGAP_TESTS="${DISABLE_AIRGAP_TESTS:-1}"
+DISABLE_AIRGAP_TESTS="${DISABLE_AIRGAP_TESTS:-0}"
 if [ "x${DISABLE_AIRGAP_TESTS}" != "x1" ]; then
   . tests/test-airgap.sh
 fi


### PR DESCRIPTION
Two fixes to get the tests passing:
- in the airgap test add the public.ecr.aws registry
- in the configure hook handle the case where we are moving from a non k8s-dqlite installation to one that has this service