### PR TITLE
Improve chained ops warning

### DIFF
--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -439,8 +439,9 @@ def xable(action: str, addon_args: list):
     """
     if len(addon_args) > 1:
         click.echo(
-            "WARNING: Chained operations of addons will be DEPRECATED in the future.\n"
-            f"         Please use 'microk8s {action} <addon>' instead."
+            "WARNING: Do not enable or disable multiple addons in one command.\n"
+            "         This form of chained operations on addons will be DEPRECATED in the future.\n"
+            f"         Please, {action} one addon at a time: 'microk8s {action} <addon>'"
         )
     available_addons_info = get_available_addons(get_current_arch())
     enabled_addons_info, disabled_addons_info = get_status(available_addons_info, True)


### PR DESCRIPTION
Improve the warning messaging because the "Chained operations" are our internal code name for enabling/disabling addons in one command.