### PR TITLE
Initial implementation of image side-loading during install

### DIFF
--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -81,7 +81,24 @@ do
     # Run reconcile hooks
     $SNAP/usr/bin/python3 $SNAP/scripts/run-lifecycle-hooks.py reconcile || true
 
-    # Apply configuration files from $SNAP_COMMON/etc/launcher/
+    # Side-load images from $SNAP_COMMON/etc/sideload/*.tar
+    match_sideload_tars="${SNAP_COMMON}/etc/sideload/"*.tar
+    for sideload_tar in ${match_sideload_tars}; do
+      # bash will return the regex if no files were found, in that case skip
+      if [ "${sideload_tar}" == "${match_sideload_tars}" ]; then
+        continue
+      fi
+
+      echo "Side-load ${sideload_tar} into containerd"
+      if "${SNAP}/microk8s-ctr.wrapper" image import "${sideload_tar}"; then
+        echo "Success!"
+        mv "${sideload_tar}" "${sideload_tar}.applied"
+      else
+        echo "Failed to sideload ${sideload_tar}, will retry"
+      fi
+    done
+
+    # Apply configuration files from $SNAP_COMMON/etc/launcher/*.yaml
     match_config_files="${SNAP_COMMON}/etc/launcher/"*.yaml
     for config in ${match_config_files}; do
       # bash will return the regex if no files were found, in that case skip

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -55,6 +55,19 @@ for config_file in "$SNAP_USER_COMMON/.microk8s.yaml" "$SNAP_COMMON/.microk8s.ya
   fi
 done
 
+# Side-load images from well-known paths.
+# This is done prior to any other initialization.
+#
+# Any *.tar files that are found in these directories will be loaded into containerd after it starts.
+#
+# - $SNAP_USER_COMMON/sideload/*.tar  <-- typically /root/snap/microk8s/common/sideload/images.tar
+# - $SNAP_COMMON/sideload/*.tar       <-- typically /var/snap/microk8s/common/sideload/images.tar
+# - $SNAP/sideload/*.tar              <-- typically empty, reserved for future use-cases
+mkdir -p "${SNAP_COMMON}/etc/sideload"
+for source_dir in "${SNAP_USER_COMMON}" "${SNAP_COMMON}" "${SNAP}"; do
+  cp "${source_dir}/sideload/"*.tar "${SNAP_COMMON}/etc/sideload/" || true
+done
+
 # Produce cluster certificates
 produce_certs
 rm -rf .srl


### PR DESCRIPTION
### Summary

Implement side-loading of images during cluster initialization. This is done by adding `tar` image archives in well-known directories. After a few iterations, looks like this is one of the easiest ways for cluster administrators to automatically sideload images into containerd during provisioning.

### Manual Testing

On one node, to download all required images:

```
$ sudo snap install microk8s --classic
$ sudo microk8s images export-local images.tar
```

On node where you want to sideload images, ensure they are at `/var/snap/microk8s/common/sideload/` and install the snap:

```
$ mkdir -p /var/snap/microk8s/common/sideload
$ cp images.tar /var/snap/microk8s/common/sideload
$ sudo snap install ./microk8s.snap --dangerous --classic
```

### Automated Testing

Will do as a separate PR, our airgap tests are currently "imperative" and must be re-written to use our launch configurations.

### Example

Logs from images being side-loaded into the cluster:

