### PR TITLE
Cluster agent built for FIPS

### DIFF
--- a/build-scripts/components/cluster-agent/build.sh
+++ b/build-scripts/components/cluster-agent/build.sh
@@ -4,5 +4,6 @@ export INSTALL="${1}/bin"
 export GOEXPERIMENT=opensslcrypto
 mkdir -p "${INSTALL}"
 
-make cluster-agent
+go mod tidy
+CGO_ENABLED=1 go build -o cluster-agent ./main.go
 cp cluster-agent "${INSTALL}"

--- a/build-scripts/components/cluster-agent/build.sh
+++ b/build-scripts/components/cluster-agent/build.sh
@@ -4,6 +4,5 @@ export INSTALL="${1}/bin"
 export GOEXPERIMENT=opensslcrypto
 mkdir -p "${INSTALL}"
 
-go mod tidy
 CGO_ENABLED=1 go build -o cluster-agent ./main.go
 cp cluster-agent "${INSTALL}"

--- a/microk8s-resources/default-args/cluster-agent-env
+++ b/microk8s-resources/default-args/cluster-agent-env
@@ -1,0 +1,5 @@
+# In a node where FIPS is enabled, ie /proc/sys/crypto/fips_enabled is set to 1
+# Force FIPS to be used with. If not set GOFIPS is implicetely selected.
+export GOFIPS=0
+# Point to the location of libcrypto.so
+# export LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/"

--- a/microk8s-resources/wrappers/run-cluster-agent-with-args
+++ b/microk8s-resources/wrappers/run-cluster-agent-with-args
@@ -14,6 +14,13 @@ export LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 export OPENSSL_CONF="$SNAP/etc/ssl/openssl.cnf"
 
+set -a
+if [ -e "${SNAP_DATA}/args/cluster-agent-env" ]
+then
+  . "${SNAP_DATA}/args/cluster-agent-env"
+fi
+set +a
+
 # This is really the only way I could find to get the args passed in correctly.
 declare -a args="($(cat $SNAP_DATA/args/cluster-agent))"
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -233,6 +233,7 @@ parts:
   cluster-agent:
     after: [build-deps]
     plugin: nil
+    build-attributes: [no-patchelf]
     source: build-scripts/components/cluster-agent
     override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh cluster-agent
 


### PR DESCRIPTION
Same as k8s-dqlite and k8s services. Building the cluster-agent with cgo support and having an env file to load the right libs before starting the service.