### PR TITLE
Fix cgroups for newer kernel versions

### DIFF
--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -267,7 +267,7 @@ function suggest_fixes {
   fi
 
   if ! grep -q 'cgroup/memory' /proc/self/mountinfo; then
-    if ! grep -q 'cgroup/unified.* cgroup2 ' /proc/self/mountinfo; then
+    if ! grep -q 'cgroup2' /proc/self/mountinfo; then
       printf -- '\033[0;33mWARNING: \033[0m The memory cgroup is not enabled. \n'
       printf -- 'The cluster may not be functioning properly. Please ensure cgroups are enabled \n'
       printf -- 'See for example: https://microk8s.io/docs/install-alternatives#heading--arm \n'


### PR DESCRIPTION
#### Summary

For some newer cgroups, rather than `cgroup/memory` or `cgroup/unified` configurations, there is a unified `cgroup2` (group version 2). Matching with the newer string also takes care of the old unified cgroup string in the older kernels.

Signed-off-by: Sachin Kumar Singh <sachin.singh@canonical.com>

Closes #3514 


#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
File changes:
- **./scripts/inspect.sh** - Instead of checking for a unified group configuration for cgroup2, we just match fro cgroup2 which also takes care of kernel with the latest kernels with only cgroup2.

#### Testing
<!-- Please explain how you tested your changes. -->
Testing changes locally for kernel versions 5.4 and 5.15.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->
None

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
