### PR TITLE
Fixed error for worker node's leaving operation which caused unresponsiveness in the node

### DIFF
--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -826,7 +826,6 @@ def join_dqlite_worker_node(info, master_ip, master_port, token):
         exit(1)
 
     store_remote_ca(info["ca"])
-    store_cert("serviceaccount.key", info["service_account_key"])
 
     store_base_kubelet_args(info["kubelet_args"])
     update_kubelet_node_ip(info["kubelet_args"], hostname_override)

--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -30,8 +30,6 @@ from common.cluster.utils import (
     get_token,
 )
 
-from reset import reset_cert_reissue
-
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 CLUSTER_API = "cluster/api/v1.0"
 snapdata_path = os.environ.get("SNAP_DATA")
@@ -828,7 +826,6 @@ def join_dqlite_worker_node(info, master_ip, master_port, token):
         exit(1)
 
     store_remote_ca(info["ca"])
-    reset_cert_reissue()
 
     store_base_kubelet_args(info["kubelet_args"])
     update_kubelet_node_ip(info["kubelet_args"], hostname_override)

--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -30,6 +30,8 @@ from common.cluster.utils import (
     get_token,
 )
 
+from reset import reset_cert_reissue
+
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 CLUSTER_API = "cluster/api/v1.0"
 snapdata_path = os.environ.get("SNAP_DATA")
@@ -826,6 +828,7 @@ def join_dqlite_worker_node(info, master_ip, master_port, token):
         exit(1)
 
     store_remote_ca(info["ca"])
+    reset_cert_reissue()
 
     store_base_kubelet_args(info["kubelet_args"])
     update_kubelet_node_ip(info["kubelet_args"], hostname_override)

--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -458,6 +458,65 @@ class TestCluster(object):
         kubelet = vm.run("cat /var/snap/microk8s/current/credentials/kubelet.config")
         assert "127.0.0.1" in kubelet.decode()
 
+    def test_worker_node_leave(self):
+        """
+        Test when a worker node leaves the cluster
+        """
+        print("Setting up a worker node")
+        vm = VM(backend)
+        vm.setup(channel_to_test)
+        self.VM.append(vm)
+
+        # Form cluster
+        vm_master = self.VM[0]
+        print("Adding machine {} to cluster".format(vm.vm_name))
+        add_node = vm_master.run("/snap/bin/microk8s.add-node")
+        endpoint = [ep for ep in add_node.decode().split() if ":25000/" in ep]
+        vm.run("/snap/bin/microk8s.join {} --worker".format(endpoint[0]))
+
+        # Wait for nodes to be ready
+        print("Waiting for node to register")
+        attempt = 0
+        while attempt < 10:
+            try:
+                connected_nodes = vm_master.run("/snap/bin/microk8s.kubectl get no")
+                if "NotReady" in connected_nodes.decode():
+                    time.sleep(5)
+                    continue
+                print(connected_nodes.decode())
+                break
+            except ChildProcessError:
+                time.sleep(10)
+                attempt += 1
+                if attempt == 10:
+                    raise
+
+        # Leave the worker node from the cluster
+        print("Leaving the worker node {} from the cluster".format(vm.vm_name))
+        vm.run("/snap/bin/microk8s.leave")
+
+        # Wait for worker node to leave the cluster
+        attempt = 0
+        while attempt < 10:
+            try:
+                connected_nodes = vm_master.run("/snap/bin/microk8s.kubectl get no")
+                if "NotReady" in connected_nodes.decode():
+                    print(connected_nodes.decode())
+                    break
+                time.sleep(5)
+                continue
+            except ChildProcessError:
+                time.sleep(10)
+                attempt += 1
+                if attempt == 10:
+                    raise
+
+        # Check that the worker node is Ready
+        print("Checking that the worker node {} is working and Ready".format(vm.vm_name))
+        worker_node=vm.run("/snap/bin/microk8s status --wait-ready")
+        print(worker_node.decode())
+        assert "microk8s is running" in worker_node.decode()
+
     def test_no_cert_reissue_in_nodes(self):
         """
         Test that each node has the cert no-reissue lock.

--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -513,7 +513,7 @@ class TestCluster(object):
 
         # Check that the worker node is Ready
         print("Checking that the worker node {} is working and Ready".format(vm.vm_name))
-        worker_node=vm.run("/snap/bin/microk8s status --wait-ready")
+        worker_node = vm.run("/snap/bin/microk8s status --wait-ready")
         print(worker_node.decode())
         assert "microk8s is running" in worker_node.decode()
 


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
The error occurred during the joining of the worker node. An empty serviceaccount was created which was not required by the microk8s agent and hence was causing the node to fail when it left the cluster.

Closes #3708 

#### Testing
<!-- Please explain how you tested your changes. -->
Local testing.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
Will also create backports for this.