### PR TITLE
Lowercase hostname for kubernetes RBAC

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -789,7 +789,7 @@ function update_configs {
   $SNAP/bin/sed -i 's/PASSWORD/'"${admin_token}"'/g' ${SNAP_DATA}/credentials/client.config
   # Create the known tokens
   proxy_token=`grep kube-proxy ${SNAP_DATA}/credentials/known_tokens.csv | cut -d, -f1`
-  hostname=$(hostname)
+  hostname=$(hostname | tr '[:upper:]' '[:lower:]')
   kubelet_token=`grep kubelet-0, ${SNAP_DATA}/credentials/known_tokens.csv | cut -d, -f1`
   controller_token=`grep kube-controller-manager ${SNAP_DATA}/credentials/known_tokens.csv | cut -d, -f1`
   scheduler_token=`grep kube-scheduler ${SNAP_DATA}/credentials/known_tokens.csv | cut -d, -f1`

--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -153,7 +153,7 @@ def get_connection_info(
         if cluster_type == "dqlite":
             req_data = {
                 "token": token,
-                "hostname": socket.gethostname(),
+                "hostname": socket.gethostname().lower(),
                 "port": cluster_agent_port,
                 "worker": worker,
             }
@@ -162,7 +162,7 @@ def get_connection_info(
         else:
             req_data = {
                 "token": token,
-                "hostname": socket.gethostname(),
+                "hostname": socket.gethostname().lower(),
                 "port": cluster_agent_port,
                 "callback": callback_token,
             }
@@ -450,7 +450,7 @@ def update_cert_auth_kubelet(token, ca, master_ip, master_port):
     """
     kubelet_token = "{}-kubelet".format(token)
     traefik_port = get_traefik_port()
-    kubelet_user = "system:node:{}".format(socket.gethostname())
+    kubelet_user = "system:node:{}".format(socket.gethostname().lower())
     cert = get_client_cert(
         master_ip, master_port, "kubelet", kubelet_token, kubelet_user, "system:nodes"
     )

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -261,7 +261,7 @@ then
   touch ${SNAP_DATA}/credentials/known_tokens.csv
   chmod 660 ${SNAP_DATA}/credentials/known_tokens.csv
   kubelet_token=$(openssl rand -base64 32 | ${SNAP}/usr/bin/base64)
-  hostname=$(hostname)
+  hostname=$(hostname | tr '[:upper:]' '[:lower:]')
   echo "${kubelet_token},system:node:${hostname},kubelet-0,\"system:nodes\"" >> ${SNAP_DATA}/credentials/known_tokens.csv
   ca_data=$(cat ${SNAP_DATA}/certs/ca.crt | ${SNAP}/usr/bin/base64 -w 0)
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -68,7 +68,7 @@ echo "${admin_token},admin,admin,\"system:masters\"" > ${SNAP_DATA}/credentials/
 proxy_token=$(${SNAP}/usr/bin/openssl rand -base64 32 | ${SNAP}/usr/bin/base64)
 echo "${proxy_token},system:kube-proxy,kube-proxy" >> ${SNAP_DATA}/credentials/known_tokens.csv
 kubelet_token=$(${SNAP}/usr/bin/openssl rand -base64 32 | ${SNAP}/usr/bin/base64)
-hostname=$(hostname)
+hostname=$(hostname | tr '[:upper:]' '[:lower:]')
 echo "${kubelet_token},system:node:${hostname},kubelet-0,\"system:nodes\"" >> ${SNAP_DATA}/credentials/known_tokens.csv
 controller_token=$(${SNAP}/usr/bin/openssl rand -base64 32 | ${SNAP}/usr/bin/base64)
 echo "${controller_token},system:kube-controller-manager,controller" >> ${SNAP_DATA}/credentials/known_tokens.csv


### PR DESCRIPTION
### Summary

Closes #3270 

Make sure to convert the hostname to lowercase when creating Kubernetes certs and tokens. Otherwise, RBAC might fail (e.g. a kubelet token for `system:node:MYNODE` is created, but the kubelet should instead be `system:node:mynode`.

