### PR TITLE
Added tests for mixed version clusters

### DIFF
--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -39,7 +39,8 @@ class VM:
             self.vm_name = attach_vm
 
     def setup(self, channel_or_snap):
-        """Setup the VM with the right snap.
+        """
+        Setup the VM with the right snap.
 
         :param channel_or_snap: the snap channel or the path to the local snap build
         """
@@ -413,7 +414,7 @@ class TestCluster(object):
                     continue
             break
 
-    def test_worker_noode(self):
+    def test_worker_node(self):
         """
         Test a worker node is setup
         """
@@ -463,3 +464,79 @@ class TestCluster(object):
         for vm in self.VM:
             lock_files = vm.run("ls /var/snap/microk8s/current/var/lock/")
             assert "no-cert-reissue" in lock_files.decode()
+
+class TestUpgradeCluster(object):
+    def test_mixed_version_join(self):
+        """
+        Test n versioned node joining a n-1 versioned node
+        """
+        try:
+            print("Setting up cluster with nodes of different versions")
+            type(self).VM = []
+            versions = ["1.23/stable", "1.24/stable", "1.25/stable", "1.26/stable"]
+            cluster_size = 2
+
+            # For all the versions
+            for i in range(0, len(versions)-1):
+                # We need to test join of a node with a lower versioned cluster
+                # So only 2 nodes are created at a time
+                for j in range(0, cluster_size):
+                    print("Creating machine with version {}".format(versions[i+j]))
+                    vm = VM(backend)
+                    vm.setup(versions[i+j])
+                    print("Waiting for machine with version {}".format(versions[i+j]))
+                    vm.run("/snap/bin/microk8s.status --wait-ready --timeout 120")
+                    self.VM.append(vm)
+
+
+                # Form cluster
+                vm_lower_version = self.VM[i]
+                connected_nodes = vm_lower_version.run("/snap/bin/microk8s.kubectl get no")
+                for vm in self.VM:
+                    if vm.vm_name in connected_nodes.decode():
+                        continue
+                    else:
+                        print("Adding machine {} to cluster".format(vm.vm_name))
+                        add_node = vm_lower_version.run("/snap/bin/microk8s.add-node")
+                        endpoint = [ep for ep in add_node.decode().split() if ":25000/" in ep]
+                        vm.run("/snap/bin/microk8s.join {}".format(endpoint[0]))
+
+                # Wait for nodes to be ready
+                print("Waiting for nodes to register")
+                attempt = 0
+                while attempt < 10:
+                    try:
+                        connected_nodes = vm_lower_version.run("/snap/bin/microk8s.kubectl get no")
+                        if "NotReady" in connected_nodes.decode():
+                            time.sleep(5)
+                        connected_nodes = vm_lower_version.run("/snap/bin/microk8s.kubectl get no")
+                        print(connected_nodes.decode())
+                        break
+                    except ChildProcessError:
+                        time.sleep(10)
+                        attempt += 1
+                        if attempt == 10:
+                            raise
+
+                # Wait for CNI pods
+                print("Waiting for cni")
+                while True:
+                    ready_pods = 0
+                    pods = vm_lower_version.run("/snap/bin/microk8s.kubectl get po -n kube-system -o wide")
+                    for line in pods.decode().splitlines():
+                        if "calico" in line and "Running" in line:
+                            ready_pods += 1
+                    if ready_pods == cluster_size:
+                        print(pods.decode())
+                        break
+                    time.sleep(5)
+
+                print("Releasing lower versioned machine {} in {}".format(vm_lower_version.vm_name, vm_lower_version.backend))
+                vm_lower_version.release()
+
+        finally:
+            print("Cleanup up cluster")
+            if not reuse_vms:
+                for vm in self.VM:
+                    print("Releasing machine {} in {}".format(vm.vm_name, vm.backend))
+                    vm.release()


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
Added tests for mixed version clustering after we removed flags from previous versions which were causing the newer node to fail while joining the older node cluster.

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
Introduced a new class `TestUpgradeCluster` in `test-cluster.py` which creates 2 nodes of different versions and joins them.

#### Testing
<!-- Please explain how you tested your changes. -->

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->
Hopefully none!!

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
