### PR TITLE
Set LC_ALL LANG in the kubelite wrapper so find-resolv-conf.py will not fail

### DIFF
--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -6,6 +6,8 @@ export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 ARCH="$($SNAP/bin/uname -m)"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+export LC_ALL="${LC_ALL:-C.UTF-8}"
+export LANG="${LANG:-C.UTF-8}"
 export XDG_RUNTIME_DIR="${SNAP_COMMON}/run"
 mkdir -p "${XDG_RUNTIME_DIR}"
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ passenv =
     MK8S_*
 deps =
     black ==21.4b2
-    click==7.0
+    click==7.1.2
     flake8
     flake8-colors
     pep8-naming


### PR DESCRIPTION
This came up from the strict testing where kubelite was failing with:
```
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162363]: ++ tr = ' '
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162364]: ++ gawk '{print $2}'
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162292]: + resolv_conf=
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162292]: + '[' -z '' ']'
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]: ++ /snap/microk8s/4354/usr/bin/python3 /snap/microk8s/4354/scripts/find-resolv-conf.py
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]: Traceback (most recent call last):
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]:   File "/snap/microk8s/4354/scripts/find-resolv-conf.py", line 66, in <module>
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]:     main()
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]:   File "/snap/microk8s/4354/usr/lib/python3/dist-packages/click/core.py", line 722, in __call__
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]:     return self.main(*args, **kwargs)
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]:   File "/snap/microk8s/4354/usr/lib/python3/dist-packages/click/core.py", line 676, in main
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]:     _verify_python3_env()
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]:   File "/snap/microk8s/4354/usr/lib/python3/dist-packages/click/_unicodefun.py", line 118, in _verify_python3_env
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]:     'for mitigation steps.' + extra)
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]: RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment.  Consult http://click.pocoo.org/python3/for mitiga>
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]: This system supports the C.UTF-8 locale which is recommended.
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]: You might be able to resolve your issue by exporting the
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]: following environment variables:
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]:     export LC_ALL=C.UTF-8
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]:     export LANG=C.UTF-8
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]: Click discovered that you exported a UTF-8 locale
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]: but the locale system could not pick up from it because
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]: it does not exist.  The exported locale is "en_US.UTF-8" but it
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162365]: is not supported
Δεκ 08 18:10:19 aurora microk8s.daemon-kubelite[4162292]: + host_resolv_conf=
Δεκ 08 18:10:19 aurora systemd[1]: snap.microk8s.daemon-kubelite.service: Main process exited, code=exited, status=1/FAILURE
Δεκ 08 18:10:19 aurora systemd[1]: snap.microk8s.daemon-kubelite.service: Failed with result 'exit-code'.
```