### PR TITLE
Added support for specifying the image that is used by multipass

### DIFF
--- a/installer/cli/microk8s.py
+++ b/installer/cli/microk8s.py
@@ -89,7 +89,7 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  install         Installs MicroK8s. Use --cpu, --mem, --disk and --channel to configure your setup.
+  install         Installs MicroK8s. Use --cpu, --mem, --disk, --channel, and --image to configure your setup.
   uninstall       Removes MicroK8s"""
     click.echo(msg)
     commands = _get_microk8s_commands()
@@ -112,6 +112,7 @@ def _show_install_help():
       --mem      RAM in GB used by MicroK8s (default={definitions.DEFAULT_MEMORY_GB}, min={definitions.MIN_MEMORY_GB})
       --disk     Max volume in GB of the dynamically expandable hard disk to be used (default={definitions.DEFAULT_DISK_GB}, min={definitions.MIN_DISK_GB})
       --channel  Kubernetes version to install (default={definitions.DEFAULT_CHANNEL})
+      --image    Ubuntu version to install (default={definitions.DEFAULT_IMAGE})
       -y, --assume-yes  Automatic yes to prompts"""  # noqa
     Echo.info(msg)
 
@@ -156,6 +157,7 @@ def install(args) -> None:
     parser.add_argument("--mem", default=definitions.DEFAULT_MEMORY_GB, type=memory)
     parser.add_argument("--disk", default=definitions.DEFAULT_DISK_GB, type=disk)
     parser.add_argument("--channel", default=definitions.DEFAULT_CHANNEL, type=str)
+    parser.add_argument("--image", default=definitions.DEFAULT_IMAGE, type=str)
     parser.add_argument(
         "-y", "--assume-yes", action="store_true", default=definitions.DEFAULT_ASSUME
     )

--- a/installer/common/definitions.py
+++ b/installer/common/definitions.py
@@ -29,6 +29,7 @@ DEFAULT_MEMORY_GB: int = 4
 DEFAULT_DISK_GB: int = 50
 DEFAULT_ASSUME: bool = False
 DEFAULT_CHANNEL: str = "1.26/stable"
+DEFAULT_IMAGE: str = "18.04"
 
 MIN_CORES: int = 2
 MIN_MEMORY_GB: int = 2

--- a/installer/vm_providers/_multipass/_multipass.py
+++ b/installer/vm_providers/_multipass/_multipass.py
@@ -56,8 +56,9 @@ class Multipass(Provider):
         )
 
     def _launch(self, specs: Dict) -> None:
-        image = "18.04"
 
+        # prepare core launch setting
+        image = specs["image"]
         cpus = "{}".format(specs["cpu"])
         mem = "{}G".format(specs["mem"])
         disk = "{}G".format(specs["disk"])


### PR DESCRIPTION
#### Summary
I added the ability to specify the image version (currently fixed at 18.04) in the `microk8s install` command. While I haven't seen an issue associated with it, Windows seems to have some instability in restarting an Ubuntu 18.04 image. 20.04+ is much more stable, which contributes to a much better microk8s experience.

#### Changes
User facing change: the `microk8s install` command now has a `--image` option. The help message was updated as well.

Behind the scenes, I simply added a new spec that's passed into the microk8s._launch method, and handled appropriately. Also added a default so that 18.04 is the default image. As a result, the default behavior remains unchanged.

#### Testing
I ran the `microk8s install` method a couple times on my Windows machine to confirm that I could install different versions.

#### Possible Regressions
No. Highly unlikely.

#### Checklist

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.
