### PR TITLE
Update k8s-dqlite to 1.0.5 to include Kine fix for 1.26

### DIFF
--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.0.4"
+echo "v1.0.5"


### PR DESCRIPTION
### Summary

Update k8s-dqlite to include https://github.com/canonical/kine/pull/9