### PR TITLE
Improvements to the init configuration

### DIFF
--- a/microk8s-resources/microk8s.default.yaml
+++ b/microk8s-resources/microk8s.default.yaml
@@ -1,5 +1,8 @@
 # Default launch configuration for MicroK8s.
 ---
 version: 0.1.0
+extraKubeletArgs:
+  --cluster-domain: cluster.local
+  --cluster-dns: 10.152.183.10
 addons:
   - name: dns

--- a/scripts/wrappers/disable.py
+++ b/scripts/wrappers/disable.py
@@ -35,7 +35,7 @@ def disable(addons):
     is_cluster_locked()
     exit_if_no_permission()
     ensure_started()
-    wait_for_ready(timeout=30)
+    wait_for_ready(timeout=30, with_ready_node=False)
 
     xable("disable", addons)
 

--- a/scripts/wrappers/enable.py
+++ b/scripts/wrappers/enable.py
@@ -32,7 +32,7 @@ def enable(addons) -> None:
     is_cluster_locked()
     exit_if_no_permission()
     ensure_started()
-    wait_for_ready(timeout=30)
+    wait_for_ready(timeout=30, with_ready_node=False)
 
     xable("enable", addons)
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -29,14 +29,24 @@ fi
 
 # Copy initial configuration from well-known paths.
 # This is done prior to any other initialization.
+#
+# The following paths are checked in order for a config file.
+# Only the first file found will be used, the rest will be ignored.
+#
+# - $SNAP_USER_COMMON/.microk8s.yaml  <-- user-defined config file, typically in /root/snap/microk8s/common/.microk8s.yaml
+# - $SNAP_COMMON/.microk8s.yaml       <-- user-defined config file, typically in /var/snap/microk8s/common/.microk8s.yaml
+# - $SNAP/microk8s.default.yaml       <-- default config file bundled with the snap
+#
+# If the pre-init step fails, the snap installation will fail, as it is considered to be a user error.
 mkdir -p "${SNAP_COMMON}/etc/launcher"
-for config_file in /root/.microk8s.yaml /etc/microk8s.yaml "${SNAP}/microk8s.default.yaml"; do
+for config_file in "$SNAP_USER_COMMON/.microk8s.yaml" "$SNAP_COMMON/.microk8s.yaml" "$SNAP/microk8s.default.yaml"; do
   if [ -f "${config_file}" ]; then
     echo "Found config file ${config_file}, will use to initialize cluster."
-    cp "${config_file}" "${SNAP_COMMON}/etc/launcher/install.yaml" || true
 
-    # Stop on first file found
-    break
+    if cp "${config_file}" "${SNAP_COMMON}/etc/launcher/install.yaml" then
+      "${SNAP}/bin/cluster-agent" init --pre-init --config-file "${SNAP_COMMON}/etc/launcher/install.yaml"
+      break
+    fi
   fi
 done
 


### PR DESCRIPTION
### Summary

Improvements to the init config file operations after initial feedback and implementation

### Changes

- Wait for API server to be ready, but not for nodes to reach a Ready state when running addon enable/disable commands
- Add pre-init step when applying the configuration. This allows supplying initial configurations to the services (e.g. initial kubelet args like cloud-provider integrations)
- Add kubelet args for DNS to the default configuration, to avoid apiserver restarting during initialization.

