### PR TITLE
Installer 2.3.0

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -40,13 +40,13 @@ jobs:
       - name: Download Multipass installer
         uses: carlosperate/download-file-action@v2.0.0
         with:
-          file-url: https://github.com/canonical/multipass/releases/download/v1.8.0/multipass-1.8.0+win-win64.exe
+          file-url: https://github.com/canonical/multipass/releases/download/v1.10.1/multipass-1.10.1+win-win64.exe
           file-name: multipass.exe
           location: ${{ github.workspace }}/installer/windows
       - name: Download kubectl
         uses: carlosperate/download-file-action@v2.0.0
         with:
-          file-url: https://storage.googleapis.com/kubernetes-release/release/v1.20.0/bin/windows/amd64/kubectl.exe
+          file-url: https://storage.googleapis.com/kubernetes-release/release/v1.26.0/bin/windows/amd64/kubectl.exe
           file-name: kubectl.exe
           location: ${{ github.workspace }}/installer/windows
       - name: Create installer

--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -1,5 +1,5 @@
 urllib3==1.26.5
-click~=7.0
+click==7.1.2
 progressbar33==2.4
 psutil==5.9.0
 requests==2.25.1
@@ -7,5 +7,8 @@ requests_unixsocket==0.1.5
 pysha3==1.0.2; python_version < '3.6'
 simplejson==3.8.2
 toml==0.10.0
+certifi==2020.12.5
+chardet==3.0.4
+idna==2.7
 pyinstaller
 https://pyyaml.org/download/pyyaml/PyYAML-5.3.1-cp38-cp38-win_amd64.whl; sys_platform == 'win32'

--- a/installer/vm_providers/_multipass/_windows.py
+++ b/installer/vm_providers/_multipass/_windows.py
@@ -39,9 +39,9 @@ logger = logging.getLogger(__name__)
 
 
 _MULTIPASS_RELEASES_API_URL = "https://api.github.com/repos/canonical/multipass/releases"
-_MULTIPASS_DL_VERSION = "1.2.0"
+_MULTIPASS_DL_VERSION = "1.10.1"
 _MULTIPASS_DL_NAME = "multipass-{version}+win-win64.exe".format(version=_MULTIPASS_DL_VERSION)
-_MULTIPASS_DL_SHA3_384 = "6478cb37294052259f7a0337077264f5494e0788f23d4b5e2acac8f553ca5bc55031737c484397418e68e4ad2d0dc62f"  # noqa: E501
+_MULTIPASS_DL_SHA3_384 = "57f183873e089450a4200cbfc3dd524b076b1745449320af82712f9cb0ef245f27bc1a1823a44d4ae27abcb893ca1844"  # noqa: E501
 
 
 def windows_reload_multipass_path_env():

--- a/installer/windows/microk8s.nsi
+++ b/installer/windows/microk8s.nsi
@@ -4,7 +4,7 @@
 !include "Sections.nsh"
 
 !define PRODUCT_NAME "MicroK8s"
-!define PRODUCT_VERSION "2.2.1"
+!define PRODUCT_VERSION "2.3.0"
 !define PRODUCT_PUBLISHER "Canonical"
 !define MUI_ICON ".\microk8s.ico"
 !define MUI_HEADERIMAGE


### PR DESCRIPTION
### Summary

- Bump MicroK8s installer to 2.3.0
- Bump Multipass to 1.10.1
- Bump kubectl to 1.26.0
- Bump default microk8s version to 1.26

Also fixes some requirements, see relevant parts of https://github.com/ubuntu/homebrew-microk8s/pull/7 