### PR TITLE
do not allow the ctr command if no permission

### DIFF
--- a/microk8s-resources/wrappers/microk8s-ctr.wrapper
+++ b/microk8s-resources/wrappers/microk8s-ctr.wrapper
@@ -10,6 +10,8 @@ source $SNAP/actions/common/utils.sh
 
 SNAPSHOTTER=$(snapshotter)
 
+exit_if_no_permissions
+
 if ! [ -e $SNAP_DATA/args/ctr ]
 then
   echo "Arguments file $SNAP_DATA/args/ctr is missing."


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
Do not allow `microk8s ctr` command if user do not have permission.

#### Changes
Add check to the `ctr` wrapper to make sure the user has permission before continuing.

#### Possible Regressions
None

#### Checklist
<!-- Please verify that you have done the following -->

* [ X ] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [ X ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.

