### PR TITLE
Regenerate apiserver certificate if not matching CA - Fixes #3785 #3321 #3068 #2123 

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -649,7 +649,8 @@ produce_certs() {
 ensure_server_ca() {
     # ensure the server.crt is issued by ca.crt
     # if current csr.conf is invalid, regenerate front-proxy-client certificates as well
-    
+
+    export OPENSSL_CONF="${SNAP}/etc/ssl/openssl.cnf"
     if ! ${SNAP}/usr/bin/openssl verify -CAfile ${SNAP_DATA}/certs/ca.crt ${SNAP_DATA}/certs/server.crt &>/dev/null
     then
         csr_modified="$(ensure_csr_conf_conservative)"
@@ -668,6 +669,7 @@ ensure_server_ca() {
 
 check_csr_conf() {
     # if no argument is given, default csr.conf will be checked
+    export OPENSSL_CONF="${SNAP}/etc/ssl/openssl.cnf"
 
     csr_conf="${1:-${SNAP_DATA}/certs/csr.conf}"
     ${SNAP}/usr/bin/openssl req -new -config $csr_conf -noout -nodes -keyout /dev/null &>/dev/null

--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -45,36 +45,43 @@ do
       chgrp ${group} ${SNAP_COMMON}/run/containerd.sock || true
     fi
 
-    if ! [ -e "${SNAP_DATA}/var/lock/no-cert-reissue" ] &&
-       ! grep -E "(--advertise-address|--bind-address)" $SNAP_DATA/args/kube-apiserver &> /dev/null &&
-       ip route | grep default &> /dev/null
-    then
-      if snapctl services microk8s.daemon-kubelite | grep active &> /dev/null
+    # certificate regeneration on: IP/csr change if not clustered, CA mismatch if clustered
+    manage_certs() {
+      if ! [ -e "${SNAP_DATA}/var/lock/no-cert-reissue" ] &&
+        ! grep -E "(--advertise-address|--bind-address)" $SNAP_DATA/args/kube-apiserver &> /dev/null &&
+        ip route | grep default &> /dev/null
       then
-        csr_modified="$(produce_certs)"
-        if [[ "$csr_modified" -eq "1" ]];
-        then
-            echo "CSR change detected. Restarting the cluster-agent"
-            snapctl restart microk8s.daemon-cluster-agent
+          echo "$(produce_certs)"
+      else
+          echo "$(ensure_server_ca)"
+      fi
+    }
 
-            echo "CSR change detected. Reconfiguring the kube-apiserver"
-            rm -rf .srl
-            snapctl stop microk8s.daemon-kubelite
-            if is_strict
-            then
-              remove_all_containers
-              snapctl restart microk8s.daemon-containerd
-            else
-              snapctl stop microk8s.daemon-containerd
-              kill_all_container_shims
-              snapctl start microk8s.daemon-containerd
-            fi
-            snapctl start microk8s.daemon-kubelite
-            start_all_containers
-            restart_attempt=$[$restart_attempt+1]
-        else
-            restart_attempt=0
-        fi
+    if snapctl services microk8s.daemon-kubelite | grep active &> /dev/null
+    then
+      certs_modified="$(manage_certs)"
+      if [[ "$certs_modified" -eq "1" ]]
+      then
+          echo "cert change detected. Restarting the cluster-agent"
+          snapctl restart microk8s.daemon-cluster-agent
+
+          echo "cert change detected. Reconfiguring the kube-apiserver"
+          rm -rf .srl
+          snapctl stop microk8s.daemon-kubelite
+          if is_strict
+          then
+            remove_all_containers
+            snapctl restart microk8s.daemon-containerd
+          else
+            snapctl stop microk8s.daemon-containerd
+            kill_all_container_shims
+            snapctl start microk8s.daemon-containerd
+          fi
+          snapctl start microk8s.daemon-kubelite
+          start_all_containers
+          restart_attempt=$[$restart_attempt+1]
+      else
+          restart_attempt=0
       fi
     fi
 

--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -51,9 +51,9 @@ do
         ! grep -E "(--advertise-address|--bind-address)" $SNAP_DATA/args/kube-apiserver &> /dev/null &&
         ip route | grep default &> /dev/null
       then
-          echo "$(produce_certs)"
+        echo "$(produce_certs)"
       else
-          echo "$(ensure_server_ca)"
+        echo "$(ensure_server_ca)"
       fi
     }
 
@@ -63,26 +63,26 @@ do
       if [[ "$certs_modified" -eq "1" ]] &&
         ! [ -e "${SNAP_DATA}/var/lock/join-in-progress" ]
       then
-          echo "cert change detected. Restarting the cluster-agent"
-          snapctl restart microk8s.daemon-cluster-agent
+        echo "cert change detected. Restarting the cluster-agent"
+        snapctl restart microk8s.daemon-cluster-agent
 
-          echo "cert change detected. Reconfiguring the kube-apiserver"
-          rm -rf .srl
-          snapctl stop microk8s.daemon-kubelite
-          if is_strict
-          then
-            remove_all_containers
-            snapctl restart microk8s.daemon-containerd
-          else
-            snapctl stop microk8s.daemon-containerd
-            kill_all_container_shims
-            snapctl start microk8s.daemon-containerd
-          fi
-          snapctl start microk8s.daemon-kubelite
-          start_all_containers
-          restart_attempt=$[$restart_attempt+1]
+        echo "cert change detected. Reconfiguring the kube-apiserver"
+        rm -rf .srl
+        snapctl stop microk8s.daemon-kubelite
+        if is_strict
+        then
+          remove_all_containers
+          snapctl restart microk8s.daemon-containerd
+        else
+          snapctl stop microk8s.daemon-containerd
+          kill_all_container_shims
+          snapctl start microk8s.daemon-containerd
+        fi
+        snapctl start microk8s.daemon-kubelite
+        start_all_containers
+        restart_attempt=$[$restart_attempt+1]
       else
-          restart_attempt=0
+        restart_attempt=0
       fi
     fi
 

--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -60,7 +60,8 @@ do
     if snapctl services microk8s.daemon-kubelite | grep active &> /dev/null
     then
       certs_modified="$(manage_certs)"
-      if [[ "$certs_modified" -eq "1" ]]
+      if [[ "$certs_modified" -eq "1" ]] &&
+        ! [ -e "${SNAP_DATA}/var/lock/join-in-progress" ]
       then
           echo "cert change detected. Restarting the cluster-agent"
           snapctl restart microk8s.daemon-cluster-agent

--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -727,9 +727,6 @@ def update_dqlite(cluster_cert, cluster_key, voters, host):
             waits -= 1
     print(" ")
 
-    with open("{}//certs/csr.conf".format(snapdata_path), "w") as f:
-        f.write("changeme")
-
     restart_all_services()
 
 

--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -682,6 +682,7 @@ def update_dqlite(cluster_cert, cluster_key, voters, host):
     """
     service("stop", "apiserver")
     service("stop", "k8s-dqlite")
+    # will allow for apiservice-kicker to generate new certificates @5s loop rate
     time.sleep(10)
     shutil.rmtree(cluster_backup_dir, ignore_errors=True)
     shutil.move(cluster_dir, cluster_backup_dir)
@@ -910,6 +911,24 @@ def join_etcd(connection_parts, verify=True):
     mark_no_cert_reissue()
 
 
+def mark_join_in_progress():
+    """
+    Mark node as currently being in the process of joining a cluster.
+    """
+    lock_file = "{}/var/lock/join-in-progress".format(snapdata_path)
+    open(lock_file, "a").close()
+    os.chmod(lock_file, 0o700)
+
+
+def unmark_join_in_progress():
+    """
+    Unmark as joining cluster; join operation has finished.
+    """
+    lock_file = "{}/var/lock/join-in-progress".format(snapdata_path)
+    if os.path.exists(lock_file):
+        os.unlink(lock_file)
+
+
 @click.command(
     context_settings={"ignore_unknown_options": True, "help_option_names": ["-h", "--help"]}
 )
@@ -967,10 +986,14 @@ If you would still like to join the cluster as a control plane node, use:
         )
         sys.exit(1)
 
+    mark_join_in_progress()
+
     if is_node_running_dqlite():
         join_dqlite(connection_parts, verify, worker)
     else:
         join_etcd(connection_parts, verify)
+
+    unmark_join_in_progress()
     sys.exit(0)
 
 


### PR DESCRIPTION
#### Summary
Regenerate *apiserver* certificate `server.crt` from *apiservice-kicker*, if it is not issued by the current CA `ca.crt`. If configuration `csr.conf`/`csr.conf.rendered` is missing, render them, and regenerate `front-proxy-client.crt` as well, as changes may be introduced and both certificates will then be created from the same configuration.


It streamlines the process of regenerating certificates from *apiservice-kicker*, by introducing some separation of concerns between the two cases:
* generating certificates due to a CA change (or absence of a certificate)
* generating new certificates with new SANs due to an address change

Further, an existing `csr.conf` will **not be rerendered and replaced automatically** on cluster join, with the following rationales. Where 1. has already been outlined in #3785, and 2. may be opinionated:
1) The `csr.conf` may be customized by the user to reflect special infrastructure/security requirements.
2) Rendering a new `csr.conf` should only be necessary on name/address changes: Neither does joining a cluster introduce these changes, nor does the process convey the intention to have any changes made to the signing request configuration.

##### Fixes
* #3785
* #2123
* #3321
* #3068
* parts of #3241 in combination with #3740


#### Changes
##### joining method `join.py`
* joining procedure maintains a "lock-file" at `/var/lock/join-in-progress` to indicate a joining procedure is currently in process. This lock-file will be consumed by the *apiservice-kicker* to avoid a *snapctl* race condition.
* keep `csr.conf` intact; do not write `changeme` and invalidate it

##### *apiservice-kicker* (& `utils.sh`)
* separate certificate generation due to address/name change from certificate generation due to cluster join
* make runtime components restart on actual certificate change and not on `csr.conf` change
* change logging from `CSR change detected [...]` to `cert change detected [...]`
* disable restarting runtime components when join is in progress (consume `/var/lock/join-in-progress`), as it may lead to race conditions between restarts from *apiservice-kicker* and [`restart_all_services()` in `join.py`](https://github.com/bitmeal/microk8s/blob/8784f57e406233b76b5b4f3cba73d908e1efdfc1/scripts/wrappers/join.py#L731) certificate regeneration by the *apiservice-kicker* should be done when calling `restart_all_services()` [due to the already existing sleep of 10s](https://github.com/bitmeal/microk8s/blob/8784f57e406233b76b5b4f3cba73d908e1efdfc1/scripts/wrappers/join.py#L685-L686).

#### Testing
##### automated
Running `test-cluster.py`, yielding nonreproducible results, randomly failing 1-2 tests. From analysis of the logs and performing multiple runs, tests seem to fail due to timing issues. These should best be rerun on some different environment. I am currently running them as `{🚀xen} --> {VM} --> {🧱LXC builder VM} --> {{🧱🧱LXC-in-LXC test VMs}}` and not majorly surprised to see timing related issues.

##### manually
Manually reproduced the following test cases without issues:
* regenerating certificates on address change when running as a single node (add/remove and bring up/down a `dummy`-type interface in LXC VM)
* joining/building a HA cluster as HA nodes
* joining/building a HA cluster as HA nodes with `--advertise-address` or `--bind-address` configured on *kube-apiserver*
* joining a cluster as worker node

When clustering, a *DaemonSet* of `containous/whoami` pods/containers was deployed and their operation was validated.

#### Possible Regressions
Regarding behavior of external tooling:
* Parsing the log output of *apiservice-kicker*, due to changes outlined above
* Relying on invalidation of `csr.conf` as a trigger in join process

Regarding user-facing behavior of join procedure:
* Relying on auto rerendering of `csr.conf` on cluster join. Changes to e.g. `csr.conf.template` that have not already been rendered into a `csr.conf` have to be applied manually, or `csr.conf` and `csr.conf.rendered` removed before joining to trigger rendering.

#### Checklist
* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests. ***Should be covered by existing integration tests.***

#### Notes
* The commits can - of course - be squashed for merge, but may be helpful as individual ones for review
* ~~CLA to be signed~~