### PR TITLE
Set non-interactive mode for our tests

### DIFF
--- a/tests/lxc/install-deps/ubuntu_16.04
+++ b/tests/lxc/install-deps/ubuntu_16.04
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export $(grep -v '^#' /etc/environment | xargs)
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y

--- a/tests/lxc/install-deps/ubuntu_18.04
+++ b/tests/lxc/install-deps/ubuntu_18.04
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export $(grep -v '^#' /etc/environment | xargs)
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -54,6 +54,7 @@ then
   PROXY=$4
 fi
 
+export DEBIAN_FRONTEND=noninteractive
 # Test clustering. This test will create lxc containers or multipass VMs
 # therefore we do not need to run it inside a VM/container
 apt-get install python3-pip -y


### PR DESCRIPTION
Backport https://github.com/canonical/microk8s/pull/3996 to 1.25