### PR TITLE
Stop testing mixed version clusters on lxc+strict

### DIFF
--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -8,6 +8,10 @@ import requests
 import signal
 import subprocess
 from os import path
+from utils import (
+    is_strict,
+)
+
 
 # Provide a list of VMs you want to reuse. VMs should have already microk8s installed.
 # the test will attempt a refresh to the channel requested for testing
@@ -281,6 +285,10 @@ class TestCluster(object):
                 assert False
             print("Calico found in node {}".format(vm.vm_name))
 
+    @pytest.mark.skipif(
+        is_strict(),
+        reason="Skipping because calico interfaces are not removed on strict",
+    )
     def test_calico_interfaces_removed_on_snap_remove(self):
         """
         Test that calico interfaces are not present on the node
@@ -591,6 +599,10 @@ class TestUpgradeCluster(object):
                     print("Releasing machine {} in {}".format(vm.vm_name, vm.backend))
                     vm.release()
 
+    @pytest.mark.skipif(
+        is_strict() and backend == "lxc",
+        reason="Skipping test of multi-version cluster on strict and lxc",
+    )
     def test_mixed_version_join(self):
         """
         Test n versioned node joining a n-1 versioned cluster.


### PR DESCRIPTION
This PR disables two tests when testing strict releases.

The `test_calico_interfaces_removed_on_snap_remove` is already disabled in the strict snap. This PR will make the strict patch cleaner.

The `test_mixed_version_join` is new. On lxc when this test runs we receive apparmor denials such as:
```
[ 1167.513699] audit: type=1400 audit(1682088400.887:5468): apparmor="DENIED" operation="chown" profile="snap.microk8s.add-node" name="/var/snap/microk8s/5017/credentials/cluster-tokens.txt" pid=51115 comm="chgrp" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
[ 1167.516199] audit: type=1400 audit(1682088400.891:5469): apparmor="DENIED" operation="chmod" profile="snap.microk8s.add-node" name="/var/snap/microk8s/5017/credentials/cluster-tokens.txt" pid=51117 comm="chmod" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
[ 1167.519332] audit: type=1400 audit(1682088400.895:5470): apparmor="DENIED" operation="chmod" profile="snap.microk8s.add-node" name="/var/snap/microk8s/5017/credentials/cluster-tokens.txt" pid=51120 comm="chmod" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
[ 1167.816437] audit: type=1400 audit(1682088401.191:5471): apparmor="DENIED" operation="open" profile="snap.microk8s.add-node" name="/var/snap/microk8s/5017/credentials/cluster-tokens.txt" pid=51125 comm="python3" requested_mask="ac" denied_mask="ac" fsuid=0 ouid=0
``` 
There must be a bug in the way apparmor profiles are applied because clustering nodes of the same version or if you change the order you provision nodes we do not see this problem. This needs further investigation but for now we have to disable this test.
