### PR TITLE
remove air-gapped registry when offline tests finishes for 1.26

### DIFF
--- a/tests/test-airgap.sh
+++ b/tests/test-airgap.sh
@@ -98,5 +98,5 @@ lxc exec airgap-test -- bash -c 'sudo microk8s enable hostpath-storage dns'
 airgap_wait_for_pods airgap-test
 
 echo "Cleaning up"
-# lxc rm airgap-registry --force
+lxc rm airgap-registry --force
 lxc rm airgap-test --force


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
Backport #3716 to 1.26

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
