### PR TITLE
Added force deletion to ignore missing lock file in start script

### DIFF
--- a/microk8s-resources/wrappers/microk8s-start.wrapper
+++ b/microk8s-resources/wrappers/microk8s-start.wrapper
@@ -55,7 +55,7 @@ else
     if run_with_sudo test -e ${SNAP_DATA}/var/lock/stopped.lock
     then
         # Mark the api server as starting
-        run_with_sudo rm ${SNAP_DATA}/var/lock/stopped.lock &> /dev/null
+        run_with_sudo rm -f ${SNAP_DATA}/var/lock/stopped.lock &> /dev/null
     fi
 fi
 


### PR DESCRIPTION
The microk8s start script has a bug based on a race condition for the deletion of the stopped.lock file. The start script first starts the snap services and then tries to remove the stopped.lock file. The problem is that run-kubelite-with-args has a [deletion code block](https://github.com/canonical/microk8s/blob/f7cac669e495108700407701243816552021a9f4/microk8s-resources/wrappers/run-kubelite-with-args#L35-L40) for the same lock file. And if this block is executed before the start script finishes, t[he removal of the lock file](https://github.com/canonical/microk8s/blob/f7cac669e495108700407701243816552021a9f4/microk8s-resources/wrappers/microk8s-start.wrapper#L58) in the start script fails because the file does not exist.