### PR TITLE
microk8s refresh-certs use new csr.conf.template

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -312,7 +312,7 @@ sanatise_argskube_proxy() {
   # Function to sanitize arguments for kube-proxy
 
   # userspace proxy-mode is not allowed on the 1.26+ k8s
-  # https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/#removal-of-kube-proxy-userspace-modes 
+  # https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/#removal-of-kube-proxy-userspace-modes
   if grep -- "--proxy-mode=userspace" $SNAP_DATA/args/kube-proxy
   then
     echo "Removing --proxy-mode=userspace flag from kube-proxy, since it breaks Calico."
@@ -593,6 +593,11 @@ gen_proxy_client_cert() (
     ${SNAP}/usr/bin/openssl req -new -sha256 -key ${SNAP_DATA}/certs/front-proxy-client.key -out ${SNAP_DATA}/certs/front-proxy-client.csr -config <(sed '/^prompt = no/d' ${SNAP_DATA}/certs/csr.conf) -subj "/CN=front-proxy-client"
     ${SNAP}/usr/bin/openssl x509 -req -sha256 -in ${SNAP_DATA}/certs/front-proxy-client.csr -CA ${SNAP_DATA}/certs/front-proxy-ca.crt -CAkey ${SNAP_DATA}/certs/front-proxy-ca.key -CAcreateserial -out ${SNAP_DATA}/certs/front-proxy-client.crt -days 365 -extensions v3_ext -extfile ${SNAP_DATA}/certs/csr.conf
 )
+
+refresh_csr_conf() {
+  render_csr_conf
+  cp ${SNAP_DATA}/certs/csr.conf.rendered ${SNAP_DATA}/certs/csr.conf
+}
 
 produce_certs() {
     export OPENSSL_CONF="${SNAP}/etc/ssl/openssl.cnf"

--- a/scripts/wrappers/refresh_certs.py
+++ b/scripts/wrappers/refresh_certs.py
@@ -128,10 +128,15 @@ def reproduce_front_proxy_client_cert():
     Produce the front proxy client certificate
     """
     subprocess.check_call("rm -rf {}/certs/front-proxy-client.crt".format(snapdata_path).split())
-    p = subprocess.Popen(
-        ["bash", "-c", ". {}/actions/common/utils.sh; gen_proxy_client_cert".format(snap_path)]
+    subprocess.check_call(
+        [
+            "bash",
+            "-c",
+            ". {}/actions/common/utils.sh; refresh_csr_conf; gen_proxy_client_cert".format(
+                snap_path
+            ),
+        ]
     )
-    p.communicate()
     subprocess.check_call("rm -rf .slr".split())
     restart("kubelite")
 
@@ -141,10 +146,13 @@ def reproduce_server_cert():
     Produce the server certificate
     """
     subprocess.check_call("rm -rf {}/certs/server.crt".format(snapdata_path).split())
-    p = subprocess.Popen(
-        ["bash", "-c", ". {}/actions/common/utils.sh; gen_server_cert".format(snap_path)]
+    subprocess.check_call(
+        [
+            "bash",
+            "-c",
+            ". {}/actions/common/utils.sh; refresh_csr_conf; gen_server_cert".format(snap_path),
+        ]
     )
-    p.communicate()
     subprocess.check_call("rm -rf .slr".split())
     restart("kubelite")
     restart("cluster-agent")

--- a/tests/unit/test_refresh_certs.py
+++ b/tests/unit/test_refresh_certs.py
@@ -44,54 +44,42 @@ class TestRefreshCerts(object):
         assert self.is_argument_in_call(mock_subproc_popen, "update_configs")
 
     @patch("refresh_certs.restart")
-    @patch("subprocess.Popen")
     @patch("subprocess.check_call")
-    def test_reproduce_front_proxy_client_cert(
-        self, mock_check_call, mock_subproc_popen, mock_restart
-    ):
-        process_mock = Mock()
-        mock_subproc_popen.return_value = process_mock
-
-        reproduce_front_proxy_client_cert()
-
+    def test_reproduce_front_proxy_client_cert(self, mock_check_call, mock_restart):
         """
         Make sure we:
         1. remove the front-proxy-client.crt
         2. call gen_proxy_client_cert
         3. restart microk8s
         """
+        reproduce_front_proxy_client_cert()
+
         snapdata_path = os.environ.get("SNAP_DATA")
         cmd = "rm -rf {}/certs/front-proxy-client.crt".format(snapdata_path).split()
         assert call(cmd) in mock_check_call.call_args_list
         assert mock_check_call.called
-        assert mock_subproc_popen.called
         assert mock_restart.called
-        assert self.is_argument_in_call(mock_subproc_popen, "gen_proxy_client_cert")
+        assert self.is_argument_in_call(mock_check_call, "gen_proxy_client_cert")
 
     @patch("refresh_certs.restart")
-    @patch("subprocess.Popen")
     @patch("subprocess.check_call")
-    def test_reproduce_server_cert(self, mock_check_call, mock_subproc_popen, mock_restart):
-        process_mock = Mock()
-        mock_subproc_popen.return_value = process_mock
-
-        reproduce_server_cert()
-
+    def test_reproduce_server_cert(self, mock_check_call, mock_restart):
         """
         Make sure we:
         1. remove the server.crt
         2. call gen_server_cert
         3. restart microk8s
         """
+        reproduce_server_cert()
+
         snapdata_path = os.environ.get("SNAP_DATA")
         assert (
             call("rm -rf {}/certs/server.crt".format(snapdata_path).split())
             in mock_check_call.call_args_list
         )
         assert mock_check_call.called
-        assert mock_subproc_popen.called
         assert mock_restart.called
-        assert self.is_argument_in_call(mock_subproc_popen, "gen_server_cert")
+        assert self.is_argument_in_call(mock_check_call, "gen_server_cert")
 
     def is_argument_in_call(self, mock_function, argument_substring):
         """Search for a substring in the list of arguments in all calls of a mocked function"""


### PR DESCRIPTION
### Summary

Closes #3241

Replaces #3182, doing the same thing while touching less critical parts of the codebase.

Thanks @dud225 for the initial work.