```
Feb 22 08:04:48 u1 microk8s.daemon-apiserver-kicker[36880]: Side-load /var/snap/microk8s/common/etc/sideload/images.tar into containerd
Feb 22 08:04:48 u1 sudo[37574]:     root : TTY=unknown ; PWD=/var/snap/microk8s/x1 ; USER=root ; ENV=LD_LIBRARY_PATH=/snap/microk8s/x1/lib:/snap/microk8s/x1/usr/lib:/snap/microk8s/x1/lib/x86_64-linux-gnu:/snap/microk8s/x1/usr/lib/x86_64-linux-gnu CONTAINERD_SNAPSHOTTER=overlayfs ; COMMAND=/snap/microk8s/x1/bin/ctr --address=/var/snap/microk8s/common/run/containerd.sock --namespace k8s.io image import /var/snap/microk8s/common/etc/sideload/images.tar
Feb 22 08:04:48 u1 sudo[37574]: pam_unix(sudo:session): session opened for user root by (uid=0)
Feb 22 08:04:59 u1 microk8s.daemon-apiserver-kicker[37575]: unpacking docker.io/calico/cni:v3.23.5 (sha256:7ca5c455cff6c0d661e33918d95a1133afb450411dbfb7e4369a9ecf5e0212dc)...done
Feb 22 08:04:59 u1 microk8s.daemon-apiserver-kicker[37575]: unpacking docker.io/calico/cni@sha256:7ca5c455cff6c0d661e33918d95a1133afb450411dbfb7e4369a9ecf5e0212dc (sha256:7ca5c455cff6c0d661e33918d95a1133afb450411dbfb7e4369a9ecf5e0212dc)...done
Feb 22 08:05:01 u1 microk8s.daemon-apiserver-kicker[37575]: unpacking docker.io/calico/kube-controllers:v3.23.5 (sha256:58cc91c551e9e941a752e205eefed1c8da56f97a51e054b3d341b67bb7bf27eb)...done
Feb 22 08:05:01 u1 microk8s.daemon-apiserver-kicker[37575]: unpacking docker.io/calico/kube-controllers@sha256:58cc91c551e9e941a752e205eefed1c8da56f97a51e054b3d341b67bb7bf27eb (sha256:58cc91c551e9e941a752e205eefed1c8da56f97a51e054b3d341b67bb7bf27eb)...done
Feb 22 08:05:03 u1 microk8s.daemon-apiserver-kicker[37575]: unpacking docker.io/calico/node:v3.23.5 (sha256:b7f4f7a0ce463de5d294fdf2bb13f61035ec6e3e5ee05dd61dcc8e79bc29d934)...done
Feb 22 08:05:03 u1 microk8s.daemon-apiserver-kicker[37575]: unpacking docker.io/calico/node@sha256:b7f4f7a0ce463de5d294fdf2bb13f61035ec6e3e5ee05dd61dcc8e79bc29d934 (sha256:b7f4f7a0ce463de5d294fdf2bb13f61035ec6e3e5ee05dd61dcc8e79bc29d934)...done
Feb 22 08:05:04 u1 microk8s.daemon-apiserver-kicker[37575]: unpacking docker.io/coredns/coredns:1.10.0 (sha256:017727efcfeb7d053af68e51436ce8e65edbc6ca573720afb4f79c8594036955)...done
Feb 22 08:05:04 u1 microk8s.daemon-apiserver-kicker[37575]: unpacking docker.io/coredns/coredns@sha256:017727efcfeb7d053af68e51436ce8e65edbc6ca573720afb4f79c8594036955 (sha256:017727efcfeb7d053af68e51436ce8e65edbc6ca573720afb4f79c8594036955)...done
Feb 22 08:05:04 u1 microk8s.daemon-apiserver-kicker[37575]: unpacking registry.k8s.io/pause:3.7 (sha256:bb6ed397957e9ca7c65ada0db5c5d1c707c9c8afc80a94acbe69f3ae76988f0c)...done
Feb 22 08:05:04 u1 microk8s.daemon-apiserver-kicker[37575]: unpacking registry.k8s.io/pause@sha256:bb6ed397957e9ca7c65ada0db5c5d1c707c9c8afc80a94acbe69f3ae76988f0c (sha256:bb6ed397957e9ca7c65ada0db5c5d1c707c9c8afc80a94acbe69f3ae76988f0c)...done
Feb 22 08:05:04 u1 sudo[37574]: pam_unix(sudo:session): session closed for user root
Feb 22 08:05:04 u1 microk8s.daemon-apiserver-kicker[36880]: Success!
```

Output from `kubectl get deploy coredns -n kube-system`, image already exists and the pod starts immediately:

```
  Normal   Pulled                  13s   kubelet            Container image "coredns/coredns:1.10.0" already present on machine
  Normal   Created                 13s   kubelet            Created container coredns
  Normal   Started                 13s   kubelet            Started container coredns
```