### PR TITLE
[1.23] Use Go 1.19 to build Kubernetes

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -343,7 +343,7 @@ parts:
       - git
     override-build: |
       set -eux
-      snap refresh go --channel=1.17/stable || true
+      snap refresh go --channel=1.19/stable || true
       . ./set-env-variables.sh
 
       # if "${KUBE_SNAP_BINS}" exist we have to use the binaries from there


### PR DESCRIPTION
## Summary

Build Kubernetes binaries with Go 1.19, following upstream.