### PR TITLE
[1.23] Worker node leave fix

### DIFF
--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -375,9 +375,8 @@ class TestCluster(object):
 
         # Wait for nodes to be ready
         print("Waiting for node to register")
-        time.sleep(10)
         connected_nodes = vm_master.run("/snap/bin/microk8s.kubectl get no")
-        while "NotReady" in connected_nodes.decode() and vm.vm_name in connected_nodes.decode():
+        while "NotReady" in connected_nodes.decode() or vm.vm_name not in connected_nodes.decode():
             time.sleep(5)
             connected_nodes = vm_master.run("/snap/bin/microk8s.kubectl get no")
         print(connected_nodes.decode())

--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -375,6 +375,7 @@ class TestCluster(object):
 
         # Wait for nodes to be ready
         print("Waiting for node to register")
+        time.sleep(10)
         connected_nodes = vm_master.run("/snap/bin/microk8s.kubectl get no")
         while "NotReady" in connected_nodes.decode() and vm.vm_name in connected_nodes.decode():
             time.sleep(5)


### PR DESCRIPTION
Increasing the time to detect the node in cases where `k get nodes` returned an empty list.