### PR TITLE
#Fixes 3243

### DIFF
--- a/scripts/wrappers/reset.py
+++ b/scripts/wrappers/reset.py
@@ -232,7 +232,7 @@ def remove_extra_resources(ns_name):
     for rs in extra_resources:
         if rs.startswith("apiservices"):
             continue
-        cmd = [KUBECTL, "delete", "--all", "-n", ns_name, "--timeout=60s"]
+        cmd = [KUBECTL, "delete", "--all", rs, "-n", ns_name, "--timeout=60s"]
         subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
Updated [`remove_extra_resources`](https://github.com/canonical/microk8s/blob/master/scripts/wrappers/reset.py#L225) function used in `microk8s reset` command to delete extra resources (e.g., `services`). As the command created in this function did not include the resources to delete and executing the command in `subprocess.run` would possibly fail silently, those resources were available even after the reset (see change below).
This in turn might lead and lead to unintended side-effects. For example, surviving resources caused the configuration issue described in #1823 in my local setup.   

Closes #3243  
References #1823

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
In [line 235](https://github.com/canonical/microk8s/blob/master/scripts/wrappers/reset.py#L235) I added the `rs` variable from the `for` loop to the creation of the `cmd` variable (similar to [line 128](https://github.com/canonical/microk8s/blob/master/scripts/wrappers/reset.py#L128)). 

#### Testing
<!-- Please explain how you tested your changes. -->
1. Build and installed microk8s locally following (https://github.com/canonical/microk8s/blob/master/docs/build.md)[https://github.com/canonical/microk8s/blob/master/docs/build.md].

2. Created test `service` and `configMap` using the following files
``` yaml
apiVersion: v1
kind: Service
metadata:
  name: my-service
spec:
  selector:
    app.kubernetes.io/name: MyApp
  ports:
    - protocol: TCP
      port: 80
      targetPort: 9376
```  
and 

``` yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: game-demo
data:
  # property-like keys; each key maps to a simple value
  player_initial_lives: "3"
  ui_properties_file_name: "user-interface.properties"

  # file-like keys
  game.properties: |
    enemy.types=aliens,monsters
    player.maximum-lives=5    
  user-interface.properties: |
    color.good=purple
    color.bad=yellow
    allow.textmode=true 
``` 

3. Verified creation of `service`and `configMap` in default namespace using the following commands:
- `sudo microk8s kubectl get svc`
- `sudo microk8s kubectl get configMaps`

4. Executed `microk8s reset`

5. Verified that resources were deleted as expected using command from step 3.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->
As changes are local to only one function of the `reset.py` script, it is believed that no other functions are impacted

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
As far as I could see, the `reset.py` script was not covered by unit test, however, the changes and the expected behavior was successfully tested manually as described above. 