### PR TITLE
[Backport 1.26-strict] Static link containerd and runc

### DIFF
--- a/build-scripts/components/containerd/build.sh
+++ b/build-scripts/components/containerd/build.sh
@@ -3,6 +3,13 @@
 INSTALL="${1}/bin"
 mkdir -p "${INSTALL}"
 
+VERSION="${2}"
+REVISION=$(git rev-parse HEAD)
+
+sed -i "s,^VERSION.*$,VERSION=${VERSION}," Makefile
+sed -i "s,^REVISION.*$,REVISION=${REVISION}," Makefile
+
+export STATIC=1
 for bin in ctr containerd containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2; do
   make "bin/${bin}"
   cp "bin/${bin}" "${INSTALL}/${bin}"

--- a/build-scripts/components/runc/build.sh
+++ b/build-scripts/components/runc/build.sh
@@ -3,5 +3,5 @@
 export INSTALL="${1}/bin"
 mkdir -p "${INSTALL}"
 
-make BUILDTAGS="seccomp apparmor" EXTRA_LDFLAGS="-s -w"
+make BUILDTAGS="seccomp apparmor" EXTRA_LDFLAGS="-s -w" static
 cp runc "${INSTALL}/runc"


### PR DESCRIPTION
### Summary

Backport #3839 to 1.26-strict