### PR TITLE
build k8s-dqlite with go1.19.5

### DIFF
--- a/build-scripts/components/k8s-dqlite/build.sh
+++ b/build-scripts/components/k8s-dqlite/build.sh
@@ -3,9 +3,21 @@
 INSTALL="${1}/bin"
 mkdir -p "${INSTALL}"
 
+# Temporarily pin Go version to 1.19.5 to deal with TLS session resumption issues
+ARCH="$(arch)"
+case "$ARCH" in
+  x86_64) ARCH=amd64 ;;
+esac
+
+if [ ! -f go/bin/go ]; then
+  curl -LO "https://go.dev/dl/go1.19.5.linux-${ARCH}.tar.gz"
+  tar xvzf "go1.19.5.linux-${ARCH}.tar.gz"
+fi
+
 export CGO_LDFLAGS_ALLOW="-Wl,-z,now"
 export CGO_CFLAGS="-I${SNAPCRAFT_STAGE}/usr/include/"
 export CGO_LDFLAGS="-L${SNAPCRAFT_STAGE}/lib"
-go build -ldflags "-s -w" -tags libsqlite3,dqlite .
+
+GOPATH="$PWD/go" ./go/bin/go build -ldflags "-s -w" -tags libsqlite3,dqlite .
 
 cp k8s-dqlite "${INSTALL}/k8s-dqlite"


### PR DESCRIPTION
### Summary

Backport #3846 to 1.26-strict branch