### PR TITLE
Containerd and runc build with CGO

### DIFF
--- a/build-scripts/components/containerd/build.sh
+++ b/build-scripts/components/containerd/build.sh
@@ -4,6 +4,7 @@ INSTALL="${1}/bin"
 mkdir -p "${INSTALL}"
 
 for bin in ctr containerd containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2; do
+  export SHIM_CGO_ENABLED=1
   make "bin/${bin}"
   cp "bin/${bin}" "${INSTALL}/${bin}"
 done

--- a/build-scripts/components/runc/build.sh
+++ b/build-scripts/components/runc/build.sh
@@ -3,5 +3,6 @@
 export INSTALL="${1}/bin"
 mkdir -p "${INSTALL}"
 
+export SHIM_CGO_ENABLED=1
 make BUILDTAGS="seccomp apparmor" EXTRA_LDFLAGS="-s -w"
 cp runc "${INSTALL}/runc"

--- a/build-scripts/components/runc/build.sh
+++ b/build-scripts/components/runc/build.sh
@@ -3,6 +3,6 @@
 export INSTALL="${1}/bin"
 mkdir -p "${INSTALL}"
 
-export SHIM_CGO_ENABLED=1
+export CGO_ENABLED=1
 make BUILDTAGS="seccomp apparmor" EXTRA_LDFLAGS="-s -w"
 cp runc "${INSTALL}/runc"

--- a/microk8s-resources/default-args/containerd-env
+++ b/microk8s-resources/default-args/containerd-env
@@ -32,3 +32,8 @@ ulimit -n 65536 || true
 # this get inherited to the running containers
 #
 ulimit -l 16384 || true
+
+# Set GOFIPS to use FIPS certified libs
+export GOFIPS=0
+# Point to the location of libcrypto.so
+# export LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/"


### PR DESCRIPTION
#### Summary
Build containerd and runc with CGO enabled so it can use FIPS certified libs

#### Changes
Changes in the build scripts and the env containerd runs under.

#### Testing
Manual. Enable GOFIPS and give it a wrong lib path to verify it is trying to find libs from there.

