### PR TITLE
Generate bill of materials when building snap

### DIFF
--- a/build-scripts/generate-bom.py
+++ b/build-scripts/generate-bom.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import json
+import os
+from pathlib import Path
+import subprocess
+
+DIR = Path(__file__).absolute().parent
+
+SNAPCRAFT_PART_BUILD = Path(os.getenv("SNAPCRAFT_PART_BUILD", ""))
+SNAPCRAFT_PART_INSTALL = Path(os.getenv("SNAPCRAFT_PART_INSTALL", ""))
+
+BUILD_DIRECTORY = SNAPCRAFT_PART_BUILD.exists() and SNAPCRAFT_PART_BUILD or DIR / ".build"
+INSTALL_DIRECTORY = SNAPCRAFT_PART_INSTALL.exists() and SNAPCRAFT_PART_INSTALL or DIR / ".install"
+
+# Location of Python binary
+PYTHON = INSTALL_DIRECTORY / ".." / ".." / "python-runtime" / "install" / "usr" / "bin" / "python3"
+
+# Location of MicroK8s addons
+MICROK8S_ADDONS = INSTALL_DIRECTORY / ".." / ".." / "microk8s-addons" / "install" / "addons"
+
+# List of tools used to build or bundled in the snap
+TOOLS = {
+    "go": ["go", "version"],
+    "gcc": ["gcc", "--version"],
+    "python": [PYTHON, "-B", "-VV"],
+    "python-requirements": [PYTHON, "-B", "-m", "pip", "freeze"],
+}
+
+# List of components built from source
+COMPONENTS = [
+    "cluster-agent",
+    "cni",
+    "containerd",
+    "dqlite",
+    "dqlite-client",
+    "etcd",
+    "flannel-cni-plugin",
+    "flanneld",
+    "helm",
+    "k8s-dqlite",
+    "kubernetes",
+    "migrator",
+    "raft",
+    "runc",
+    "sqlite",
+]
+
+
+def _listdir(dir: Path):
+    try:
+        return sorted(os.listdir(dir))
+    except OSError:
+        return []
+
+
+def _parse_output(*args, **kwargs):
+    return subprocess.check_output(*args, **kwargs).decode().strip()
+
+
+def _read_file(path: Path) -> str:
+    return path.read_text().strip()
+
+
+if __name__ == "__main__":
+    BOM = {
+        "microk8s": {
+            "version": _parse_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]),
+            "revision": _parse_output(["git", "rev-parse", "HEAD"]),
+        },
+        "tools": {},
+        "components": {},
+        "addons": {},
+    }
+
+    for tool_name, version_cmd in TOOLS.items():
+        BOM["tools"][tool_name] = _parse_output(version_cmd).split("\n")
+
+    for component in COMPONENTS:
+        component_dir = DIR / "components" / component
+
+        BOM["components"][component] = {
+            "repository": _read_file(component_dir / "repository"),
+            "version": _parse_output([component_dir / "version.sh"]),
+            "revision": _parse_output(
+                ["git", "rev-parse", "HEAD"],
+                cwd=BUILD_DIRECTORY / ".." / ".." / component / "build" / component,
+            ),
+            "patches": _listdir(component_dir / "patches"),
+            "strict-patches": _listdir(component_dir / "strict-patches"),
+        }
+
+    for repo in _listdir(MICROK8S_ADDONS):
+        repo_dir = MICROK8S_ADDONS / repo
+        if not repo_dir.is_dir():
+            continue
+
+        BOM["addons"][repo] = {
+            "repository": _parse_output(["git", "remote", "get-url", "origin"], cwd=repo_dir),
+            "version": _parse_output(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo_dir),
+            "revision": _parse_output(["git", "rev-parse", "HEAD"], cwd=repo_dir),
+        }
+
+    print(json.dumps(BOM, indent=2))

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -142,6 +142,9 @@ function store_kubernetes_info {
     sudo -E /snap/bin/microk8s kubectl get pv 2>&1 | sudo tee $INSPECT_DUMP/k8s/get-pv > /dev/null # 2>&1 redirects stderr and stdout to /dev/null if no resources found
     sudo -E /snap/bin/microk8s kubectl get pvc --all-namespaces 2>&1 | sudo tee $INSPECT_DUMP/k8s/get-pvc > /dev/null # 2>&1 redirects stderr and stdout to /dev/null if no resources found
   fi
+
+  # Collect bill of materials
+  cp $SNAP/bom.json $INSPECT_DUMP/bom.json
 }
 
 function check_storage_addon {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -349,6 +349,8 @@ parts:
       - sqlite
     plugin: nil
     source: .
+    build-packages:
+      - python3-yaml
     override-build: |
       ./build-scripts/generate-bom.py > "${SNAPCRAFT_PART_INSTALL}/bom.json"
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -328,6 +328,30 @@ parts:
       - -usr/share/doc
       - -usr/share/man
 
+  bom:
+    after:
+      - cluster-agent
+      - cni
+      - containerd
+      - dqlite
+      - dqlite-client
+      - etcd
+      - flannel-cni-plugin
+      - flanneld
+      - helm
+      - k8s-dqlite
+      - kubernetes
+      - microk8s-addons
+      - migrator
+      - python-runtime
+      - raft
+      - runc
+      - sqlite
+    plugin: nil
+    source: .
+    override-build: |
+      ./build-scripts/generate-bom.py > "${SNAPCRAFT_PART_INSTALL}/bom.json"
+
 apps:
   microk8s:
     command: microk8s.wrapper


### PR DESCRIPTION
### Summary

Generate bill of materials when building snap. Include this bill of materials when building an inspection report.

Example bill of materials, built from this commit. The following items are included:

- Tool versions (gcc and go)
- Component repositories, version, git revision, list of patches
- MicroK8s commit

```json
{
  "microk8s": {
    "version": "MK-1128/bom",
    "revision": "eb2c74f2fa089d42ca9ae6082c1730d22c13250d"
  },
  "tools": {
    "go": [
      "go version go1.20.3 linux/amd64"
    ],
    "gcc": [
      "gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0",
      "Copyright (C) 2019 Free Software Foundation, Inc.",
      "This is free software; see the source for copying conditions.  There is NO",
      "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
    ],
    "python": [
      "Python 3.8.10 (default, Mar 13 2023, 10:26:41) ",
      "[GCC 9.4.0]"
    ],
    "python-requirements": [
      "attrs==23.1.0",
      "certifi==2019.11.28",
      "chardet==3.0.4",
      "Click==7.0",
      "colorama==0.4.3",
      "cryptography==2.8",
      "idna==2.8",
      "jsonschema==4.0.0",
      "netifaces==0.10.9",
      "pyOpenSSL==19.0.0",
      "pyrsistent==0.19.3",
      "python-dateutil==2.7.3",
      "PyYAML==5.3.1",
      "requests==2.22.0",
      "six==1.14.0",
      "urllib3==1.25.8"
    ]
  },
  "components": {
    "cluster-agent": {
      "repository": "https://github.com/canonical/microk8s-cluster-agent",
      "version": "main",
      "revision": "d091a931c8bd1cc9b4697828339c1aab2d8e9fb4",
      "patches": [],
      "strict-patches": []
    },
    "cni": {
      "repository": "https://github.com/containernetworking/plugins",
      "version": "v1.2.0",
      "revision": "ca5d2e8dcc57843d7ba435cf269b4f842877f924",
      "patches": [
        "0001-single-entrypoint-for-cni-tools.patch"
      ],
      "strict-patches": []
    },
    "containerd": {
      "repository": "https://github.com/containerd/containerd",
      "version": "v1.6.15",
      "revision": "ffa6768249be6e1002a955d89cbebc4b71a235ee",
      "patches": [
        "0001-microk8s-sideload-images-plugin.patch"
      ],
      "strict-patches": []
    },
    "dqlite": {
      "repository": "https://github.com/canonical/dqlite",
      "version": "v1.14.0",
      "revision": "86ac733f42e0eb140c7ee3e7516c814516979d26",
      "patches": [],
      "strict-patches": []
    },
    "dqlite-client": {
      "repository": "https://github.com/canonical/go-dqlite",
      "version": "v1.11.7",
      "revision": "7d04094a32ae2afb880086c9c6acf985c779c1b1",
      "patches": [],
      "strict-patches": []
    },
    "etcd": {
      "repository": "https://github.com/etcd-io/etcd",
      "version": "v3.5.5",
      "revision": "19002cfc689fba2b8f56605e5797bf79f8b61fdd",
      "patches": [],
      "strict-patches": []
    },
    "flannel-cni-plugin": {
      "repository": "https://github.com/flannel-io/cni-plugin",
      "version": "v1.1.2",
      "revision": "18a3027e7d03feeb6ecdfdbc3bf254a8c8b38b04",
      "patches": [],
      "strict-patches": []
    },
    "flanneld": {
      "repository": "https://github.com/flannel-io/flannel",
      "version": "v0.21.2",
      "revision": "807032c87d217cde14f0ba565292c1cff54ef53c",
      "patches": [
        "0001-disable-udp-backend.patch"
      ],
      "strict-patches": []
    },
    "helm": {
      "repository": "https://github.com/helm/helm",
      "version": "v3.9.1",
      "revision": "b0637d4d50a6e30764e1c55d60e0880bfa6dc500",
      "patches": [
        "0001-disable-warnings-for-kubeconfig-permissions.patch"
      ],
      "strict-patches": []
    },
    "k8s-dqlite": {
      "repository": "https://github.com/canonical/k8s-dqlite",
      "version": "v1.1.5",
      "revision": "583a772e0ee885a2147ceff9553915150dd6daa1",
      "patches": [],
      "strict-patches": []
    },
    "kubernetes": {
      "repository": "https://github.com/kubernetes/kubernetes",
      "version": "v1.27.1",
      "revision": "ace2bdd0662fa4e6d8473f76288859d73d043ef1",
      "patches": [
        "0000-Kubelite-integration.patch",
        "0001-Unix-socket-skip-validation-in-component-status.patch"
      ],
      "strict-patches": []
    },
    "migrator": {
      "repository": "https://github.com/canonical/go-migrator",
      "version": "master",
      "revision": "3ca9d3f9cfdc4326e4a2f131776253797913943f",
      "patches": [],
      "strict-patches": []
    },
    "raft": {
      "repository": "https://github.com/canonical/raft",
      "version": "v0.17.1",
      "revision": "80489bb3b2dd72b2380527e2012751ec833ad513",
      "patches": [],
      "strict-patches": []
    },
    "runc": {
      "repository": "https://github.com/opencontainers/runc",
      "version": "v1.1.4",
      "revision": "5fd4c4d144137e991c4acebb2146ab1483a97925",
      "patches": [],
      "strict-patches": [
        "0001-apparmor-change-profile-immediately-not-on-exec.patch",
        "0002-setns_init_linux-set-the-NNP-flag-after-changing-the.patch",
        "0003-standard_init_linux-change-AppArmor-profile-as-late-.patch"
      ]
    },
    "sqlite": {
      "repository": "https://github.com/sqlite/sqlite",
      "version": "version-3.33.0",
      "revision": "ef215fbf3b581ef4e0273bb3932fa522af88fd7e",
      "patches": [],
      "strict-patches": []
    }
  },
  "addons": {
    "community": {
      "repository": "https://github.com/canonical/microk8s-community-addons",
      "version": "main",
      "revision": "2cdcca2bf079fdf0e6c33d24625d325ebd7966b5"
    },
    "core": {
      "repository": "https://github.com/canonical/microk8s-core-addons",
      "version": "main",
      "revision": "b180d92306edec9ca6f7cfe6096f26b2ce179fdc"
    }
  }
}
```