### PR TITLE
Remove the userspace proxy mode if present

### DIFF
--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -187,22 +187,22 @@ then
   refresh_opt_in_local_config "conntrack-max-per-core" "0" kube-proxy
 fi
 
+# userspace proxy-mode is not allowed on the 1.26+ k8s
+# https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/#removal-of-kube-proxy-userspace-modes 
+if grep -- "--proxy-mode=userspace" $SNAP_DATA/args/kube-proxy
+then
+  echo "Removing --proxy-mode=userspace flag from kube-proxy, since it breaks Calico."
+  skip_opt_in_local_config "proxy-mode" "kube-proxy"
+fi
+
 if ! [ -f /proc/sys/net/bridge/bridge-nf-call-iptables ]
 then
   # NOTE(neoaggelos): https://github.com/canonical/microk8s/issues/3085
   # Attempt to use modprobe from the host, otherwise fallback to the one
   # provided with the snap.
-  #
-  # If the br_netfilter module is loaded successfully, make sure to remove
-  # the --proxy-mode=userspace flag from kube-proxy, since it breaks Calico.
   if /sbin/modprobe br_netfilter || modprobe br_netfilter
   then
     echo "Successfully loaded br_netfilter module."
-    if grep -- "--proxy-mode=userspace" $SNAP_DATA/args/kube-proxy
-    then
-      echo "Removing --proxy-mode=userspace flag from kube-proxy, since it breaks Calico."
-      skip_opt_in_local_config "proxy-mode" "kube-proxy"
-    fi
   else
     echo "Failed to load br_netfilter. Calico might not work properly."
   fi


### PR DESCRIPTION
#### Summary
`userspace` proxy-mode is not allowed on the 1.26+ k8s https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/#removal-of-kube-proxy-userspace-modes  so we remove it from the kube-proxy config if we find it there.
