### PR TITLE
1.26 removed kubelet --log-dir argument

### DIFF
--- a/microk8s-resources/default-args/kubelet
+++ b/microk8s-resources/default-args/kubelet
@@ -3,7 +3,6 @@
 --client-ca-file=${SNAP_DATA}/certs/ca.crt
 --anonymous-auth=false
 --root-dir=${SNAP_COMMON}/var/lib/kubelet
---log-dir=${SNAP_COMMON}/var/log
 --fail-swap-on=false
 --feature-gates=DevicePlugins=true
 --eviction-hard="memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -612,9 +612,15 @@ for svc in kubelet proxy; do
   cfg="${SNAP_DATA}/credentials/${svc}.config"
   if [ -e ${cfg} ]; then
     sed -i 's,/var/snap/microk8s/[x0-9]*/,/var/snap/microk8s/current/,' "${cfg}" || true
-    sed -i 's,/var/snap/microk8s/[x0-9]*/,/var/snap/microk8s/current/,' "${cfg}" || true
   fi
 done
+
+# (1.26) Removed --log-dir argument from kubelet
+if grep -e "\-\-log\-dir" "${SNAP_DATA}/args/kubelet"
+then
+  "${SNAP}/bin/sed" -i '/\-\-log\-dir/d' "${SNAP_DATA}/args/kubelet"
+  need_api_restart=true
+fi
 
 # Refresh calico if needed
 refresh_calico_if_needed


### PR DESCRIPTION
### Summary

Kubernetes 1.26 no longer accepts the `--log-dir` argument. Remove so that kubelet starts properly

### Changes

Also removed unnecessary second sed call from #3554