### PR TITLE
[Master] Set non-interactive mode for our tests and robust airgap test

### DIFF
--- a/tests/libs/airgap.sh
+++ b/tests/libs/airgap.sh
@@ -49,8 +49,19 @@ addons:
 
   if [[ ${TO_CHANNEL} =~ /.*/microk8s.*snap ]]
   then
-    lxc file push "${TO_CHANNEL}" "$NAME"/tmp/microk8s_latest_amd64.snap
-    lxc exec "$NAME" -- snap install /tmp/microk8s_latest_amd64.snap --dangerous --classic
+    lxc file push "${TO_CHANNEL}" "$NAME"/var/tmp/microk8s_latest_amd64.snap
+    while ! lxc exec "$NAME" -- bash -c "snap install snapd"; do
+      echo retry install snapd
+      sleep 1
+    done
+    while ! lxc exec "$NAME" -- bash -c "snap install core20"; do
+      echo retry install core20
+      sleep 1
+    done
+    while ! lxc exec "$NAME" -- bash -c "snap install /var/tmp/microk8s_latest_amd64.snap --dangerous --classic"; do
+      echo retry snap install
+      sleep 1
+    done
   else
     lxc exec "$NAME" -- snap install microk8s --channel="${TO_CHANNEL}" --classic
   fi
@@ -87,9 +98,9 @@ function setup_airgapped_microk8s() {
   create_machine "$NAME" "$DISTRO" "$PROXY"
   if [[ ${TO_CHANNEL} =~ /.*/microk8s.*snap ]]
   then
-    lxc file push "${TO_CHANNEL}" "$NAME"/tmp/microk8s.snap
+    lxc file push "${TO_CHANNEL}" "$NAME"/var/tmp/microk8s.snap
   else
-    lxc exec "$NAME" -- snap download microk8s --channel="${TO_CHANNEL}" --target-directory /tmp --basename microk8s
+    lxc exec "$NAME" -- snap download microk8s --channel="${TO_CHANNEL}" --target-directory /var/tmp --basename microk8s
   fi
   while ! lxc exec "$NAME" -- bash -c "snap install snapd"; do
     echo retry install snapd
@@ -146,7 +157,7 @@ addons:
   - name: registry
   " > /root/snap/microk8s/common/.microk8s.yaml
 
-  while ! snap install /tmp/microk8s.snap --dangerous --classic; do
+  while ! snap install /var/tmp/microk8s.snap --dangerous --classic; do
     sleep 1
   done
   '

--- a/tests/libs/utils.sh
+++ b/tests/libs/utils.sh
@@ -37,6 +37,7 @@ function setup_tests() {
   TO_CHANNEL="${3-$TO_CHANNEL}"
   PROXY="${4-$PROXY}"
 
+  export DEBIAN_FRONTEND=noninteractive
   apt-get install python3-pip -y
   pip3 install -U pytest requests pyyaml sh
   apt-get install jq -y

--- a/tests/lxc/install-deps/ubuntu_16.04
+++ b/tests/lxc/install-deps/ubuntu_16.04
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export $(grep -v '^#' /etc/environment | xargs)
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y

--- a/tests/lxc/install-deps/ubuntu_18.04
+++ b/tests/lxc/install-deps/ubuntu_18.04
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export $(grep -v '^#' /etc/environment | xargs)
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y

--- a/tests/lxc/install-deps/ubuntu_20.04
+++ b/tests/lxc/install-deps/ubuntu_20.04
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export $(grep -v '^#' /etc/environment | xargs)
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y

--- a/tests/lxc/install-deps/ubuntu_22.04
+++ b/tests/lxc/install-deps/ubuntu_22.04
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export $(grep -v '^#' /etc/environment | xargs)
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y


### PR DESCRIPTION
#### Summary
- Setting `DEBIAN_FRONTEND=noninteractive` in our CI tests.
- Improvements in airgap test flakiness 