### PR TITLE
Change the condition for nod (#3870)

### DIFF
--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -439,7 +439,7 @@ class TestCluster(object):
                 connected_nodes = vm_master.run("/snap/bin/microk8s.kubectl get no")
                 if (
                     "NotReady" in connected_nodes.decode()
-                    and vm.vm_name not in connected_nodes.decode()
+                    or vm.vm_name not in connected_nodes.decode()
                 ):
                     time.sleep(5)
                     continue


### PR DESCRIPTION
Back porting this fix.

We need to wait for a node to join in case where there is a node marked as NotReady *or* if we do not see the joining node in the list of all nodes.