### PR TITLE
fix: openssl config path error in some distros when joining a cluster

### DIFF
--- a/microk8s-resources/wrappers/microk8s-join.wrapper
+++ b/microk8s-resources/wrappers/microk8s-join.wrapper
@@ -4,6 +4,7 @@ set -eu
 
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 ARCH="$($SNAP/bin/uname -m)"
+export OPENSSL_CONF="$SNAP/etc/ssl/openssl.cnf"
 export IN_SNAP_LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
 export PYTHONNOUSERSITE=false
 export LC_ALL="${LC_ALL:-C.UTF-8}"


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
MicroK8s by default looks for `openssl.cnf` from `/usr/lib/ssl/openssl.cnf` which does not exist on some distributions like Red Hat / Fedora / CentOS.

 Closes #3715

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
Explictly set the `openssl.cnf` path by setting `OPENSSL_CONF` environment variable for join script.

https://github.com/canonical/microk8s/blob/64d6d977ab3cf13624be44c78ddb65e77c06a649/microk8s-resources/wrappers/microk8s-join.wrapper#L7

#### Testing
<!-- Please explain how you tested your changes. -->
Manually tested

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
