### PR TITLE
fix kubeconfig for worker node services

### DIFF
--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -256,9 +256,13 @@ def get_client_cert(master_ip, master_port, fname, token, username, group=None):
     info = "/CN={}".format(username)
     if group:
         info = "{}/O={}".format(info, group)
-    cer_req_file = "{}/certs/{}.csr".format(snapdata_path, fname)
-    cer_key_file = "{}/certs/{}.key".format(snapdata_path, fname)
-    cer_file = "{}/certs/{}.crt".format(snapdata_path, fname)
+
+    # the filenames must survive snap refreshes, so replace revision number with current
+    snapdata_current = os.path.abspath(os.path.join(snapdata_path, "..", "current"))
+
+    cer_req_file = "{}/certs/{}.csr".format(snapdata_current, fname)
+    cer_key_file = "{}/certs/{}.key".format(snapdata_current, fname)
+    cer_file = "{}/certs/{}.crt".format(snapdata_current, fname)
     if not os.path.exists(cer_key_file):
         cmd_gen_cert_key = "{snap}/usr/bin/openssl genrsa -out {key} 2048".format(
             snap=snap_path, key=cer_key_file

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -606,6 +606,16 @@ then
   snapctl restart ${SNAP_NAME}.daemon-k8s-dqlite
 fi
 
+# Fix hard-coded snap revision numbers in worker node services of existing clusters
+# https://github.com/canonical/microk8s/pull/3554
+for svc in kubelet proxy; do
+  cfg="${SNAP_DATA}/credentials/${svc}.config"
+  if [ -e ${cfg} ]; then
+    sed -i 's,/var/snap/microk8s/[x0-9]*/,/var/snap/microk8s/current/,' "${cfg}" || true
+    sed -i 's,/var/snap/microk8s/[x0-9]*/,/var/snap/microk8s/current/,' "${cfg}" || true
+  fi
+done
+
 # Refresh calico if needed
 refresh_calico_if_needed
 


### PR DESCRIPTION
Previously, these paths included snap revision numbers, which would break after two snap refreshes

See https://kubernetes.slack.com/archives/CAUNWQ85V/p1668093680342589 for context