### PR TITLE
Bump k8s-dqlite to v1.1.1 to support disk-mode

### DIFF
--- a/build-scripts/components/dqlite-client/version.sh
+++ b/build-scripts/components/dqlite-client/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.11.1"
+echo "v1.11.6"

--- a/build-scripts/components/dqlite/version.sh
+++ b/build-scripts/components/dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.11.1"
+echo "v1.14.0"

--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.1.0"
+echo "v1.1.1"

--- a/build-scripts/components/raft/version.sh
+++ b/build-scripts/components/raft/version.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-# Matching https://github.com/canonical/dqlite/blob/master/configure.ac#L52
-echo "v0.14.0"
+# Matching https://github.com/canonical/dqlite/blob/master/configure.ac#L57
+echo "v0.17.1"


### PR DESCRIPTION
### Summary

Bump k8s-dqlite to v1.1.1 to support disk-mode, with deps

- Update dqlite to v1.13.0 (needed for disk mode)
- Update go-dqlite to v1.11.6 (needed for go bindings of disk mode)
- Update raft to v0.16.0 (needed >= v0.14.0 for dqlite)

### Notes

Marked as work in progress until linked PR https://github.com/canonical/k8s-dqlite/pull/38 is merged

### Testing

A development build has been pushed to `latest/edge/dqlite-disk-mode`. Test with:

```bash
sudo snap install microk8s --classic --channel latest/edge/dqlite-disk-mode
echo '--disk-mode' | sudo tee -a /var/snap/microk8s/current/args/k8s-dqlite
sudo snap restart microk8s.daemon-k8s-dqlite
```

In the logs, you should see a log line that disk mode operation is enabled.

```log
Jan 16 15:04:36 u1 microk8s.daemon-k8s-dqlite[11443]: I0116 19:04:36.636870   11443 log.go:198] Enable dqlite disk mode
Jan 16 15:04:36 u1 microk8s.daemon-k8s-dqlite[11443]: I0116 19:04:36.636872   11443 log.go:198] WARNING: dqlite disk mode is current at an experimental state and SHOULD NOT be used in production. Expect data loss.
```