### PR TITLE
Ensure grep considers arguments as regex

### DIFF
--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -85,7 +85,7 @@ then
 fi
 
 # Configure host resolv.conf file with non-loopback upstream nameservers
-resolv_conf="$(cat $SNAP_DATA/args/kubelet | grep "--resolv-conf" | tr "=" " " | gawk '{print $2}')"
+resolv_conf="$(cat $SNAP_DATA/args/kubelet | grep -- "--resolv-conf" | tr "=" " " | gawk '{print $2}')"
 if [ -z "$resolv_conf" ]
 then
   host_resolv_conf="$("$SNAP/usr/bin/python3" "$SNAP/scripts/find-resolv-conf.py")"


### PR DESCRIPTION
### Summary

Fixes

```
Nov 16 11:35:49 ip-172-31-13-224 microk8s.daemon-kubelite[32433]: ++ cat /var/snap/microk8s/4225/args/kubelet
Nov 16 11:35:49 ip-172-31-13-224 microk8s.daemon-kubelite[32434]: ++ grep --resolv-conf
Nov 16 11:35:49 ip-172-31-13-224 microk8s.daemon-kubelite[32436]: ++ gawk '{print $2}'
Nov 16 11:35:49 ip-172-31-13-224 microk8s.daemon-kubelite[32434]: grep: unrecognized option '--resolv-conf'
Nov 16 11:35:49 ip-172-31-13-224 microk8s.daemon-kubelite[32435]: ++ tr = ' '
Nov 16 11:35:49 ip-172-31-13-224 microk8s.daemon-kubelite[32434]: Usage: grep [OPTION]... PATTERN [FILE]...
Nov 16 11:35:49 ip-172-31-13-224 microk8s.daemon-kubelite[32434]: Try 'grep --help' for more information.
Nov 16 11:35:49 ip-172-31-13-224 microk8s.daemon-kubelite[32375]: + resolv_conf=
Nov 16 11:35:49 ip-172-31-13-224 microk8s.daemon-kubelite[32375]: + '[' -z '' ']'
Nov 16 11:35:49 ip-172-31-13-224 microk8s.daemon-kubelite[32437]: ++ /snap/microk8s/4225/usr/bin/python3 /snap/microk8s/4225/scripts/find-resolv-conf.py
```