### PR TITLE
update images for 1.26 and 1.24-eksd branches

### DIFF
--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -14,13 +14,16 @@ jobs:
           # Latest branches
           - { branch: master, channel: latest/edge }
           # Stable branches
+          - { branch: 1.26, channel: 1.26 }
           - { branch: 1.25, channel: 1.25 }
           - { branch: 1.24, channel: 1.24 }
           - { branch: 1.23, channel: 1.23 }
           - { branch: 1.22, channel: 1.22 }
-          # Strict branches
+          # Stable strict branches
+          - { branch: 1.26-strict, channel: 1.26-strict }
           - { branch: 1.25-strict, channel: 1.25-strict }
           # EKSD branches
+          - { branch: 1.24-eksd, channel: 1.24-eksd }
           - { branch: 1.23-eksd, channel: 1.23-eksd }
     steps:
       - name: Checkout


### PR DESCRIPTION
### Summary

Run update-images for 1.26 and 1.24-eksd branches