### PR TITLE
Upgrade from core18 to core22 

### DIFF
--- a/build-scripts/python-requirements/requirements.txt
+++ b/build-scripts/python-requirements/requirements.txt
@@ -1,0 +1,3 @@
+PyYAML==5.3.1
+netifaces==0.10.9
+jsonschema==4.0.0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,7 +29,7 @@ parts:
       - autotools-dev
       - bison
       - btrfs-progs
-      - libbtrfs-dev 
+      - libbtrfs-dev
       - build-essential
       - curl
       - flex

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -258,33 +258,33 @@ parts:
     source: build-scripts/components/microk8s-completion
     override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh microk8s-completion
 
-  python-requirements:
-    source: .
-    plugin: python
-    python-packages:
-      - PyYAML == 5.3.1
-      - netifaces == 0.10.9
-      - jsonschema == 4.0.0
+  python-runtime:
+    plugin: nil
     stage-packages:
+      - libpython3-stdlib
+      - libpython3.10-stdlib
+      - libpython3.10-minimal
+      - python3-pip
+      - python3-setuptools
+      - python3-wheel
+      - python3-venv
+      - python3-minimal
+      - python3-distutils
+      - python3-pkg-resources
+      - python3.10-minimal
       - python3-openssl
       - python3-requests
       - python3-click
       - python3-dateutil
+
+  python-requirements:
+    source: build-scripts/python-requirements
+    plugin: python
+    python-requirements:
+      - requirements.txt
     stage:
       - -usr/share/doc
       - -usr/share/man
-    # see LP: #1882994
-    override-build: |
-      snapcraftctl build
-      `find $SNAPCRAFT_PART_INSTALL -name '__pycache__' | xargs rm -r`
-      `find $SNAPCRAFT_PART_INSTALL -name 'RECORD' | xargs rm`
-      rm $SNAPCRAFT_PART_INSTALL/pyvenv.cfg
-      rm $SNAPCRAFT_PART_INSTALL/bin/activate
-      rm $SNAPCRAFT_PART_INSTALL/bin/activate.csh
-      rm $SNAPCRAFT_PART_INSTALL/bin/activate.fish
-      rm $SNAPCRAFT_PART_INSTALL/bin/python3
-      rm $SNAPCRAFT_PART_INSTALL/bin/python
-      ln -s /usr/bin/python3 $SNAPCRAFT_PART_INSTALL/usr/bin/python3
 
 apps:
   microk8s:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,8 +10,12 @@ description: |-
 
 grade: stable
 confinement: classic
-base: core18
+base: core22
 assumes: [snapd2.52]
+environment:
+  PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/local/bin:$SNAP/usr/local/sbin:$PATH
+  PYTHONPATH: $PYTHONPATH:/usr/lib/python3.10:/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.10:$SNAP/lib/python3.10/site-packages:$SNAP/usr/lib/python3/dist-packages
+  PYTHONWARNINGS: ignore
 
 parts:
   build-deps:
@@ -24,7 +28,8 @@ parts:
       - autopoint
       - autotools-dev
       - bison
-      - btrfs-tools
+      - btrfs-progs
+      - libbtrfs-dev 
       - build-essential
       - curl
       - flex
@@ -128,9 +133,6 @@ parts:
     after: [libnftnl]
     source: https://www.netfilter.org/projects/iptables/files/iptables-1.8.6.tar.bz2
     plugin: autotools
-    configflags:
-      - "--disable-shared"
-      - "--enable-static"
     prime: [-bin/iptables-xml]
 
   migrator:
@@ -150,7 +152,7 @@ parts:
       - libnss-resolve
       - libnss-mymachines
       - conntrack
-      - libssl1.0.0
+      - libssl3
     stage:
       - -sbin/xtables-multi
       - -sbin/iptables*
@@ -168,7 +170,6 @@ parts:
   bash-utils:
     plugin: nil
     stage-packages:
-      - aufs-tools
       - coreutils
       - curl
       - diffutils
@@ -258,8 +259,8 @@ parts:
     override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh microk8s-completion
 
   python-requirements:
+    source: .
     plugin: python
-    python-version: python3
     python-packages:
       - PyYAML == 5.3.1
       - netifaces == 0.10.9
@@ -272,6 +273,18 @@ parts:
     stage:
       - -usr/share/doc
       - -usr/share/man
+    # see LP: #1882994
+    override-build: |
+      snapcraftctl build
+      `find $SNAPCRAFT_PART_INSTALL -name '__pycache__' | xargs rm -r`
+      `find $SNAPCRAFT_PART_INSTALL -name 'RECORD' | xargs rm`
+      rm $SNAPCRAFT_PART_INSTALL/pyvenv.cfg
+      rm $SNAPCRAFT_PART_INSTALL/bin/activate
+      rm $SNAPCRAFT_PART_INSTALL/bin/activate.csh
+      rm $SNAPCRAFT_PART_INSTALL/bin/activate.fish
+      rm $SNAPCRAFT_PART_INSTALL/bin/python3
+      rm $SNAPCRAFT_PART_INSTALL/bin/python
+      ln -s /usr/bin/python3 $SNAPCRAFT_PART_INSTALL/usr/bin/python3
 
 apps:
   microk8s:


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
Fixed python packaging, switched missing libraries and adjusted yaml bits

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
* Switch from `core18` to `core22`
* Replaced `btrfs-tools` with `btrfs-progs` and `libbtrfs-dev`
* Removed configflags from `iptables` build process
* Upgraded `libssl1.0.0` to `libssl3`
* Removed `aufs-tools` (removed in 22.04)
* Changed python packaging to work with core22

#### Testing
<!-- Please explain how you tested your changes. -->
Snapped, installed and tested manually with workloads. Should be tested more extensively .

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->
Initial assessment seems like the changed packages do not cause a problem, there might be things that hasn't come up yet.

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [X] The introduced changes are covered by unit and/or integration tests.

