### PR TITLE
[backport/1.25] Increase daemon-containerd timeout and order daemon-kubelite after it

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -290,9 +290,11 @@ apps:
     # https://forum.snapcraft.io/t/process-lifecycle-on-snap-refresh/140/37
     stop-mode: sigterm
     restart-condition: always
+    start-timeout: 5m
   daemon-kubelite:
     command: run-kubelite-with-args
     daemon: simple
+    after: [daemon-containerd]
   daemon-apiserver-kicker:
     command: apiservice-kicker
     daemon: simple


### PR DESCRIPTION
This is a cherry-pick of PR #3685 to release branch 1.25.

Summary of test steps (see PR for details):

Before:
```
$ sudo snap install microk8s --classic --channel=1.25/edge
$ snap info microk8s | grep 1.25/edge:
  1.25/edge:             v1.25.6         2023-02-09 (4677) 175MB classic
...
$ systemctl show snap.microk8s.daemon-containerd.service | grep NRestarts
NRestarts=3
$ systemctl show snap.microk8s.daemon-kubelite.service | grep NRestarts
NRestarts=12
```

After:
```
$ git log --oneline -2
b0a417c039c8 (daemon-containerd-timeout-1.25) Increase daemon-containerd timeout and order daemon-kubelite after it (#3685)
a15a5691c159 (origin/1.25) Update containerd to 1.6.15 (#3745)

$ sudo snap install ./microk8s_v1.25.6_amd64.snap --classic --dangerous
...
$ systemctl show snap.microk8s.daemon-containerd.service | grep NRestarts
NRestarts=0
$ systemctl show snap.microk8s.daemon-kubelite.service | grep NRestarts
NRestarts=0
```




<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

#### Testing
<!-- Please explain how you tested your changes. -->

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [ ] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
