### PR TITLE
Increase daemon-containerd timeout and order daemon-kubelite after it

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -336,9 +336,11 @@ apps:
     # https://forum.snapcraft.io/t/process-lifecycle-on-snap-refresh/140/37
     stop-mode: sigterm
     restart-condition: always
+    start-timeout: 5m
   daemon-kubelite:
     command: run-kubelite-with-args
     daemon: simple
+    after: [daemon-containerd]
   daemon-apiserver-kicker:
     command: apiservice-kicker
     daemon: simple


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

Increase the start timeout of `daemon-containerd`.
Order the start of `daemon-kubelite` after it.

Closes #3684

#### Changes

Please see above; no user facing changes.

#### Testing

Please see #3684 for reproduction steps.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

Apparently no regressions from increasing the `daemon-containerd` timeout to 5 minutes.

There might delays in the setup/commands performed by `daemon-kubelite` until
up to `waiting for containerd socket` in `run-kubelite-with-args`, as it now starts
_after_ `daemon-containerd`, and not concurrently with it anymore.

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
(I think this ^ might not be needed per association with Canonical already?)
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
