### PR TITLE
Return non-zero on "microk8s status" when service is stopped

### DIFF
--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -221,7 +221,7 @@ def exit_if_stopped():
     stoppedLockFile = os.path.expandvars("${SNAP_DATA}/var/lock/stopped.lock")
     if os.path.isfile(stoppedLockFile):
         print("microk8s is not running, try microk8s start")
-        exit(0)
+        exit(1)
 
 
 def exit_if_no_permission():


### PR DESCRIPTION

#### Summary
microk8s status returns 0 when the server is down.

$ microk8s status --yaml ; echo $?
microk8s is not running, try microk8s start
0

What Should Happen Instead?
I would expect it to return non-zero, so that I don't need to search for text in the output.

This also complicates my life when trying to directly parse its output as yaml.
Closes #3974 
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

It returns 1 instead of 0 when the server is down.

#### Testing
<!-- Please explain how you tested your changes. -->

I DID NOT TEST MY CHANGES. 
Please someone adopt this tiny change and test it for me :) 

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [ ] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
