### PR TITLE
(1.26+) update etcd to v3.5.5

### DIFF
--- a/build-scripts/components/etcd/build.sh
+++ b/build-scripts/components/etcd/build.sh
@@ -3,7 +3,7 @@
 export INSTALL="${1}"
 mkdir -p "${INSTALL}"
 
-GO_LDFLAGS="-s -w" GO_BUILD_FLAGS="-v" ./build
+GO_LDFLAGS="-s -w" GO_BUILD_FLAGS="-v" ./build.sh
 
 for bin in etcd etcdctl; do
   cp "bin/${bin}" "${INSTALL}/${bin}"

--- a/build-scripts/components/etcd/version.sh
+++ b/build-scripts/components/etcd/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v3.4.3"
+echo "v3.5.5"


### PR DESCRIPTION
### Summary

Upgrade etcd to 3.5.5 for 1.26 onwards

Currently in draft to get a build and initiate testing.