### PR TITLE
Fix TLS config for k8s-dqlite

### DIFF
--- a/build-scripts/components/k8s-dqlite/patches/0001-Fix-TLS-Config.patch
+++ b/build-scripts/components/k8s-dqlite/patches/0001-Fix-TLS-Config.patch
@@ -1,0 +1,30 @@
+From 99518263de7d90b8bfac85bd4494e4c120c82da8 Mon Sep 17 00:00:00 2001
+From: Angelos Kolaitis <angelos.kolaitis@canonical.com>
+Date: Fri, 10 Mar 2023 10:37:07 +0000
+Subject: [PATCH] Fix TLS config
+
+---
+ server/server.go | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/server/server.go b/server/server.go
+index 14f7268..0688288 100644
+--- a/server/server.go
++++ b/server/server.go
+@@ -83,7 +83,13 @@ func New(dir string, listen string, enableTLS bool) (*Server, error) {
+ 	log.Printf("Failure domain set to %d", cfg.FailureDomain)
+ 	if enableTLS {
+ 		log.Printf("TLS enabled")
+-		options = append(options, app.WithTLS(app.SimpleTLSConfig(cfg.KeyPair, cfg.Pool)))
++		listen, dial := app.SimpleTLSConfig(cfg.KeyPair, cfg.Pool)
++		listen.CipherSuites = nil
++		listen.PreferServerCipherSuites = false
++		listen.CurvePreferences = nil
++		dial.CipherSuites = nil
++		dial.PreferServerCipherSuites = false
++		options = append(options, app.WithTLS(listen, dial))
+ 	}
+
+ 	// Possibly initialize our ID, address and initial node store content.
+--
+2.17.1


### PR DESCRIPTION
### Summary

Backport https://github.com/canonical/microk8s/pull/3822

We cannot upgrade go-dqlite 1.11.7 since it requires dqlite 1.14.0, a minor version upgrade from what we currently have.