### PR TITLE
[Backport 1.25] Ensure cp nodes upgraded to 1.25 don't start apiserver proxy

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -160,6 +160,12 @@ then
   cp -r ${SNAP}/default-args/apiserver-proxy ${SNAP_DATA}/args/
 fi
 
+# (1.24 -> 1.25) migrate from traefik to apiserver-proxy
+if [ -e ${SNAP_DATA}/var/lock/no-traefik ]
+then
+  touch ${SNAP_DATA}/var/lock/no-apiserver-proxy
+fi
+
 # Upgrading to containerd
 if [ ! -e ${SNAP_DATA}/args/containerd ] ||
    grep -e "\-\-docker unix://\${SNAP_DATA}/docker.sock" ${SNAP_DATA}/args/kubelet

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ passenv =
     MK8S_*
 deps =
     black ==21.4b2
-    click==7.0
+    click==7.1.2
     flake8
     flake8-colors
     pep8-naming


### PR DESCRIPTION
Backport https://github.com/canonical/microk8s/pull/3632 to 1.25 branch