### PR TITLE
Added cidr guards on join and flag to disable cni management

### DIFF
--- a/scripts/calico/upgrade.py
+++ b/scripts/calico/upgrade.py
@@ -134,12 +134,16 @@ def backup_old_cni(cni_file):
     shutil.copyfile(cni_file, backup_cni_file)
 
 
-def try_upgrade(cni_file, new_cni_file):
+def try_upgrade(cni_file, new_cni_file, cni_no_manage):
     """
     Perform the upgrade if possible.
 
     return: True if the CNI needs to be reloaded
     """
+
+    # If cni auto management is disabled by lock file do nothing
+    if os.path.exists(cni_no_manage):
+        return False
 
     # If cni files are not in place do nothing
     if not (os.path.exists(cni_file) and os.path.exists(new_cni_file)):
@@ -182,11 +186,12 @@ def main():
     """
     cni_reapply_lock_file = os.path.expandvars("${SNAP_DATA}/var/lock/cni-loaded")
     cni_file = os.path.expandvars("${SNAP_DATA}/args/cni-network/cni.yaml")
+    cni_no_manage = os.path.expandvars("${SNAP_DATA}/var/lock/no-manage-calico")
     new_cni_file = os.path.expandvars(
         "${SNAP}/upgrade-scripts/000-switch-to-calico/resources/calico.yaml"
     )
 
-    if try_upgrade(cni_file, new_cni_file):
+    if try_upgrade(cni_file, new_cni_file, cni_no_manage):
         # we mark the CNI needs to be updated so the api service kicker will take over
         mark_apply_needed(cni_reapply_lock_file)
 

--- a/scripts/wrappers/common/cluster/utils.py
+++ b/scripts/wrappers/common/cluster/utils.py
@@ -188,6 +188,18 @@ def get_cluster_agent_port():
     return cluster_agent_port
 
 
+def get_cluster_cidr():
+    snapdata_path = os.environ.get("SNAP_DATA")
+    filename = "{}/args/kube-proxy".format(snapdata_path)
+    with open(filename) as fp:
+        for _, line in enumerate(fp):
+            if line.startswith("--cluster-cidr"):
+                cidr_parse = line.split("=")
+                if len(cidr_parse) > 1:
+                    return cidr_parse[1].rstrip()
+    return ""
+
+
 def get_control_plane_nodes_internal_ips():
     """
     Return the internal IP of the nodes labeled running the control plane.

--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -28,7 +28,7 @@ from common.cluster.utils import (
     mark_no_cert_reissue,
     restart_all_services,
     get_token,
-    get_cluster_cidr
+    get_cluster_cidr,
 )
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -765,12 +765,8 @@ def join_dqlite(connection_parts, verify=False, worker=False):
     cluster_cidr = get_cluster_cidr()
 
     if "cluster_cidr" in info and info["cluster_cidr"] != cluster_cidr:
-        print(
-            "Joining cluster failed. CIDR for the nodes does not match."
-        )
-        print(
-            f"Cluster CIDR: {info['cluster_cidr']} -- Node CIDR:  {cluster_cidr}"
-        )
+        print("Joining cluster failed. CIDR for the nodes does not match.")
+        print(f"Cluster CIDR: {info['cluster_cidr']} -- Node CIDR:  {cluster_cidr}")
         exit(4)
 
     if worker:

--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -28,6 +28,7 @@ from common.cluster.utils import (
     mark_no_cert_reissue,
     restart_all_services,
     get_token,
+    get_cluster_cidr
 )
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -759,6 +760,18 @@ def join_dqlite(connection_parts, verify=False, worker=False):
         fingerprint=fingerprint,
         worker=worker,
     )
+
+    # Get the cluster_cidr from kube-proxy args
+    cluster_cidr = get_cluster_cidr()
+
+    if "cluster_cidr" in info and info["cluster_cidr"] != cluster_cidr:
+        print(
+            "Joining cluster failed. CIDR for the nodes does not match."
+        )
+        print(
+            f"Cluster CIDR: {info['cluster_cidr']} -- Node CIDR:  {cluster_cidr}"
+        )
+        exit(4)
 
     if worker:
         join_dqlite_worker_node(info, master_ip, master_port, token)


### PR DESCRIPTION
Added a check on join to see if node CIDRs are matching
Added an optional flag to let the users disable calico management

Tested manually by building [microk8s-cluster-agent#28](https://github.com/canonical/microk8s-cluster-agent/pull/28) and pointing the snap to use the built binary.