### PR TITLE
[main] Close the gap between test-upgrade-path in strict

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -256,3 +256,9 @@ def is_container():
         print("no indication of a container in /proc")
 
     return False
+
+
+def is_strict():
+    if "STRICT" in os.environ and os.environ["STRICT"] == "yes":
+        return True
+    return False


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
Closing upgrade path gap with strict

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
Closing upgrade path gap with strict

#### Testing
<!-- Please explain how you tested your changes. -->
Manually tested by running `test-upgrade-path`

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
