### PR TITLE
Add arguments sanitisation when starting services (#3690) - 1.26-strict

### DIFF
--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -67,6 +67,19 @@ then
   fi
 fi
 
+# Sanatize arguments
+if [ -e $SNAP_DATA/var/lock/no-arg-sanitisation ] 
+then 
+  echo "Skipping argument sanitisation."
+else
+  echo "Sanitise arguments."
+  sanatise_argskubeapi_server
+  sanatise_argskubelet
+  sanatise_argskube_proxy
+  sanatise_argskube_scheduler
+  sanatise_argskube_controller_manager
+fi
+
 ## Kubelet configuration
 pod_cidr="$(cat $SNAP_DATA/args/kubelet | grep "pod-cidr" | tr "=" " "| gawk '{print $2}')"
 if [ -z "$pod_cidr" ]
@@ -187,14 +200,6 @@ if grep -E lxc /proc/1/environ &&
   ! grep -E "conntrack-max-per-core" $SNAP_DATA/args/kube-proxy
 then
   refresh_opt_in_local_config "conntrack-max-per-core" "0" kube-proxy
-fi
-
-# userspace proxy-mode is not allowed on the 1.26+ k8s
-# https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/#removal-of-kube-proxy-userspace-modes 
-if grep -- "--proxy-mode=userspace" $SNAP_DATA/args/kube-proxy
-then
-  echo "Removing --proxy-mode=userspace flag from kube-proxy, since it breaks Calico."
-  skip_opt_in_local_config "proxy-mode" "kube-proxy"
 fi
 
 if ! [ -f /proc/sys/net/bridge/bridge-nf-call-iptables ]

--- a/tests/test-upgrade-path.py
+++ b/tests/test-upgrade-path.py
@@ -58,7 +58,7 @@ class TestUpgradePath(object):
 
         # channel = "1.{}/stable".format(start_channel)
 
-        channel = "latest/edge/strict"
+        channel = "1.26-strict/edge"
         print("Installing {}".format(channel))
         cmd = "sudo snap install microk8s --channel={}".format(channel)
         run_until_success(cmd)


### PR DESCRIPTION
#### Summary
Add a function for all the services to remove deprecated arguments. Backporting https://github.com/canonical/microk8s/pull/3690 

#### Changes
Included a new util function for argument sanitization. Used this function in all the desired services.
