### PR TITLE
Add conditions when using etcd instead of dqlite

### DIFF
--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -163,16 +163,16 @@ def get_etcd_info():
 
 
 def is_external_etcd():
-    external_etcd = 0
+    external_etcd = True
     kube_apiserver_args = os.path.expandvars("${SNAP_DATA}/args/kube-apiserver")
     with open(kube_apiserver_args, "r") as f:
         kube_apiserver_args_content = f.read()
         for line in kube_apiserver_args_content.split("\n"):
-            # All these variables should be present for an external etcd config
-            if "external-etcd" or "etcd-cafile" or "etcd-certfile" or "etcd-keyfile" in line:
-                external_etcd += 1
+            if "var/kubernetes/backend/kine.sock" in line:
+                external_etcd = False
+                break
 
-    return external_etcd == 4
+    return external_etcd
 
 
 def is_cluster_locked():

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -154,10 +154,12 @@ def get_etcd_info():
         for line in kube_apiserver_args_content.split("\n"):
             if "etcd-servers" in line:
                 # list all etcd endpointss
-                for endpoint in line.split("=")[1].split(","):
-                    ip_port = endpoint.split("//")[1]
-                    etcd_endpoints.append(ip_port)
-                break
+                if "=" in line:
+                    for endpoint in line.split("=")[1].split(","):
+                        if "//" in endpoint:
+                            ip_port = endpoint.split("//")[1]
+                            etcd_endpoints.append(ip_port)
+                    break
 
     return etcd_endpoints
 

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -153,7 +153,7 @@ def get_etcd_info():
         etcd_endpoints = []
         for line in kube_apiserver_args_content.split("\n"):
             if "etcd-servers" in line:
-                server_url = get_argumets(line)
+                server_url = get_server_urls(line)
                 # list all etcd endpointss
                 for endpoint in server_url.split(","):
                     if "//" in endpoint:
@@ -164,15 +164,15 @@ def get_etcd_info():
     return etcd_endpoints
 
 
-def get_argumets(etcd_servers_arg):
+def get_server_urls(args):
     server_url = None
-    parts = etcd_servers_arg.split("=")
+    parts = args.split("=")
     if len(parts) == 2:
         # Argument has an equals sign, e.g. "--etcd-servers=http://10.0.0.1:2379"
         server_url = parts[1]
     elif len(parts) == 1:
         # Argument has a space, e.g. "--etcd-servers http://10.0.0.1:2379"
-        server_url = etcd_servers_arg.split("--etcd-servers")[1].strip()
+        server_url = args.split("--etcd-servers")[1].strip()
     return server_url
 
 

--- a/scripts/wrappers/status.py
+++ b/scripts/wrappers/status.py
@@ -67,9 +67,9 @@ def print_pretty(isReady, enabled_addons, disabled_addons):
             print("{:>2}{} {}".format("", "datastore master nodes:", masters))
             print("{:>2}{} {}".format("", "datastore standby nodes:", standby))
         elif etcd_endpoints:
-                print("{:>2}{}".format("", "datastore endpoints:"))
-                for endpoint in etcd_endpoints:
-                    print("{:>3}{}".format("", endpoint))
+            print("{:>2}{}".format("", "datastore endpoints:"))
+            for endpoint in etcd_endpoints:
+                print("{:>3}{}".format("", endpoint))
 
         print("addons:")
         if enabled_addons and len(enabled_addons) > 0:

--- a/scripts/wrappers/status.py
+++ b/scripts/wrappers/status.py
@@ -42,7 +42,7 @@ def print_pretty(isReady, enabled_addons, disabled_addons):
             if etcd_endpoints:
                 print("{:>2}{}".format("", "datastore endpoints:"))
                 for endpoint in etcd_endpoints:
-                    print("{:>3}{}".format("", endpoint))
+                    print("{:>4}{}".format("", endpoint))
         elif not is_external_etcd():
             info = get_dqlite_info()
             if ha_cluster_formed(info):
@@ -69,7 +69,7 @@ def print_pretty(isReady, enabled_addons, disabled_addons):
         elif etcd_endpoints:
             print("{:>2}{}".format("", "datastore endpoints:"))
             for endpoint in etcd_endpoints:
-                print("{:>3}{}".format("", endpoint))
+                print("{:>4}{}".format("", endpoint))
 
         print("addons:")
         if enabled_addons and len(enabled_addons) > 0:

