### PR TITLE
Handle node when leaving the cluster

### DIFF
--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -419,7 +419,7 @@ class TestCluster(object):
                 connected_nodes = vm_master.run("/snap/bin/microk8s.kubectl get no")
                 if (
                     "NotReady" in connected_nodes.decode()
-                    or vm.vm_name not in connected_nodes.decode()
+                    or vm.vm_name in connected_nodes.decode()
                 ):
                     time.sleep(5)
                     continue


### PR DESCRIPTION
When testing the leave command we should wait if the departing node to not be present in the list of nodes or if we have a node as NotReady