### PR TITLE
Fix kubelet arguments for 1.27

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -192,7 +192,9 @@ skip_opt_in_local_config() {
     # argument $2 is the configuration file under $SNAP_DATA/args
     local opt="--$1"
     local config_file="$SNAP_DATA/args/$2"
-    run_with_sudo "${SNAP}/bin/sed" -i '/'"$opt"'/d' "${config_file}"
+
+    # regex is "$opt[= ]", otherwise we remove all arguments with the same prefix
+    run_with_sudo "${SNAP}/bin/sed" -i '/'"$opt[= ]"'/d' "${config_file}"
 }
 
 

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -302,6 +302,9 @@ sanatise_argskubelet() {
     "pod-infra-container-image"
     "experimental-dockershim-root-directory"
     "non-masquerade-cidr"
+    "containerd"
+    # Remove container-runtime flag from 1.27+
+    "container-runtime"
   )
 
   remove_args "kubelet" "${args[@]}"

--- a/microk8s-resources/default-args/kubelet
+++ b/microk8s-resources/default-args/kubelet
@@ -6,9 +6,7 @@
 --fail-swap-on=false
 --feature-gates=DevicePlugins=true
 --eviction-hard="memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi"
---container-runtime=remote
 --container-runtime-endpoint=${SNAP_COMMON}/run/containerd.sock
---containerd=${SNAP_COMMON}/run/containerd.sock
 --node-labels="microk8s.io/cluster=true,node.kubernetes.io/microk8s-controlplane=microk8s-controlplane"
 --authentication-token-webhook=true
 --read-only-port=0


### PR DESCRIPTION
### Summary

Fixes

```
Mar 21 06:42:43 u1 microk8s.daemon-kubelite[69528]: Error: failed to parse kubelet flag: unknown flag: --container-runtime
Mar 21 06:42:43 u1 microk8s.daemon-kubelite[69528]: F0321 06:42:43.601537   69528 daemon.go:57] Kubelet exited failed to parse kubelet flag: unknown flag: --container-runtime
Mar 21 06:42:43 u1 microk8s.daemon-kubelite[69528]: Flag --containerd has been deprecated, This is a cadvisor flag that was mistakenly registered with the Kubelet. Due to legacy concerns, it will follow the standard CLI deprecation timeline before being removed.
```

Also contains a fix for the `skip_opt_in_local_config` helper function. This is because removing the `container-runtime` flag would also remove the `container-runtime-endpoint` flag, which is not desired.