### PR TITLE
Revert "Build libdqlite and libraft with debuginfo"

### DIFF
--- a/build-scripts/components/dqlite/build.sh
+++ b/build-scripts/components/dqlite/build.sh
@@ -11,7 +11,7 @@ export SQLITE_LIBS="-L${SNAPCRAFT_STAGE}/lib -lsqlite3"
 export RAFT_CFLAGS="-I${SNAPCRAFT_STAGE}/usr/include"
 export RAFT_LIBS="-L${SNAPCRAFT_STAGE}/lib -lraft"
 
-./configure --enable-debug
+./configure
 
 mkdir -p build
 

--- a/build-scripts/components/raft/build.sh
+++ b/build-scripts/components/raft/build.sh
@@ -6,7 +6,7 @@ INSTALL="${1}"
 [ ! -f ./configure ] && [ -f ./bootstrap ] && env NOCONFIGURE=1 ./bootstrap
 [ ! -f ./configure ] && autoreconf --install
 
-./configure --enable-debug
+./configure
 
 mkdir -p build
 


### PR DESCRIPTION
I was confused, `--enable-debug` turns on assertions, not debug info. These libraries are not stripped in any case, and in #3821 I'm working on another approach to getting better diagnostics.

Reverts canonical/microk8s#3750

Signed-off-by: Cole Miller <cole.miller@canonical.com>