### PR TITLE
[1.23-eksd] Worker node leave fix

### DIFF
--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -413,6 +413,7 @@ class TestCluster(object):
 
         # Wait for nodes to be ready
         print("Waiting for node to register")
+        time.sleep(10)
         attempt = 0
         while attempt < 10:
             try:

--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -451,7 +451,7 @@ class TestCluster(object):
                 print(connected_nodes.decode())
                 if (
                     "NotReady" in connected_nodes.decode()
-                    and vm.vm_name in connected_nodes.decode()
+                    or vm.vm_name not in connected_nodes.decode()
                 ):
                     time.sleep(5)
                     continue

--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -413,14 +413,13 @@ class TestCluster(object):
 
         # Wait for nodes to be ready
         print("Waiting for node to register")
-        time.sleep(10)
         attempt = 0
         while attempt < 10:
             try:
                 connected_nodes = vm_master.run("/snap/bin/microk8s.kubectl get no")
                 if (
                     "NotReady" in connected_nodes.decode()
-                    and vm.vm_name in connected_nodes.decode()
+                    or vm.vm_name not in connected_nodes.decode()
                 ):
                     time.sleep(5)
                     continue


### PR DESCRIPTION
Increasing the time to detect the node in cases where `k get nodes` returned an empty list.