### PR TITLE
[backport/1.24] Increase daemon-containerd timeout and order daemon-kubelite after it

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,10 +28,12 @@ apps:
     # https://forum.snapcraft.io/t/process-lifecycle-on-snap-refresh/140/37
     stop-mode: sigterm
     restart-condition: always
+    start-timeout: 5m
     plugs: [kubernetes-support]
   daemon-kubelite:
     command: run-kubelite-with-args
     daemon: simple
+    after: [daemon-containerd]
   daemon-apiserver:
     command: run-null-daemon
     daemon: simple


### PR DESCRIPTION
This is a cherry-pick of PR #3685 to release branch 1.24 (trivial backport).

Summary of test steps (see PR for details):

Before:
```
$ sudo snap install microk8s --classic --channel=1.24/edge
$ snap info microk8s | grep 1.24/edge:
  1.24/edge:             v1.24.10        2023-02-03 (4638) 224MB classic
...
$ systemctl show snap.microk8s.daemon-containerd.service | grep NRestarts
NRestarts=3
$ systemctl show snap.microk8s.daemon-kubelite.service | grep NRestarts
NRestarts=13

```

After:
```
$ git log --oneline -2
ca3b5bb31b0c (daemon-containerd-timeout-1.24) Increase daemon-containerd timeout and order daemon-kubelite after it (#3685)
6bc7a2979987 (origin/1.24) update list of images used by 1.24 (#3727)

$ sudo snap install ./microk8s_v1.24.10_amd64.snap --classic --dangerous
...
$ systemctl show snap.microk8s.daemon-containerd.service | grep NRestarts
NRestarts=0
$ systemctl show snap.microk8s.daemon-kubelite.service | grep NRestarts
NRestarts=0
```



<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

#### Testing
<!-- Please explain how you tested your changes. -->

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [ ] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
