### PR TITLE
Fix enable ha-cluster

### DIFF
--- a/upgrade-scripts/000-switch-to-calico/commit-master.sh
+++ b/upgrade-scripts/000-switch-to-calico/commit-master.sh
@@ -27,8 +27,6 @@ refresh_opt_in_config "allow-privileged" "true" kube-apiserver
 
 # Reconfigure kubelet/containerd to pick up the new CNI config and binary.
 cp "$SNAP_DATA"/args/kubelet "$BACKUP_DIR/args"
-echo "Restarting kubelet"
-refresh_opt_in_config "cni-bin-dir" "\${SNAP_DATA}/opt/cni/bin/" kubelet
 
 cp "$SNAP_DATA"/args/containerd-template.toml "$BACKUP_DIR/args"
 if grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
@@ -38,9 +36,9 @@ if grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
 fi
 
 cp "$SNAP_DATA"/args/kube-proxy "$BACKUP_DIR/args"
-echo "Restarting kube proxy"
 refresh_opt_in_config "cluster-cidr" "10.1.0.0/16" kube-proxy
 
+echo "Restarting kubelite"
 snapctl restart ${SNAP_NAME}.daemon-kubelite
 
 set_service_not_expected_to_start flanneld

--- a/upgrade-scripts/000-switch-to-calico/commit-node.sh
+++ b/upgrade-scripts/000-switch-to-calico/commit-node.sh
@@ -27,8 +27,6 @@ refresh_opt_in_config "allow-privileged" "true" kube-apiserver
 
 # Reconfigure kubelet/containerd to pick up the new CNI config and binary.
 cp "$SNAP_DATA"/args/kubelet "$BACKUP_DIR/args"
-echo "Restarting kubelet"
-refresh_opt_in_config "cni-bin-dir" "\${SNAP_DATA}/opt/cni/bin/" kubelet
 
 cp "$SNAP_DATA"/args/containerd-template.toml "$BACKUP_DIR/args"
 if grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
@@ -38,9 +36,9 @@ if grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
 fi
 
 cp "$SNAP_DATA"/args/kube-proxy "$BACKUP_DIR/args"
-echo "Restarting kube proxy"
 refresh_opt_in_config "cluster-cidr" "10.1.0.0/16" kube-proxy
 
+echo "Restarting kubelite"
 snapctl restart ${SNAP_NAME}.daemon-kubelite
 
 set_service_not_expected_to_start flanneld

--- a/upgrade-scripts/001-switch-to-dqlite/commit-master.sh
+++ b/upgrade-scripts/001-switch-to-dqlite/commit-master.sh
@@ -45,8 +45,8 @@ then
   init_cluster
 fi
 
-snapctl restart ${SNAP_NAME}.daemon-kubelite
 snapctl restart ${SNAP_NAME}.daemon-k8s-dqlite
+snapctl restart ${SNAP_NAME}.daemon-kubelite
 
 run_etcd="$(is_service_expected_to_start etcd)"
 if [ "${run_etcd}" == "1" ]
@@ -86,6 +86,7 @@ then
   set_service_expected_to_start k8s-dqlite
 fi
 
+rm -rf ${SNAP_DATA}/var/lock/cni-loaded
 ${SNAP}/microk8s-start.wrapper
 ${SNAP}/microk8s-status.wrapper --wait-ready --timeout 120
 


### PR DESCRIPTION
#### Summary
This PR fixes the `microk8s enable ha-cluster` command.
 
#### Changes
- the cni-bin-dir is removed from the kubelet args
- we load the CNI after enabling ha-cluster (calico)

#### Testing
Manual

