### PR TITLE
update flanneld and cni to support ipv6 nat

### DIFF
--- a/build-scripts/components/cni/patches/0001-single-entrypoint-for-cni-tools.patch
+++ b/build-scripts/components/cni/patches/0001-single-entrypoint-for-cni-tools.patch
@@ -1,11 +1,11 @@
-From 91f16e8232437292eab8308250ca5d73ea9c4753 Mon Sep 17 00:00:00 2001
-From: Angelos Kolaitis <neoaggelos@gmail.com>
-Date: Fri, 22 Jul 2022 18:41:36 +0300
+From 3d0636d0ad86c9050da190b50bc01387d71dc80a Mon Sep 17 00:00:00 2001
+From: MicroK8s builder bot <microk8s-builder-bot@canonical.com>
+Date: Sun, 12 Feb 2023 13:34:45 +0000
 Subject: [PATCH] single entrypoint for cni tools
 
 ---
- cni.go | 56 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 56 insertions(+)
+ cni.go | 54 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 54 insertions(+)
  create mode 100644 cni.go
 
 diff --git a/cni.go b/cni.go
@@ -13,7 +13,7 @@ new file mode 100644
 index 0000000..93828f9
 --- /dev/null
 +++ b/cni.go
-@@ -0,0 +1,56 @@
+@@ -0,0 +1,54 @@
 +package main
 +
 +import (
@@ -35,7 +35,6 @@ index 0000000..93828f9
 +	main_vlan "github.com/containernetworking/plugins/plugins/main/vlan"
 +
 +	meta_bandwidth "github.com/containernetworking/plugins/plugins/meta/bandwidth"
-+	meta_flannel "github.com/containernetworking/plugins/plugins/meta/flannel"
 +	meta_firewall "github.com/containernetworking/plugins/plugins/meta/firewall"
 +	meta_portmap "github.com/containernetworking/plugins/plugins/meta/portmap"
 +	meta_sbr "github.com/containernetworking/plugins/plugins/meta/sbr"
@@ -63,12 +62,11 @@ index 0000000..93828f9
 +	reexec.Register("ptp", main_ptp.Main)
 +	reexec.Register("vlan", main_vlan.Main)
 +	reexec.Register("bandwidth", meta_bandwidth.Main)
-+	reexec.Register("flannel", meta_flannel.Main)
 +	reexec.Register("firewall", meta_firewall.Main)
 +	reexec.Register("portmap", meta_portmap.Main)
 +	reexec.Register("sbr", meta_sbr.Main)
 +	reexec.Register("tuning", meta_tuning.Main)
 +	reexec.Register("vrf", meta_vrf.Main)
 +}
---
+-- 
 2.25.1

--- a/build-scripts/components/cni/version.sh
+++ b/build-scripts/components/cni/version.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Match https://github.com/kubernetes/kubernetes/blob/master/build/dependencies.yaml#L20
-echo "v0.9.1"
+echo "v1.2.0"

--- a/build-scripts/components/flanneld/patches/0001-disable-udp-backend.patch
+++ b/build-scripts/components/flanneld/patches/0001-disable-udp-backend.patch
@@ -1,6 +1,6 @@
-From 1be61878980de11932c1efc7cf4652904dfc3515 Mon Sep 17 00:00:00 2001
+From a395af4fe79f292cc60168898052d2d5e496e5f7 Mon Sep 17 00:00:00 2001
 From: MicroK8s builder bot <microk8s-builder-bot@canonical.com>
-Date: Mon, 1 Aug 2022 18:31:03 +0300
+Date: Sun, 12 Feb 2023 12:42:06 +0000
 Subject: [PATCH] disable udp backend
 
 ---
@@ -8,18 +8,17 @@ Subject: [PATCH] disable udp backend
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/main.go b/main.go
-index 4fd8f7f..0b3cc1c 100644
+index 0d72bee..b6ef4b4 100644
 --- a/main.go
 +++ b/main.go
-@@ -55,7 +55,7 @@ import (
+@@ -54,7 +54,7 @@ import (
  	_ "github.com/flannel-io/flannel/backend/ipip"
  	_ "github.com/flannel-io/flannel/backend/ipsec"
  	_ "github.com/flannel-io/flannel/backend/tencentvpc"
 -	_ "github.com/flannel-io/flannel/backend/udp"
 +	// _ "github.com/flannel-io/flannel/backend/udp"
  	_ "github.com/flannel-io/flannel/backend/vxlan"
+ 	_ "github.com/flannel-io/flannel/backend/wireguard"
  )
- 
 -- 
-2.34.1
-
+2.25.1

--- a/build-scripts/components/flanneld/version.sh
+++ b/build-scripts/components/flanneld/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v0.15.1"
+echo "v0.17.0"


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
This PR update flanneld to v0.17.0 and cni to v1.2.0

The motive of this PR is to let microk8s able to communicate with service over ipv6 with some extra configuration in non-ha cluster

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
Update flanneld to v0.17.0 and cni to v1.2.0

#### Testing
<!-- Please explain how you tested your changes. -->
`snap install microk8s_v1.26.1_amd64.snap --classic --dangerous`
`microk8s disable ha-cluster --force`
`microk8s enable dns`
`nano /var/snap/microk8s/current/args/flannel-network-mgr-config`
The content should be:
```
{
  "Network": "10.1.0.0/16",
  "Backend": {
    "Type": "vxlan"
  },
  "EnableIPv6": true,
  "IPv6Network": "fd01::/64"
}
```
`reboot`
`microk8s.kubectl run -it --rm ipv6 --image=ubuntu -- bash`
`apt update && apt install curl -y && curl ipv6.icanhazip.com`
It should return the host ipv6 after running the last command

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->
Multi-cluster environment isn't tested yet

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
- `flanneld` updated to v0.17.0 instead of latest is because that version is the last version that still uses etcv2 and still support ipv6 nat (flannel-io/flannel#1562)
- `cni` needs to update to at least v1.0.1 due to [this](https://github.com/flannel-io/flannel/blob/v0.17.0/Documentation/configuration.md#dual-stack:~:text=v1.0.1%20of%20flannel%20binary%20from%20containernetworking/plugins) requirement
- The `flannel-network-mgr-config` configuration documentation can be found [here](https://github.com/flannel-io/flannel/blob/v0.17.0/Documentation/configuration.md#configuration)
- These commands can be followed to enable ipv6 ingress which is based on [this](https://discuss.kubernetes.io/t/microk8s-ipv6-dualstack-how-to/14507) discussion:
`nano /var/snap/microk8s/current/args/kube-proxy`
Change `--cluster-cidr=10.1.0.0/16` to `--cluster-cidr=10.1.0.0/16,fd01::/64`
`nano /var/snap/microk8s/current/args/kube-apiserver`
Change `--service-cluster-ip-range=10.152.183.0/24` to `--service-cluster-ip-range=10.152.183.0/24,fd98::/108`
`nano /var/snap/microk8s/current/args/kube-controller-manager`
Add `--service-cluster-ip-range=10.152.183.0/24,fd98::/108` and `--cluster-cidr=10.1.0.0/16,fd01::/64`