### PR TITLE
Init configurations during install or with `snap set microk8s config=<config>`

### DIFF
--- a/microk8s-resources/microk8s.default.yaml
+++ b/microk8s-resources/microk8s.default.yaml
@@ -1,0 +1,5 @@
+# Default launch configuration for MicroK8s.
+---
+version: 0.1.0
+addons:
+  - name: dns

--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -81,6 +81,23 @@ do
     # Run reconcile hooks
     $SNAP/usr/bin/python3 $SNAP/scripts/run-lifecycle-hooks.py reconcile || true
 
+    # Apply configuration files from $SNAP_COMMON/etc/launcher/
+    match_config_files="${SNAP_COMMON}/etc/launcher/"*.yaml
+    for config in ${match_config_files}; do
+      # bash will return the regex if no files were found, in that case skip
+      if [ "${config}" == "${match_config_files}" ]; then
+        continue
+      fi
+
+      echo "Applying ${config}"
+      if "${SNAP}/bin/cluster-agent" init --config-file "${config}"; then
+        echo "Successfully applied ${config}"
+        mv "${config}" "${config}.applied"
+      else
+        echo "Failed to apply ${config}"
+      fi
+    done
+
     # If no local-registry-hosting documentation has been installed,
     # install a help guide that points to the microk8s registry docs.
     #

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -35,6 +35,24 @@ need_kubelet_restart=false
 need_controller_restart=false
 need_scheduler_restart=false
 
+# If the configurations directory is missing from SNAP_COMMON, we are upgrading from an older MicroK8s version.
+if [ ! -d "${SNAP_COMMON}/etc/launcher" ]
+then
+  mkdir -p "${SNAP_COMMON}/etc/launcher"
+fi
+
+# snap set microk8s config="$(cat config.yaml)"
+config="$(snapctl get config || true)"
+if [ ! -z "${config}" ]
+then
+  # Only write config file if not already applied.
+  applied_config="$(cat ${SNAP_COMMON}/etc/launcher/snap-set.yaml.applied || true)"
+  if [ -z "${applied_config}" ] || [ "${config}" != "${applied_config}" ]
+  then
+    echo "${config}" > "${SNAP_COMMON}/etc/launcher/snap-set.yaml"
+  fi
+fi
+
 # If the addons directory is missing from SNAP_COMMON, then we are upgrading from an older MicroK8s version.
 if [ ! -d "${SNAP_COMMON}/addons" ]
 then

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -14,7 +14,6 @@ export LD_LIBRARY_PATH="${SNAP}/lib:${SNAP}/usr/lib:${SNAP}/lib/$ARCH-linux-gnu:
 export PATH="${SNAP}/usr/sbin:${SNAP}/usr/bin:${SNAP}/sbin:${SNAP}/bin:$PATH:/usr/bin:/usr/local/bin"
 export OPENSSL_CONF="${SNAP}/etc/ssl/openssl.cnf"
 
-
 cp -r --preserve=mode ${SNAP}/default-args ${SNAP_DATA}/args
 mv ${SNAP_DATA}/args/certs.d/localhost__32000 ${SNAP_DATA}/args/certs.d/localhost:32000
 
@@ -27,6 +26,19 @@ then
 else
   echo "\`/var/lib/kubelet\` already exists.  Will not be linking to $SNAP_COMMON"
 fi
+
+# Copy initial configuration from well-known paths.
+# This is done prior to any other initialization.
+mkdir -p "${SNAP_COMMON}/etc/launcher"
+for config_file in /root/.microk8s.yaml /etc/microk8s.yaml "${SNAP}/microk8s.default.yaml"; do
+  if [ -f "${config_file}" ]; then
+    echo "Found config file ${config_file}, will use to initialize cluster."
+    cp "${config_file}" "${SNAP_COMMON}/etc/launcher/install.yaml" || true
+
+    # Stop on first file found
+    break
+  fi
+done
 
 # Create the certificates
 mkdir ${SNAP_DATA}/certs

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -268,6 +268,8 @@ parts:
         rm -rf "${SNAPCRAFT_PART_INSTALL}/*"
       fi
 
+      cp microk8s.default.yaml "${SNAPCRAFT_PART_INSTALL}/microk8s.default.yaml"
+
       cp -r default-args "${SNAPCRAFT_PART_INSTALL}/default-args"
       cp -r default-hooks "${SNAPCRAFT_PART_INSTALL}/default-hooks"
       cp -r certs "${SNAPCRAFT_PART_INSTALL}/certs"


### PR DESCRIPTION
### Summary

Allow setting MicroK8s configuration using:

- `snap set microk8s config="$(cat config.yaml)"` commands.
- An existing configuration file on the disk during the snap installation (for now: `/etc/microk8s.yaml` and `/root/.microk8s.yaml`)

### Implementation Notes

1. Configuration is only copied to `$SNAP_COMMON/etc/microk8s/{init,snap-set}.yaml` and is applied by the apiservice-kicker service. This decouples any long-running actions or actions that require the API server to be running (e.g. enable addons) from the actual snap installation.
2. If applied successfully, the files are renamed to have a `.applied` suffix and are then ignored. In the future, we might want to remove them completely after applying.
3. Configuration is applied using https://github.com/canonical/microk8s-cluster-agent/pull/11. In fact, this PR is non-functional until the `cluster-agent init` command implementation is merged.
4. We will not include a `snap set microk8s config-file=config.yaml` variant, since relative paths cannot be resolved by the `configure` hook.
5. The configure hook _must_ take care of creating `snap-set.yaml` only if the configuration has not been applied yet. This is because the configure runs in multiple scenarios (e.g. snap refresh), which would cause the configuration to be applied every time.

### Other Notes

The strict branch (https://github.com/canonical/microk8s/blob/strict/microk8s-resources/wrappers/apiservice-kicker#L103-L107) currently contains this hard-coded code:

```bash
      if [ -e $SNAP_COMMON/etc/launcher/configuration/config.yaml ] &&
         $SNAP/usr/bin/python3 $SNAP/scripts/launcher.py $SNAP_COMMON/etc/launcher/configuration/config.yaml
      then
        mv $SNAP_COMMON/etc/launcher/configuration/config.yaml $SNAP_COMMON/etc/launcher/configuration/config.yaml.applied
      fi
```

Perhaps there is value in adjusting the code accordingly, so that any configurations coming from the content interfaces are instead copied to `$SNAP_COMMON/etc/microk8s/`, and then no extra code is needed.

### Testing

Example config file:

```yaml
---
addons:
  - name: storage
  - name: dns
  - name: rbac
    disable: true
```

- `write /etc/microk8s.yaml && snap install microk8s`
- `snap install microk8s && snap set microk8s config="$(cat config.yaml)"`

The actual configuration testing is currently only unit-tested in https://github.com/canonical/microk8s-cluster-agent/pull/11
