### PR TITLE
Allow argument to configure cadvisor containerd connection

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -304,7 +304,6 @@ sanatise_argskubelet() {
     "pod-infra-container-image"
     "experimental-dockershim-root-directory"
     "non-masquerade-cidr"
-    "containerd"
     # Remove container-runtime flag from 1.27+
     "container-runtime"
   )

--- a/microk8s-resources/default-args/kubelet
+++ b/microk8s-resources/default-args/kubelet
@@ -7,6 +7,7 @@
 --feature-gates=DevicePlugins=true
 --eviction-hard="memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi"
 --container-runtime-endpoint=${SNAP_COMMON}/run/containerd.sock
+--containerd=${SNAP_COMMON}/run/containerd.sock
 --node-labels="microk8s.io/cluster=true,node.kubernetes.io/microk8s-controlplane=microk8s-controlplane"
 --authentication-token-webhook=true
 --read-only-port=0


### PR DESCRIPTION
#### Summary
The observability addon fails to pull some metrics on containers. We allow the containerd argument so cadvisor knows where to search for the running containers.

#### Changes
Allow `--containerd` argument and put it in the default arguments.

#### Testing
Manual

