### PR TITLE
Run GPU tests on 1.26

### DIFF
--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -143,3 +143,9 @@ if [ -d "/var/snap/microk8s/common/addons/eksd" ]
 then
   pytest -s /var/snap/microk8s/common/addons/eksd/tests/test-addons.py
 fi
+
+if [ -f "/var/snap/microk8s/common/addons/core/tests/test-addons.py" ] &&
+   grep test_gpu /var/snap/microk8s/common/addons/core/tests/test-addons.py -q
+then
+  timeout 3600 pytest -s /var/snap/microk8s/common/addons/core/tests/* -k gpu
+fi

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -147,5 +147,5 @@ fi
 if [ -f "/var/snap/microk8s/common/addons/core/tests/test-addons.py" ] &&
    grep test_gpu /var/snap/microk8s/common/addons/core/tests/test-addons.py -q
 then
-  timeout 3600 pytest -s /var/snap/microk8s/common/addons/core/tests/* -k gpu
+  timeout 3600 pytest -s /var/snap/microk8s/common/addons/core/tests/test-addons.py -k test_gpu
 fi


### PR DESCRIPTION
#### Summary
Run the GPU tests on the host since all tests are run in lxc containers

#### Changes
This work is in test-distro.sh

#### Testing
Manual

