### PR TITLE
Bump go-dqlite to 1.11.7

### DIFF
--- a/build-scripts/components/dqlite-client/version.sh
+++ b/build-scripts/components/dqlite-client/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.11.6"
+echo "v1.11.7"


### PR DESCRIPTION
### Summary

Update go-dqlite to 1.11.7 for important bug-fixes https://github.com/canonical/go-dqlite/releases/tag/v1.11.7 