### PR TITLE
Add arguments sanitisation when starting services (#3690) - 1.25

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -220,6 +220,94 @@ skip_opt_in_config() {
 }
 
 
+remove_args() {
+  # Removes arguments from respective service
+  # argument $1: the service
+  # rest of arguments: the arguments to be removed
+  local service_name="$1"
+  shift
+  local args=("$@")
+  for arg in "${args[@]}"; do
+    if grep -q "$arg" "$SNAP_DATA/args/$service_name"; then
+      echo "Removing argument: $arg from $service_name"
+      skip_opt_in_local_config "$arg" "$service_name"
+    fi
+  done
+}
+
+
+sanatise_argskubeapi_server() {
+  # Function to sanitize arguments for API server
+  local args=(
+    # Remove insecure-port from 1.24+
+    "insecure-port"
+    "insecure-bind-address"
+    "port"
+    "address"
+    # Remove service-account-api-audiences from 1.25+
+    # https://github.com/kubernetes/kubernetes/commit/92707cafbb67a5664324eb891ef70ab3d1dd4a97
+    "service-account-api-audiences"
+    # extra
+    "feature-gates=RemoveSelfLink"
+    "experimental-encryption-provider-config"
+    "target-ram-mb"
+  )
+
+  remove_args "kube-apiserver" "${args[@]}"
+}
+
+
+sanatise_argskubelet() {
+  # Function to sanitize arguments for kubelet
+  local args=(
+    # Removed dockershim flags from 1.24+
+    # https://github.com/kubernetes/enhancements/issues/2221
+    "docker-endpoint"
+    "image-pull-progress-deadline"
+    "network-plugin"
+    "cni-conf-dir"
+    "cni-bin-dir"
+    "cni-cache-dir"
+    "network-plugin-mtu"
+    # extra
+    "experimental-kernel-memcg-notification"
+    "pod-infra-container-image"
+    "experimental-dockershim-root-directory"
+    "non-masquerade-cidr"
+  )
+
+  remove_args "kubelet" "${args[@]}"
+}
+
+
+sanatise_argskube_controller_manager() {
+  # Function to sanitize arguments for kube-controller-manager
+  local args=(
+    # Remove insecure ports from 1.24+
+    # https://github.com/kubernetes/kubernetes/pull/96216/files
+    "address"
+    "port"
+    # extra
+    "experimental-cluster-signing-duration"
+  )
+
+  remove_args "kube-controller-manager" "${args[@]}"
+}
+
+
+sanatise_argskube_scheduler() {
+  # Function to sanitize arguments for kube-scheduler
+  local args=(
+    # Remove insecure ports from 1.24+
+    # https://github.com/kubernetes/kubernetes/pull/96345/files
+    "address"
+    "port"
+  )
+
+  remove_args "kube-scheduler" "${args[@]}"
+}
+
+
 restart_service() {
     # restart a systemd service
     # argument $1 is the service name

--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -65,6 +65,18 @@ then
   fi
 fi
 
+# Sanatize arguments
+if [ -e $SNAP_DATA/var/lock/no-arg-sanitisation ] 
+then 
+  echo "Skipping argument sanitisation."
+else
+  echo "Sanitise arguments."
+  sanatise_argskubeapi_server
+  sanatise_argskubelet
+  sanatise_argskube_scheduler
+  sanatise_argskube_controller_manager
+fi
+
 ## Kubelet configuration
 pod_cidr="$(cat $SNAP_DATA/args/kubelet | grep "pod-cidr" | tr "=" " "| gawk '{print $2}')"
 if [ -z "$pod_cidr" ]


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
Add a function for all the services to remove deprecated arguments. Backporting https://github.com/canonical/microk8s/pull/3690 to 1.25

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
The --proxy-mode option is under a different business login in 1.25 so didn't removed it, by the extension of which there were not so many flags left in kube-proxy sanitisation function, nad hence removed it altogether.

#### Testing
<!-- Please explain how you tested your changes. -->

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
