### PR TITLE
exit with error code 1 if cluster is not ready after timeout

### DIFF
--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -195,11 +195,12 @@ def is_cluster_locked():
 
 def wait_for_ready(timeout, with_ready_node=True):
     start_time = time.time()
+    end_time = start_time + timeout
 
     while True:
         if is_cluster_ready(with_ready_node=with_ready_node):
             return True
-        elif timeout and time.time() > start_time + timeout:
+        elif timeout and time.time() > end_time:
             return False
         else:
             time.sleep(2)

--- a/scripts/wrappers/status.py
+++ b/scripts/wrappers/status.py
@@ -211,7 +211,6 @@ if __name__ == "__main__":
     if wait_ready:
         is_ready = wait_for_ready(timeout)
         if not is_ready:
-            print("Cluster is not ready after {} seconds.".format(timeout))
             sys.exit(1)
     else:
         is_ready = is_cluster_ready()

--- a/scripts/wrappers/status.py
+++ b/scripts/wrappers/status.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 import argparse
+import sys
 
 from common.utils import (
     exit_if_no_permission,
@@ -208,26 +209,29 @@ if __name__ == "__main__":
     yaml_short = args.yaml
 
     if wait_ready:
-        isReady = wait_for_ready(timeout)
+        is_ready = wait_for_ready(timeout)
+        if not is_ready:
+            print("Cluster is not ready after {} seconds.".format(timeout))
+            sys.exit(1)
     else:
-        isReady = is_cluster_ready()
+        is_ready = is_cluster_ready()
 
     available_addons = get_available_addons(get_current_arch())
 
     if args.addon != "all":
         available_addons = get_addon_by_name(available_addons, args.addon)
 
-    enabled, disabled = get_status(available_addons, isReady)
+    enabled, disabled = get_status(available_addons, is_ready)
 
     if args.addon != "all":
         print_addon_status(enabled)
     else:
         if args.format == "yaml":
-            print_yaml(isReady, enabled, disabled)
+            print_yaml(is_ready, enabled, disabled)
         elif args.format == "short":
-            print_short(isReady, enabled, disabled)
+            print_short(is_ready, enabled, disabled)
         else:
             if yaml_short:
-                print_short_yaml(isReady, enabled, disabled)
+                print_short_yaml(is_ready, enabled, disabled)
             else:
-                print_pretty(isReady, enabled, disabled)
+                print_pretty(is_ready, enabled, disabled)

--- a/scripts/wrappers/status.py
+++ b/scripts/wrappers/status.py
@@ -210,8 +210,6 @@ if __name__ == "__main__":
 
     if wait_ready:
         is_ready = wait_for_ready(timeout)
-        if not is_ready:
-            sys.exit(1)
     else:
         is_ready = is_cluster_ready()
 
@@ -234,3 +232,6 @@ if __name__ == "__main__":
                 print_short_yaml(is_ready, enabled, disabled)
             else:
                 print_pretty(is_ready, enabled, disabled)
+
+    if not is_ready:
+        sys.exit(1)


### PR DESCRIPTION
covers part of #3927
* exit with error code 1 if cluster is not ready after timeout
* refactor wait_for_ready to eliminate loop calculation
* refactor variable name according to PEP8

