### PR TITLE
remove -f flag from suggested chown cmd

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -18,7 +18,7 @@ exit_if_no_permissions() {
     echo "You can either try again with sudo or add the user $USER to the '${group}' group:" >&2
     echo "" >&2
     echo "    sudo usermod -a -G ${group} $USER" >&2
-    echo "    sudo chown -f -R $USER ~/.kube" >&2
+    echo "    sudo chown -R $USER ~/.kube" >&2
     echo "" >&2
     echo "After this, reload the user groups either via a reboot or by running 'newgrp ${group}'." >&2
     exit 1

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -197,7 +197,7 @@ def exit_if_no_permission():
         )
         print("")
         print("    sudo usermod -a -G microk8s {}".format(user))
-        print("    sudo chown -f -R $USER ~/.kube")
+        print("    sudo chown -R $USER ~/.kube")
         print("")
         print(
             "After this, reload the user groups either via a reboot or by running 'newgrp microk8s'."


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

When the user has insufficient permissions, we suggest commands to run. We shouldn't suggest using the `-f` flag in `chown`, because this suppresses error messages which might be useful to the user.

Fixes #3534

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

Remove `-f` flag in `chown` in the "insufficient permissions" error.

#### Testing
<!-- Please explain how you tested your changes. -->

N/A

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

N/A

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->

N/A