### PR TITLE
Auto-configure kubelet resolv.conf file with upstream nameservers

### DIFF
--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -84,6 +84,17 @@ then
   fi
 fi
 
+# Configure host resolv.conf file with non-loopback upstream nameservers
+resolv_conf="$(cat $SNAP_DATA/args/kubelet | grep "--resolv-conf" | tr "=" " " | gawk '{print $2}')"
+if [ -z "$resolv_conf" ]
+then
+  host_resolv_conf="$("$SNAP/usr/bin/python3" "$SNAP/scripts/find-resolv-conf.py")"
+  if [ ! -z "$host_resolv_conf" ]; then
+    refresh_opt_in_local_config "resolv-conf" "${host_resolv_conf}" "kubelet"
+    echo "Configured kubelet to use ${host_resolv_conf} for DNS configuration"
+  fi
+fi
+
 #UFW configuration
 if ! is_strict && (ufw version &> /dev/null)
 then

--- a/scripts/find-resolv-conf.py
+++ b/scripts/find-resolv-conf.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import ipaddress
+import re
+
+import click
+
+
+# https://regex101.com/r/RWZH94/1
+NAMESERVER_REGEX = r"^\s*nameserver\s+(\S*)\s*$"
+
+DEFAULT_RESOLV_CONFS = [
+    "/etc/resolv.conf",
+    "/run/systemd/resolve/resolv.conf",
+]
+
+
+def safe_is_non_loopback_address(address: str):
+    """
+    Return true if the given address is a valid non loopback address. Returns
+    false if the address is loopback or invalid
+    """
+    try:
+        return not ipaddress.ip_address(address).is_loopback
+    except ValueError:
+        return False
+
+
+def find_resolv_conf_with_non_loopback_address(resolv_confs: list):
+    """
+    Given a list of resolv.conf file paths, return the first one that contains non-loopback
+    upstream nameservers.
+    """
+    for path in resolv_confs:
+        try:
+            with open(path) as fin:
+                contents = fin.read()
+
+            nameservers = re.findall(NAMESERVER_REGEX, contents, re.MULTILINE)
+
+            if nameservers and all(map(safe_is_non_loopback_address, nameservers)):
+                return path
+        except (OSError, ValueError):
+            # ignore invalid resolv.conf files
+            pass
+
+
+@click.command("find-resolv-conf")
+@click.argument("resolv_confs", nargs=-1)
+def main(resolv_confs):
+    """
+    find-resolv-conf looks in the system for a resolv.conf file that contains non-loopback
+    upstream nameservers. If there are any, the first one found is printed to stdout.
+
+    Paths to resolv.conf files may be given as arguments. By default, known system locations
+    defined in DEFAULT_RESOLV_CONFS are checked.
+
+    If no resolv.conf file with non-loopback nameservers is found, nothing is printed to stdout.
+    """
+    path = find_resolv_conf_with_non_loopback_address(resolv_confs or DEFAULT_RESOLV_CONFS)
+    if path:
+        print(path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Summary

Auto-configure resolv.conf file used by kubelet for host DNS resolution.

- By default `/etc/resolv.conf` is used. In most systemd systems, this points to 127.0.0.53, which is the loopback address for the local resolver, and is unusable inside pods.
- In most OSes, /run/systemd/resolve/resolv.conf will instead have a list of reachable upstream nameservers.
- Only change the resolv.conf file if all nameservers are non-loopback addresses. This is checked with find-resolv-conf.py. Otherwise, no configuration is changed, maintaining the old behaviour
- If user has already configured --resolv-conf, configuration will not be overwritten.
