### PR TITLE
Require root for microk8s addons commands

### DIFF
--- a/scripts/wrappers/addons.py
+++ b/scripts/wrappers/addons.py
@@ -11,7 +11,7 @@ import click
 import jsonschema
 import yaml
 
-from common.utils import get_current_arch, snap_common, get_group, snap
+from common.utils import get_current_arch, snap_common, get_group, snap, exit_if_no_root
 
 GIT = os.path.expandvars("$SNAP/git.wrapper")
 
@@ -229,7 +229,11 @@ def remove(name: str):
 
 @repository.command("update", help="Update a MicroK8s addons repository")
 @click.argument("name")
-def update(name: str):
+@click.option("--skip-check-root/--no-skip-check-root", is_flag=True, default=False)
+def update(name: str, skip_check_root: bool):
+    if not skip_check_root:
+        exit_if_no_root()
+
     repo_dir = snap_common() / "addons" / name
     if not repo_dir.exists():
         click.echo("Error: repository '{}' does not exist".format(name), err=True)

--- a/tests/unit/test_addons.py
+++ b/tests/unit/test_addons.py
@@ -328,7 +328,7 @@ def test_update_rollbacks_repo_on_validation_error(
     with create_test_repo("repo_to_update") as repo_dir:
 
         with pytest.raises(SystemExit):
-            update.callback("repo_to_update")
+            update.callback("repo_to_update", skip_check_root=True)
 
         validate_addons_repo_mock.assert_called_once_with(repo_dir)
         git_current_commit_mock.assert_called_once_with(repo_dir)


### PR DESCRIPTION
### Summary

Closes https://github.com/canonical/microk8s/issues/3730

The root cause behind the issue is the way git treats repositories where the current user is different from the owner of the repository.

Temporarily work around the issue by requiring root, which also makes sense from a security perspective.