### PR TITLE
Update the k8s patches for 1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MicroK8s
 
-![](https://img.shields.io/badge/Kubernetes-1.25-326de6.svg)
+![](https://img.shields.io/badge/Kubernetes-1.26-326de6.svg)
 
 <img src="/docs/images/certified_kubernetes_color-222x300.png" align="right" width="200px">
 

--- a/build-scripts/components/kubernetes/patches/0000-Kubelite-integration.patch
+++ b/build-scripts/components/kubernetes/patches/0000-Kubelite-integration.patch
@@ -1,10 +1,10 @@
-From ae9147faf2e2ad7142702d2fa5d821a9efdff85e Mon Sep 17 00:00:00 2001
+From d0ae18d074db5ff361f363073f32b2f30c7a3686 Mon Sep 17 00:00:00 2001
 From: Konstantinos Tsakalozos <kos.tsakalozos@canonical.com>
 Date: Wed, 3 Mar 2021 18:19:37 +0200
 Subject: [PATCH] Kubelite integration
 
 ---
- cmd/kube-apiserver/app/server.go    |  9 ++--
+ cmd/kube-apiserver/app/server.go    |  9 +++-
  cmd/kube-scheduler/app/server.go    |  6 ++-
  cmd/kubelet/app/server.go           | 13 +++--
  cmd/kubelite/app/daemons/daemon.go  | 84 +++++++++++++++++++++++++++++
@@ -12,17 +12,17 @@ Subject: [PATCH] Kubelite integration
  cmd/kubelite/app/server.go          | 79 +++++++++++++++++++++++++++
  cmd/kubelite/kubelite.go            | 28 ++++++++++
  pkg/volume/csi/csi_plugin.go        | 10 ++--
- 8 files changed, 296 insertions(+), 12 deletions(-)
+ 8 files changed, 297 insertions(+), 11 deletions(-)
  create mode 100644 cmd/kubelite/app/daemons/daemon.go
  create mode 100644 cmd/kubelite/app/options/options.go
  create mode 100644 cmd/kubelite/app/server.go
  create mode 100644 cmd/kubelite/kubelite.go
 
 diff --git a/cmd/kube-apiserver/app/server.go b/cmd/kube-apiserver/app/server.go
-index aa2995428ba..9cc861190d5 100644
+index fc36d044dbe..cffb7c35a3c 100644
 --- a/cmd/kube-apiserver/app/server.go
 +++ b/cmd/kube-apiserver/app/server.go
-@@ -87,7 +87,7 @@ func init() {
+@@ -89,7 +89,7 @@ func init() {
  }
  
  // NewAPIServerCommand creates a *cobra.Command object with default parameters
@@ -31,12 +31,12 @@ index aa2995428ba..9cc861190d5 100644
  	s := options.NewServerRunOptions()
  	cmd := &cobra.Command{
  		Use: "kube-apiserver",
-@@ -125,8 +125,11 @@ cluster's shared state through which all other components interact.`,
- 			if errs := completedOptions.Validate(); len(errs) != 0 {
- 				return utilerrors.NewAggregate(errs)
+@@ -129,7 +129,12 @@ cluster's shared state through which all other components interact.`,
  			}
--
+ 			// add feature enablement metrics
+ 			utilfeature.DefaultMutableFeatureGate.AddMetrics()
 -			return Run(completedOptions, genericapiserver.SetupSignalHandler())
++
 +			if len(stopCh) != 0 {
 +				return Run(completedOptions, stopCh[0])
 +			} else {
@@ -46,10 +46,10 @@ index aa2995428ba..9cc861190d5 100644
  		Args: func(cmd *cobra.Command, args []string) error {
  			for _, arg := range args {
 diff --git a/cmd/kube-scheduler/app/server.go b/cmd/kube-scheduler/app/server.go
-index c352ba664d0..54177aa117d 100644
+index 8d01f3b7670..44ac7f69328 100644
 --- a/cmd/kube-scheduler/app/server.go
 +++ b/cmd/kube-scheduler/app/server.go
-@@ -129,7 +129,11 @@ func runCommand(cmd *cobra.Command, opts *options.Options, registryOptions ...Op
+@@ -132,7 +132,11 @@ func runCommand(cmd *cobra.Command, opts *options.Options, registryOptions ...Op
  	ctx, cancel := context.WithCancel(context.Background())
  	defer cancel()
  	go func() {
@@ -63,10 +63,10 @@ index c352ba664d0..54177aa117d 100644
  		cancel()
  	}()
 diff --git a/cmd/kubelet/app/server.go b/cmd/kubelet/app/server.go
-index 6d064326ec7..98d99d828e5 100644
+index 9444f136866..8ca88f64d04 100644
 --- a/cmd/kubelet/app/server.go
 +++ b/cmd/kubelet/app/server.go
-@@ -116,7 +116,7 @@ const (
+@@ -120,7 +120,7 @@ const (
  )
  
  // NewKubeletCommand creates a *cobra.Command object with default parameters
@@ -75,7 +75,7 @@ index 6d064326ec7..98d99d828e5 100644
  	cleanFlagSet := pflag.NewFlagSet(componentKubelet, pflag.ContinueOnError)
  	cleanFlagSet.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
  	kubeletFlags := options.NewKubeletFlags()
-@@ -253,6 +253,12 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
+@@ -250,6 +250,12 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
  			if err := checkPermissions(); err != nil {
  				klog.ErrorS(err, "kubelet running with insufficient permissions")
  			}
@@ -88,13 +88,14 @@ index 6d064326ec7..98d99d828e5 100644
  
  			// make the kubelet's config safe for logging
  			config := kubeletServer.KubeletConfiguration.DeepCopy()
-@@ -262,11 +268,8 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
+@@ -259,12 +265,9 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
  			// log the kubelet's config for inspection
  			klog.V(5).InfoS("KubeletConfiguration", "configuration", config)
  
 -			// set up signal context for kubelet shutdown
 -			ctx := genericapiserver.SetupSignalContext()
 -
+ 			utilfeature.DefaultMutableFeatureGate.AddMetrics()
  			// run the kubelet
 -			return Run(ctx, kubeletServer, kubeletDeps, utilfeature.DefaultFeatureGate)
 +			return Run(runctx, kubeletServer, kubeletDeps, utilfeature.DefaultFeatureGate)
@@ -397,10 +398,10 @@ index 00000000000..667b24f68e6
 +	println("Stopping kubelite")
 +}
 diff --git a/pkg/volume/csi/csi_plugin.go b/pkg/volume/csi/csi_plugin.go
-index 592aaaeaaf6..4a47b4d87a3 100644
+index ce7a543c94f..a8094f878d6 100644
 --- a/pkg/volume/csi/csi_plugin.go
 +++ b/pkg/volume/csi/csi_plugin.go
-@@ -243,18 +243,22 @@ func (p *csiPlugin) Init(host volume.VolumeHost) error {
+@@ -240,18 +240,22 @@ func (p *csiPlugin) Init(host volume.VolumeHost) error {
  	}
  
  	// Initializing the label management channels
@@ -427,5 +428,5 @@ index 592aaaeaaf6..4a47b4d87a3 100644
  	if !ok {
  		klog.V(4).Info("Cast from VolumeHost to KubeletVolumeHost failed. Skipping CSINode initialization, not running on kubelet")
 -- 
-2.25.1
+2.34.1
 

--- a/build-scripts/components/kubernetes/patches/0001-Unix-socket-skip-validation-in-component-status.patch
+++ b/build-scripts/components/kubernetes/patches/0001-Unix-socket-skip-validation-in-component-status.patch
@@ -1,4 +1,4 @@
-From dd1db952eab13912a55207c81a2ac267909677ac Mon Sep 17 00:00:00 2001
+From 5914ae7825da97f69c45e23e03f0800c1f7c336f Mon Sep 17 00:00:00 2001
 From: Konstantinos Tsakalozos <kos.tsakalozos@canonical.com>
 Date: Tue, 24 Aug 2021 11:17:19 +0300
 Subject: [PATCH] Unix socket skip validation in component status
@@ -8,10 +8,10 @@ Subject: [PATCH] Unix socket skip validation in component status
  1 file changed, 6 insertions(+)
 
 diff --git a/pkg/registry/core/rest/storage_core.go b/pkg/registry/core/rest/storage_core.go
-index 1f915c32d4b..0bb7f1a9bf9 100644
+index 206e87e8909..b26012cbd71 100644
 --- a/pkg/registry/core/rest/storage_core.go
 +++ b/pkg/registry/core/rest/storage_core.go
-@@ -350,6 +350,12 @@ func (s componentStatusStorage) serversToValidate() map[string]*componentstatus.
+@@ -401,6 +401,12 @@ func (s componentStatusStorage) serversToValidate() map[string]*componentstatus.
  			klog.Errorf("Failed to parse etcd url for validation: %v", err)
  			continue
  		}
@@ -25,5 +25,5 @@ index 1f915c32d4b..0bb7f1a9bf9 100644
  		var addr string
  		if strings.Contains(etcdUrl.Host, ":") {
 -- 
-2.25.1
+2.34.1
 


### PR DESCRIPTION
The master branch would be building 1.26 now so the pre-release patches are moved to the patches directory.

We also update the README.