### PR TITLE
support config from /etc/microk8s.yaml

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -52,13 +52,14 @@ cp ${SNAP}/certs/csr.conf.template ${SNAP_DATA}/certs/csr.conf.template
 # The following paths are checked in order for a config file.
 # Only the first file found will be used, the rest will be ignored.
 #
+# - /etc/microk8s.yaml                <-- user-defined config file
 # - $SNAP_USER_COMMON/.microk8s.yaml  <-- user-defined config file, typically in /root/snap/microk8s/common/.microk8s.yaml
 # - $SNAP_COMMON/.microk8s.yaml       <-- user-defined config file, typically in /var/snap/microk8s/common/.microk8s.yaml
 # - $SNAP/microk8s.default.yaml       <-- default config file bundled with the snap
 #
 # If the pre-init step fails, the snap installation will fail, as it is considered to be a user error.
 mkdir -p "${SNAP_COMMON}/etc/launcher"
-for config_file in "$SNAP_USER_COMMON/.microk8s.yaml" "$SNAP_COMMON/.microk8s.yaml" "$SNAP/microk8s.default.yaml"; do
+for config_file in "/etc/microk8s.yaml" "$SNAP_USER_COMMON/.microk8s.yaml" "$SNAP_COMMON/.microk8s.yaml" "$SNAP/microk8s.default.yaml"; do
   if [ -f "${config_file}" ]; then
     echo "Found config file ${config_file}, will use to initialize cluster."
 


### PR DESCRIPTION
### Summary

The default config paths might be confusing for users, especially they implicitly require extra directories to be created.

For classic confinement, enable reading microk8s launch configuration from an `/etc/microk8s.yaml` config file as well.