### PR TITLE
Added auto add for provider id on eksd

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -948,3 +948,24 @@ wait_for_default_route() {
     sleep 2
   done
 }
+
+is_ec2_instance() {
+  if [ -f "/sys/hypervisor/uuid" ]
+  then
+    EC2UID=$(head -c 3 /sys/hypervisor/uuid | tr '[:upper:]' '[:lower:]')
+    if [[ $EC2UID == *"ec2"* ]]
+    then
+      return 0
+    fi
+  else
+    if [ -f "/sys/devices/virtual/dmi/id/product_uuid" ]
+    then
+      EC2UID=$(head -c 3 /sys/devices/virtual/dmi/id/product_uuid | tr '[:upper:]' '[:lower:]')
+      if [[ $EC2UID == *"ec2"* ]]
+      then
+        return 0
+      fi
+    fi
+  fi
+  return 1
+}

--- a/microk8s-resources/default-hooks/reconcile.d/10-provider-id-update
+++ b/microk8s-resources/default-hooks/reconcile.d/10-provider-id-update
@@ -7,12 +7,15 @@ KUBECTL="${SNAP}/microk8s-kubectl.wrapper"
 if [ -e "${SNAP_DATA}/var/lock/providerid-needs-update" ]
 then
   echo "Updating providerID"
-  INSTANCE_ID=$(curl -sS http://169.254.169.254/latest/meta-data/instance-id)
-  A_ZONE=$(curl -sS http://169.254.169.254/latest/meta-data/placement/availability-zone)
-  hostname=$(hostname)
-  if (is_apiserver_ready) &&
-      "${KUBECTL}" --request-timeout 2m patch node $hostname -p "{\"spec\":{\"providerID\":\"aws:///$A_ZONE/$INSTANCE_ID\"}}"
+  INSTANCE_ID=$(curl -sS -m 5 http://169.254.169.254/latest/meta-data/instance-id)
+  A_ZONE=$(curl -sS -m 5 http://169.254.169.254/latest/meta-data/placement/availability-zone)
+  if [[ ! -z "$INSTANCE_ID" ]] && [[ ! -z "$A_ZONE" ]]
   then
-    rm "${SNAP_DATA}/var/lock/providerid-needs-update"
+    hostname=$(hostname)
+    if (is_apiserver_ready) &&
+        "${KUBECTL}" --request-timeout 2m patch node $hostname -p "{\"spec\":{\"providerID\":\"aws:///$A_ZONE/$INSTANCE_ID\"}}"
+    then
+      rm "${SNAP_DATA}/var/lock/providerid-needs-update"
+    fi
   fi
 fi

--- a/microk8s-resources/default-hooks/reconcile.d/10-provider-id-update
+++ b/microk8s-resources/default-hooks/reconcile.d/10-provider-id-update
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+. "${SNAP}/actions/common/utils.sh"
+
+KUBECTL="${SNAP}/microk8s-kubectl.wrapper"
+
+if [ -e "${SNAP_DATA}/var/lock/providerid-needs-update" ]
+then
+  echo "Updating providerID"
+  INSTANCE_ID=$(curl -sS http://169.254.169.254/latest/meta-data/instance-id)
+  A_ZONE=$(curl -sS http://169.254.169.254/latest/meta-data/placement/availability-zone)
+  hostname=$(hostname)
+  if (is_apiserver_ready) &&
+      "${KUBECTL}" --request-timeout 2m patch node $hostname -p "{\"spec\":{\"providerID\":\"aws:///$A_ZONE/$INSTANCE_ID\"}}"
+  then
+    rm "${SNAP_DATA}/var/lock/providerid-needs-update"
+  fi
+fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -225,12 +225,15 @@ fi
 
 if is_ec2_instance
 then
-  INSTANCE_ID=$(curl -sS http://169.254.169.254/latest/meta-data/instance-id)
-  A_ZONE=$(curl -sS http://169.254.169.254/latest/meta-data/placement/availability-zone)
-  sed -i -n -e '/^--provider-id /!p' -e "\$a--provider-id aws:///$A_ZONE/$INSTANCE_ID" ${SNAP_DATA}/args/kubelet
-  cp -r --preserve=mode ${SNAP}/default-hooks/reconcile.d/10-provider-id-update ${SNAP_COMMON}/hooks/reconcile.d/
-  touch "${SNAP_DATA}/var/lock/providerid-needs-update"
-  need_kubelet_restart=true
+  INSTANCE_ID=$(curl -sS -m 5 http://169.254.169.254/latest/meta-data/instance-id)
+  A_ZONE=$(curl -sS -m 5 http://169.254.169.254/latest/meta-data/placement/availability-zone)
+  if [[ ! -z "$INSTANCE_ID" ]] && [[ ! -z "$A_ZONE" ]]
+  then
+    sed -i -n -e '/^--provider-id /!p' -e "\$a--provider-id aws:///$A_ZONE/$INSTANCE_ID" ${SNAP_DATA}/args/kubelet
+    cp -r --preserve=mode ${SNAP}/default-hooks/reconcile.d/10-provider-id-update ${SNAP_COMMON}/hooks/reconcile.d/
+    touch "${SNAP_DATA}/var/lock/providerid-needs-update"
+    need_kubelet_restart=true
+  fi
 fi
 
 # With v1.15 allow-privileged is removed from kubelet

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -223,6 +223,16 @@ then
     need_kubelet_restart=true
 fi
 
+if is_ec2_instance
+then
+  INSTANCE_ID=$(curl -sS http://169.254.169.254/latest/meta-data/instance-id)
+  A_ZONE=$(curl -sS http://169.254.169.254/latest/meta-data/placement/availability-zone)
+  sed -i -n -e '/^--provider-id /!p' -e "\$a--provider-id aws:///$A_ZONE/$INSTANCE_ID" ${SNAP_DATA}/args/kubelet
+  cp -r --preserve=mode ${SNAP}/default-hooks/reconcile.d/10-provider-id-update ${SNAP_COMMON}/hooks/reconcile.d/
+  touch "${SNAP_DATA}/var/lock/providerid-needs-update"
+  need_kubelet_restart=true
+fi
+
 # With v1.15 allow-privileged is removed from kubelet
 if grep -e "\-\-allow-privileged" ${SNAP_DATA}/args/kubelet
 then


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
EKSD installations of MicroK8s will automatically add providerID if they're running on EC2 machines.

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
Added some checks to configure hooks and added a new reconcile hook.

#### Testing
<!-- Please explain how you tested your changes. -->
Manually tested by installing on EC2 and non EC2 instances.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
