### PR TITLE
Prevent force-restart of Calico pods right after install

### DIFF
--- a/microk8s-resources/default-hooks/reconcile.d/90-calico-apply
+++ b/microk8s-resources/default-hooks/reconcile.d/90-calico-apply
@@ -12,5 +12,8 @@ then
   if (is_apiserver_ready) && "${KUBECTL}" apply -f "${SNAP_DATA}/args/cni-network/cni.yaml"
   then
     touch "${SNAP_DATA}/var/lock/cni-loaded"
+
+    # We just installed Calico, no need to refresh
+    rm "${SNAP_DATA}/var/lock/cni-needs-reload" || true
   fi
 fi


### PR DESCRIPTION
### Summary

After initial installation, we load the Calico CNI to the MicroK8s node.

However, the `configure` hook always touches the `cni-needs-reload` file, which is reconciled by force restarting the Calico pods. This is required to update the host mounts when the snap refreshes, but should be avoided when first installing MicroK8s.

Right now, all this does is delay the initial start of Calico.