### PR TITLE
Set non-interactive mode for our tests

### DIFF
--- a/tests/lxc/install-deps/ubuntu_16.04
+++ b/tests/lxc/install-deps/ubuntu_16.04
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export $(grep -v '^#' /etc/environment | xargs)
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y

--- a/tests/lxc/install-deps/ubuntu_18.04
+++ b/tests/lxc/install-deps/ubuntu_18.04
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export $(grep -v '^#' /etc/environment | xargs)
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y

--- a/tests/lxc/install-deps/ubuntu_20.04
+++ b/tests/lxc/install-deps/ubuntu_20.04
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export $(grep -v '^#' /etc/environment | xargs)
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y

--- a/tests/lxc/install-deps/ubuntu_22.04
+++ b/tests/lxc/install-deps/ubuntu_22.04
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export $(grep -v '^#' /etc/environment | xargs)
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -53,6 +53,7 @@ then
   PROXY=$4
 fi
 
+export DEBIAN_FRONTEND=noninteractive
 # Test airgap installation.
 # DISABLE_AIRGAP_TESTS=1 can be set to disable them.
 DISABLE_AIRGAP_TESTS="${DISABLE_AIRGAP_TESTS:-0}"


### PR DESCRIPTION
Backport https://github.com/canonical/microk8s/pull/3996 to 1.25-eksd