--- a/scripts/wrappers/status.py
+++ b/scripts/wrappers/status.py
@@ -66,8 +66,7 @@ def print_pretty(isReady, enabled_addons, disabled_addons):
 
             print("{:>2}{} {}".format("", "datastore master nodes:", masters))
             print("{:>2}{} {}".format("", "datastore standby nodes:", standby))
-        else:
-            if etcd_endpoints:
+        elif etcd_endpoints:
                 print("{:>2}{}".format("", "datastore endpoints:"))
                 for endpoint in etcd_endpoints:
                     print("{:>3}{}".format("", endpoint))

--- a/scripts/wrappers/status.py
+++ b/scripts/wrappers/status.py
@@ -39,7 +39,7 @@ def print_pretty(isReady, enabled_addons, disabled_addons):
         etcd_endpoints = get_etcd_info()
         if not is_ha_enabled():
             print("high-availability: no")
-            if len(etcd_endpoints) > 0:
+            if etcd_endpoints:
                 print("{:>2}{}".format("", "datastore endpoints:"))
                 for endpoint in etcd_endpoints:
                     print("{:>3}{}".format("", endpoint))
@@ -67,7 +67,7 @@ def print_pretty(isReady, enabled_addons, disabled_addons):
             print("{:>2}{} {}".format("", "datastore master nodes:", masters))
             print("{:>2}{} {}".format("", "datastore standby nodes:", standby))
         else:
-            if len(etcd_endpoints) > 0:
+            if etcd_endpoints:
                 print("{:>2}{}".format("", "datastore endpoints:"))
                 for endpoint in etcd_endpoints:
                     print("{:>3}{}".format("", endpoint))

--- a/scripts/wrappers/status.py
+++ b/scripts/wrappers/status.py
@@ -13,6 +13,8 @@ from common.utils import (
     get_current_arch,
     get_addon_by_name,
     get_status,
+    get_etcd_info,
+    is_external_etcd,
 )
 
 
@@ -34,9 +36,14 @@ def print_pretty(isReady, enabled_addons, disabled_addons):
     console_formatter = "{:>3} {:<20} # ({}) {}"
     if isReady:
         print("microk8s is running")
+        etcd_endpoints = get_etcd_info()
         if not is_ha_enabled():
             print("high-availability: no")
-        else:
+            if len(etcd_endpoints) > 0:
+                print("{:>2}{}".format("", "datastore endpoints:"))
+                for endpoint in etcd_endpoints:
+                    print("{:>3}{}".format("", endpoint))
+        elif not is_external_etcd():
             info = get_dqlite_info()
             if ha_cluster_formed(info):
                 print("high-availability: yes")
@@ -59,6 +66,13 @@ def print_pretty(isReady, enabled_addons, disabled_addons):
 
             print("{:>2}{} {}".format("", "datastore master nodes:", masters))
             print("{:>2}{} {}".format("", "datastore standby nodes:", standby))
+        else:
+            if len(etcd_endpoints) > 0:
+                print("{:>2}{}".format("", "datastore endpoints:"))
+                for endpoint in etcd_endpoints:
+                    print("{:>3}{}".format("", endpoint))
+
+
 
         print("addons:")
         if enabled_addons and len(enabled_addons) > 0:

--- a/scripts/wrappers/status.py
+++ b/scripts/wrappers/status.py
@@ -72,8 +72,6 @@ def print_pretty(isReady, enabled_addons, disabled_addons):
                 for endpoint in etcd_endpoints:
                     print("{:>3}{}".format("", endpoint))
 
-
-
         print("addons:")
         if enabled_addons and len(enabled_addons) > 0:
             print("{:>2}{}".format("", "enabled:"))


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
MicroK8s status takes a long time when dqlite is not running. This is an issue because microk8s status in control plane nodes will always attempt to query the status of the dqlite database.

This is false in the following conditions:
- non-HA setup; etcd is used instead and dqlite is not running
- custom setup; an external etcd data store is used, not dqlite

Now we check the etcd endpoints configured in apiserver and act accordingly:

(a) if dqlite, keep current behaviour

(b) if non-ha, print etcd single-node address

(c) if etcd, print list of members (perhaps verify status with etcdctl member list)

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

#### Testing
<!-- Please explain how you tested your changes. -->
tested locally

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
