### PR TITLE
Transition to certificate based auth from token based auth

### DIFF
--- a/build-scripts/components/cluster-agent/version.sh
+++ b/build-scripts/components/cluster-agent/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "main"
+echo "MK-1179/x509-auth"

--- a/build-scripts/components/cluster-agent/version.sh
+++ b/build-scripts/components/cluster-agent/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "MK-1179/x509-auth"
+echo "main"

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -601,7 +601,7 @@ gen_proxy_client_cert() (
 create_user_kubeconfigs() {
   export OPENSSL_CONF="${SNAP}/etc/ssl/openssl.cnf"
   for user in client kubelet scheduler controller proxy; do
-    if ! [ -f ${SNAP_DATA}/certs/$key ]; then
+    if ! [ -f ${SNAP_DATA}/certs/${user} ]; then
       ${SNAP}/usr/bin/openssl genrsa -out ${SNAP_DATA}/certs/${user}.key 2048
     fi
   done
@@ -628,9 +628,7 @@ create_user_kubeconfigs() {
   ${SNAP}/usr/bin/openssl req -new -sha256 -key ${SNAP_DATA}/certs/controller.key -out ${SNAP_DATA}/certs/controller.csr -subj ${subject}
 
   for user in client kubelet scheduler controller proxy; do
-    if ! [ -f ${SNAP_DATA}/certs/$key ]; then
-      ${SNAP}/usr/bin/openssl x509 -req -sha256 -in ${SNAP_DATA}/certs/${user}.csr -CA ${SNAP_DATA}/certs/${user}.crt -CAkey ${SNAP_DATA}/certs/ca.key -CAcreateserial -out ${SNAP_DATA}/certs/${user}.crt -days 3650
-    fi
+    ${SNAP}/usr/bin/openssl x509 -req -sha256 -in ${SNAP_DATA}/certs/${user}.csr -CA ${SNAP_DATA}/certs/ca.crt -CAkey ${SNAP_DATA}/certs/ca.key -CAcreateserial -out ${SNAP_DATA}/certs/${user}.crt -days 3650
   done
 
   mkdir -p ${SNAP_DATA}/credentials
@@ -664,7 +662,7 @@ create_x509_cert() {
   $SNAP/bin/sed -i 's/PATHTOCERT/'"${cert_data}"'/g' ${config_file}
   $SNAP/bin/sed -i 's/PATHTOKEYCERT/'"${key_data}"'/g' ${config_file}
   $SNAP/bin/sed -i 's/client-certificate/client-certificate-data/g' ${config_file}
-  $SNAP/bin/sed -i 's/client-key/client-data/g' ${config_file}
+  $SNAP/bin/sed -i 's/client-key/client-key-data/g' ${config_file}
 }
 
 produce_certs() {

--- a/microk8s-resources/default-args/kube-apiserver
+++ b/microk8s-resources/default-args/kube-apiserver
@@ -8,7 +8,6 @@
 --kubelet-client-certificate=${SNAP_DATA}/certs/server.crt
 --kubelet-client-key=${SNAP_DATA}/certs/server.key
 --secure-port=16443
---token-auth-file=${SNAP_DATA}/credentials/known_tokens.csv
 --etcd-servers="unix://${SNAP_DATA}/var/kubernetes/backend/kine.sock:12379"
 --allow-privileged=true
 --service-account-issuer='https://kubernetes.default.svc'

--- a/scripts/wrappers/common/cluster/utils.py
+++ b/scripts/wrappers/common/cluster/utils.py
@@ -597,3 +597,42 @@ def ca_one_line(ca):
     :return: one line
     """
     return base64.b64encode(ca.encode("utf-8")).decode("utf-8")
+
+
+def rebuild_client_config():
+    """
+    Recreate all the client configs
+    """
+    if is_token_auth_enabled():
+        set_arg('--token-auth-file', None, 'kube-apiserver')
+
+    snapdata_path = os.environ.get("SNAP_DATA")
+    cert_file = "{}/certs/ca.crt".format(snapdata_path)
+    with open(cert_file) as fp:
+        ca = fp.read()
+
+    apiserver_port = get_arg("--secure-port", "kube-apiserver")
+    if not apiserver_port:
+        apiserver_port = 6443
+
+    hostname = socket.gethostname().lower()
+    components = [
+        {"username": "admin", "group":"system:masters", "filename": "client"},
+        {"username": "system:kube-controller-manager", "group": None, "filename": "controller"},
+        {"username": "system:kube-proxy", "group": None, "filename": "proxy"},
+        {"username": "system:kube-scheduler", "group": None, "filename": "scheduler"},
+        {"username": f"system:node:{hostname}", "group": "system:nodes", "filename": "kubelet"},
+    ]
+    for c in components:
+        cert = get_locally_signed_client_cert(c["filename"], c["username"], c["group"])
+        create_x509_kubeconfig(
+            ca,
+            "127.0.0.1",
+            apiserver_port,
+            filename=f"{c['filename']}.config",
+            user=c["username"],
+            path_to_cert=cert["certificate_location"],
+            path_to_cert_key=cert["certificate_key_location"],
+            embed=True
+        )
+

--- a/scripts/wrappers/common/cluster/utils.py
+++ b/scripts/wrappers/common/cluster/utils.py
@@ -599,7 +599,7 @@ def ca_one_line(ca):
     return base64.b64encode(ca.encode("utf-8")).decode("utf-8")
 
 
-def rebuild_client_config():
+def rebuild_client_configs():
     """
     Recreate all the client configs
     """

--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -35,7 +35,7 @@ from common.cluster.utils import (
     is_token_auth_enabled,
     enable_token_auth,
     ca_one_line,
-    rebuild_client_config,
+    rebuild_client_configs,
 )
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -874,7 +874,7 @@ def join_dqlite_master_node(info, master_ip, token):
                 )
     else:
         # We are joining a x509-auth based cluster
-        rebuild_client_config()
+        rebuild_client_configs()
 
 
     if "api_authz_mode" in info:

--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -35,6 +35,7 @@ from common.cluster.utils import (
     is_token_auth_enabled,
     enable_token_auth,
     ca_one_line,
+    rebuild_client_config,
 )
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -871,6 +872,10 @@ def join_dqlite_master_node(info, master_ip, token):
                 create_kubeconfig(
                     component_token, info["ca"], "127.0.0.1", apiserver_port, component[2], component[1]
                 )
+    else:
+        # We are joining a x509-auth based cluster
+        rebuild_client_config()
+
 
     if "api_authz_mode" in info:
         update_apiserver(info["api_authz_mode"])

--- a/scripts/wrappers/leave.py
+++ b/scripts/wrappers/leave.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-import base64
 import json
 import os
 import shutil
@@ -18,7 +17,7 @@ from common.cluster.utils import (
     unmark_no_cert_reissue,
     restart_all_services,
     is_node_dqlite_worker,
-    rebuild_client_configs,
+    rebuild_x509_auth_client_configs,
 )
 
 snapdata_path = os.environ.get("SNAP_DATA")
@@ -41,7 +40,7 @@ def reset_current_dqlite_worker_installation():
 
     service("stop", "apiserver")
     service("stop", "k8s-dqlite")
-    rebuild_client_configs()
+    rebuild_x509_auth_client_configs()
 
     print("Generating new cluster certificates.", flush=True)
     reinit_cluster()
@@ -151,7 +150,7 @@ def reset_current_dqlite_installation():
 
     print("Generating new cluster certificates.", flush=True)
     reinit_cluster()
-    rebuild_client_configs()
+    rebuild_x509_auth_client_configs()
 
     service("start", "k8s-dqlite")
     service("start", "apiserver")

--- a/scripts/wrappers/leave.py
+++ b/scripts/wrappers/leave.py
@@ -18,7 +18,7 @@ from common.cluster.utils import (
     unmark_no_cert_reissue,
     restart_all_services,
     is_node_dqlite_worker,
-    rebuild_client_config,
+    rebuild_client_configs,
 )
 
 snapdata_path = os.environ.get("SNAP_DATA")
@@ -41,7 +41,7 @@ def reset_current_dqlite_worker_installation():
 
     service("stop", "apiserver")
     service("stop", "k8s-dqlite")
-    rebuild_client_config()
+    rebuild_client_configs()
 
     print("Generating new cluster certificates.", flush=True)
     reinit_cluster()
@@ -151,7 +151,7 @@ def reset_current_dqlite_installation():
 
     print("Generating new cluster certificates.", flush=True)
     reinit_cluster()
-    rebuild_client_config()
+    rebuild_client_configs()
 
     service("start", "k8s-dqlite")
     service("start", "apiserver")

--- a/scripts/wrappers/refresh_certs.py
+++ b/scripts/wrappers/refresh_certs.py
@@ -11,7 +11,7 @@ from common.utils import (
 
 from common.cluster.utils import (
     is_token_auth_enabled,
-    rebuild_client_configs,
+    rebuild_x509_auth_client_configs,
 )
 
 snapdata_path = os.environ.get("SNAP_DATA")
@@ -95,7 +95,7 @@ def update_configs():
         )
         p.communicate()
     else:
-        rebuild_client_configs()
+        rebuild_x509_auth_client_configs()
         restart("kubelite")
         restart("cluster-agent")
 

--- a/scripts/wrappers/refresh_certs.py
+++ b/scripts/wrappers/refresh_certs.py
@@ -5,8 +5,14 @@ import subprocess
 from dateutil.parser import parse
 import datetime
 
-from common.utils import exit_if_no_root
+from common.utils import (
+    exit_if_no_root,
+)
 
+from common.cluster.utils import (
+    is_token_auth_enabled,
+    rebuild_client_configs,
+)
 
 snapdata_path = os.environ.get("SNAP_DATA")
 snap_path = os.environ.get("SNAP")
@@ -83,10 +89,15 @@ def update_configs():
     """
     Update all kubeconfig files used by the client and the services
     """
-    p = subprocess.Popen(
-        ["bash", "-c", ". {}/actions/common/utils.sh; update_configs".format(snap_path)]
-    )
-    p.communicate()
+    if is_token_auth_enabled():
+        p = subprocess.Popen(
+            ["bash", "-c", ". {}/actions/common/utils.sh; update_configs".format(snap_path)]
+        )
+        p.communicate()
+    else:
+        rebuild_client_configs()
+        restart("kubelite")
+        restart("cluster-agent")
 
 
 def take_backup():

--- a/scripts/wrappers/remove_node.py
+++ b/scripts/wrappers/remove_node.py
@@ -11,6 +11,7 @@ import netifaces
 from common.cluster.utils import (
     try_set_file_permissions,
     is_node_running_dqlite,
+    is_token_auth_enabled,
 )
 
 snapdata_path = os.environ.get("SNAP_DATA")
@@ -83,7 +84,8 @@ def remove_node(node):
         print("Node {} does not exist.".format(node))
         exit(1)
 
-    remove_kubelet_token(node)
+    if is_token_auth_enabled():
+        remove_kubelet_token(node)
     remove_callback_token(node)
     subprocess.check_call(
         "{}/microk8s-kubectl.wrapper delete no {}".format(snap_path, node).split(),

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -255,106 +255,6 @@ then
     need_kubelet_restart=true
 fi
 
-if ! [ -f "$SNAP_DATA/credentials/kubelet.config" ]
-then
-  # Create the known tokens
-  touch ${SNAP_DATA}/credentials/known_tokens.csv
-  chmod 660 ${SNAP_DATA}/credentials/known_tokens.csv
-  kubelet_token=$(openssl rand -base64 32 | ${SNAP}/usr/bin/base64)
-  hostname=$(hostname | tr '[:upper:]' '[:lower:]')
-  echo "${kubelet_token},system:node:${hostname},kubelet-0,\"system:nodes\"" >> ${SNAP_DATA}/credentials/known_tokens.csv
-  ca_data=$(cat ${SNAP_DATA}/certs/ca.crt | ${SNAP}/usr/bin/base64 -w 0)
-
-  cp ${SNAP}/client.config.template ${SNAP_DATA}/credentials/kubelet.config
-  chmod 660 ${SNAP_DATA}/credentials/kubelet.config
-  $SNAP/bin/sed -i 's/NAME/kubelet/g' ${SNAP_DATA}/credentials/kubelet.config
-  $SNAP/bin/sed -i 's/CADATA/'"${ca_data}"'/g' ${SNAP_DATA}/credentials/kubelet.config
-  $SNAP/bin/sed -i '/username/d' ${SNAP_DATA}/credentials/kubelet.config
-  $SNAP/bin/sed -i 's/AUTHTYPE/token/g' ${SNAP_DATA}/credentials/kubelet.config
-  $SNAP/bin/sed -i 's/PASSWORD/'"${kubelet_token}"'/g' ${SNAP_DATA}/credentials/kubelet.config
-
-  refresh_opt_in_config kubeconfig \${SNAP_DATA}/credentials/kubelet.config kubelet
-  refresh_opt_in_config token-auth-file \${SNAP_DATA}/credentials/known_tokens.csv kube-apiserver
-
-  need_kubelet_restart=true
-  need_api_restart=true
-fi
-
-if ! [ -f "$SNAP_DATA/credentials/proxy.config" ]
-then
-  # Create the known tokens
-  touch ${SNAP_DATA}/credentials/known_tokens.csv
-  chmod 660 ${SNAP_DATA}/credentials/known_tokens.csv
-  proxy_token=$(openssl rand -base64 32 | ${SNAP}/usr/bin/base64)
-  echo "${proxy_token},system:kube-proxy,kube-proxy" >> ${SNAP_DATA}/credentials/known_tokens.csv
-
-  ca_data=$(cat ${SNAP_DATA}/certs/ca.crt | ${SNAP}/usr/bin/base64 -w 0)
-  cp ${SNAP}/client.config.template ${SNAP_DATA}/credentials/proxy.config
-  chmod 660 ${SNAP_DATA}/credentials/proxy.config
-  $SNAP/bin/sed -i 's/NAME/kubeproxy/g' ${SNAP_DATA}/credentials/proxy.config
-  $SNAP/bin/sed -i 's/CADATA/'"${ca_data}"'/g' ${SNAP_DATA}/credentials/proxy.config
-  $SNAP/bin/sed -i '/username/d' ${SNAP_DATA}/credentials/proxy.config
-  $SNAP/bin/sed -i 's/AUTHTYPE/token/g' ${SNAP_DATA}/credentials/proxy.config
-  $SNAP/bin/sed -i 's/PASSWORD/'"${proxy_token}"'/g' ${SNAP_DATA}/credentials/proxy.config
-
-  refresh_opt_in_config kubeconfig \${SNAP_DATA}/credentials/proxy.config kube-proxy
-  skip_opt_in_config master kube-proxy
-  refresh_opt_in_config token-auth-file \${SNAP_DATA}/credentials/known_tokens.csv kube-apiserver
-
-  need_proxy_restart=true
-  need_api_restart=true
-fi
-
-if ! [ -f "$SNAP_DATA/credentials/scheduler.config" ]
-then
-  # Create the known tokens
-  touch ${SNAP_DATA}/credentials/known_tokens.csv
-  chmod 660 ${SNAP_DATA}/credentials/known_tokens.csv
-  scheduler_token=$(openssl rand -base64 32 | ${SNAP}/usr/bin/base64)
-  echo "${scheduler_token},system:kube-scheduler,scheduler" >> ${SNAP_DATA}/credentials/known_tokens.csv
-  ca_data=$(cat ${SNAP_DATA}/certs/ca.crt | ${SNAP}/usr/bin/base64 -w 0)
-  # Create the client kubeconfig for the scheduler
-  cp ${SNAP}/client.config.template ${SNAP_DATA}/credentials/scheduler.config
-  chmod 660 ${SNAP_DATA}/credentials/scheduler.config
-  $SNAP/bin/sed -i 's/CADATA/'"${ca_data}"'/g' ${SNAP_DATA}/credentials/scheduler.config
-  $SNAP/bin/sed -i 's/NAME/scheduler/g' ${SNAP_DATA}/credentials/scheduler.config
-  $SNAP/bin/sed -i '/username/d' ${SNAP_DATA}/credentials/scheduler.config
-  $SNAP/bin/sed -i 's/AUTHTYPE/token/g' ${SNAP_DATA}/credentials/scheduler.config
-  $SNAP/bin/sed -i 's/PASSWORD/'"${scheduler_token}"'/g' ${SNAP_DATA}/credentials/scheduler.config
-
-  refresh_opt_in_config kubeconfig \${SNAP_DATA}/credentials/scheduler.config kube-scheduler
-  skip_opt_in_config master kube-scheduler
-  refresh_opt_in_config token-auth-file \${SNAP_DATA}/credentials/known_tokens.csv kube-apiserver
-
-  need_scheduler_restart=true
-  need_api_restart=true
-fi
-
-if ! [ -f "$SNAP_DATA/credentials/controller.config" ]
-then
-  # Create the known tokens
-  touch ${SNAP_DATA}/credentials/known_tokens.csv
-  chmod 660 ${SNAP_DATA}/credentials/known_tokens.csv
-  controller_token=$(openssl rand -base64 32 | ${SNAP}/usr/bin/base64)
-  echo "${controller_token},system:kube-controller-manager,controller" >> ${SNAP_DATA}/credentials/known_tokens.csv
-  ca_data=$(cat ${SNAP_DATA}/certs/ca.crt | ${SNAP}/usr/bin/base64 -w 0)
-
-  cp ${SNAP}/client.config.template ${SNAP_DATA}/credentials/controller.config
-  chmod 660 ${SNAP_DATA}/credentials/controller.config
-  $SNAP/bin/sed -i 's/CADATA/'"${ca_data}"'/g' ${SNAP_DATA}/credentials/controller.config
-  $SNAP/bin/sed -i 's/NAME/controller/g' ${SNAP_DATA}/credentials/controller.config
-  $SNAP/bin/sed -i '/username/d' ${SNAP_DATA}/credentials/controller.config
-  $SNAP/bin/sed -i 's/AUTHTYPE/token/g' ${SNAP_DATA}/credentials/controller.config
-  $SNAP/bin/sed -i 's/PASSWORD/'"${controller_token}"'/g' ${SNAP_DATA}/credentials/controller.config
-
-  refresh_opt_in_config kubeconfig \${SNAP_DATA}/credentials/controller.config kube-controller-manager
-  skip_opt_in_config master kube-controller-manager
-  refresh_opt_in_config use-service-account-credentials true kube-controller-manager
-
-  refresh_opt_in_config token-auth-file \${SNAP_DATA}/credentials/known_tokens.csv kube-apiserver
-  need_controller_restart=true
-fi
-
 # Add option to support kata containers
 if [ -e "${SNAP_DATA}/args/containerd-env" ] &&
    ! grep -e "KATA_PATH" ${SNAP_DATA}/args/containerd-env
@@ -453,25 +353,6 @@ then
   refresh_opt_in_config etcd-cafile \${SNAP_DATA}/certs/ca.crt kube-apiserver
   refresh_opt_in_config etcd-certfile \${SNAP_DATA}/certs/server.crt kube-apiserver
   refresh_opt_in_config etcd-keyfile \${SNAP_DATA}/certs/server.key kube-apiserver
-  need_api_restart=true
-fi
-
-if grep -e "basic-auth-file" ${SNAP_DATA}/args/kube-apiserver
-then
-  echo "Removing basic auth"
-  # Create the client kubeconfig
-  ca_data=$(cat ${SNAP_DATA}/certs/ca.crt | ${SNAP}/usr/bin/base64 -w 0)
-  admin_token=$(openssl rand -base64 32 | ${SNAP}/usr/bin/base64)
-  echo "${admin_token},admin,admin,\"system:masters\"" >> ${SNAP_DATA}/credentials/known_tokens.csv
-  cp ${SNAP}/client.config.template ${SNAP_DATA}/credentials/client.config
-  chmod 660 ${SNAP_DATA}/credentials/client.config
-  $SNAP/bin/sed -i 's/CADATA/'"${ca_data}"'/g' ${SNAP_DATA}/credentials/client.config
-  $SNAP/bin/sed -i 's/NAME/admin/g' ${SNAP_DATA}/credentials/client.config
-  $SNAP/bin/sed -i '/username/d' ${SNAP_DATA}/credentials/client.config
-  $SNAP/bin/sed -i 's/AUTHTYPE/token/g' ${SNAP_DATA}/credentials/client.config
-  $SNAP/bin/sed -i 's/PASSWORD/'"${admin_token}"'/g' ${SNAP_DATA}/credentials/client.config
-
-  skip_opt_in_config basic-auth-file kube-apiserver
   need_api_restart=true
 fi
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -87,60 +87,7 @@ done
 produce_certs
 rm -rf .srl
 
-mkdir -p ${SNAP_DATA}/credentials
-ca_data=$(cat ${SNAP_DATA}/certs/ca.crt | ${SNAP}/usr/bin/base64 -w 0)
-
-# Create the known tokens
-admin_token=$(openssl rand -base64 32 | ${SNAP}/usr/bin/base64)
-echo "${admin_token},admin,admin,\"system:masters\"" > ${SNAP_DATA}/credentials/known_tokens.csv
-proxy_token=$(${SNAP}/usr/bin/openssl rand -base64 32 | ${SNAP}/usr/bin/base64)
-echo "${proxy_token},system:kube-proxy,kube-proxy" >> ${SNAP_DATA}/credentials/known_tokens.csv
-kubelet_token=$(${SNAP}/usr/bin/openssl rand -base64 32 | ${SNAP}/usr/bin/base64)
-hostname=$(hostname | tr '[:upper:]' '[:lower:]')
-echo "${kubelet_token},system:node:${hostname},kubelet-0,\"system:nodes\"" >> ${SNAP_DATA}/credentials/known_tokens.csv
-controller_token=$(${SNAP}/usr/bin/openssl rand -base64 32 | ${SNAP}/usr/bin/base64)
-echo "${controller_token},system:kube-controller-manager,controller" >> ${SNAP_DATA}/credentials/known_tokens.csv
-scheduler_token=$(${SNAP}/usr/bin/openssl rand -base64 32 | ${SNAP}/usr/bin/base64)
-echo "${scheduler_token},system:kube-scheduler,scheduler" >> ${SNAP_DATA}/credentials/known_tokens.csv
-
-# Create the client kubeconfig
-cp ${SNAP}/client.config.template ${SNAP_DATA}/credentials/client.config
-$SNAP/bin/sed -i 's/CADATA/'"${ca_data}"'/g' ${SNAP_DATA}/credentials/client.config
-$SNAP/bin/sed -i 's/NAME/admin/g' ${SNAP_DATA}/credentials/client.config
-$SNAP/bin/sed -i '/username/d' ${SNAP_DATA}/credentials/client.config
-$SNAP/bin/sed -i 's/AUTHTYPE/token/g' ${SNAP_DATA}/credentials/client.config
-$SNAP/bin/sed -i 's/PASSWORD/'"${admin_token}"'/g' ${SNAP_DATA}/credentials/client.config
-
-# Create the client kubeconfig for the controller
-cp ${SNAP}/client.config.template ${SNAP_DATA}/credentials/controller.config
-$SNAP/bin/sed -i 's/CADATA/'"${ca_data}"'/g' ${SNAP_DATA}/credentials/controller.config
-$SNAP/bin/sed -i 's/NAME/controller/g' ${SNAP_DATA}/credentials/controller.config
-$SNAP/bin/sed -i '/username/d' ${SNAP_DATA}/credentials/controller.config
-$SNAP/bin/sed -i 's/AUTHTYPE/token/g' ${SNAP_DATA}/credentials/controller.config
-$SNAP/bin/sed -i 's/PASSWORD/'"${controller_token}"'/g' ${SNAP_DATA}/credentials/controller.config
-
-# Create the client kubeconfig for the scheduler
-cp ${SNAP}/client.config.template ${SNAP_DATA}/credentials/scheduler.config
-$SNAP/bin/sed -i 's/CADATA/'"${ca_data}"'/g' ${SNAP_DATA}/credentials/scheduler.config
-$SNAP/bin/sed -i 's/NAME/scheduler/g' ${SNAP_DATA}/credentials/scheduler.config
-$SNAP/bin/sed -i '/username/d' ${SNAP_DATA}/credentials/scheduler.config
-$SNAP/bin/sed -i 's/AUTHTYPE/token/g' ${SNAP_DATA}/credentials/scheduler.config
-$SNAP/bin/sed -i 's/PASSWORD/'"${scheduler_token}"'/g' ${SNAP_DATA}/credentials/scheduler.config
-
-# Create the proxy and kubelet kubeconfig
-cp ${SNAP}/client.config.template ${SNAP_DATA}/credentials/kubelet.config
-$SNAP/bin/sed -i 's/NAME/kubelet/g' ${SNAP_DATA}/credentials/kubelet.config
-$SNAP/bin/sed -i 's/CADATA/'"${ca_data}"'/g' ${SNAP_DATA}/credentials/kubelet.config
-$SNAP/bin/sed -i '/username/d' ${SNAP_DATA}/credentials/kubelet.config
-$SNAP/bin/sed -i 's/AUTHTYPE/token/g' ${SNAP_DATA}/credentials/kubelet.config
-$SNAP/bin/sed -i 's/PASSWORD/'"${kubelet_token}"'/g' ${SNAP_DATA}/credentials/kubelet.config
-
-cp ${SNAP}/client.config.template ${SNAP_DATA}/credentials/proxy.config
-$SNAP/bin/sed -i 's/NAME/kubeproxy/g' ${SNAP_DATA}/credentials/proxy.config
-$SNAP/bin/sed -i 's/CADATA/'"${ca_data}"'/g' ${SNAP_DATA}/credentials/proxy.config
-$SNAP/bin/sed -i '/username/d' ${SNAP_DATA}/credentials/proxy.config
-$SNAP/bin/sed -i 's/AUTHTYPE/token/g' ${SNAP_DATA}/credentials/proxy.config
-$SNAP/bin/sed -i 's/PASSWORD/'"${proxy_token}"'/g' ${SNAP_DATA}/credentials/proxy.config
+create_user_kubeconfigs
 
 # Install default-hooks
 cp -r --preserve=mode ${SNAP}/default-hooks ${SNAP_COMMON}/hooks

--- a/tests/unit/cluster/test_join.py
+++ b/tests/unit/cluster/test_join.py
@@ -1,3 +1,8 @@
+import os
+from shutil import rmtree
+from unittest import mock
+
+import join
 from click.testing import CliRunner
 from join import join as command
 
@@ -15,3 +20,139 @@ def test_command_errors_if_no_arguments():
     result = runner.invoke(command, [])
     assert result.exit_code != 0
     assert "Error: Missing argument" in result.output
+
+
+@mock.patch("subprocess.check_call")
+@mock.patch("os.chown")
+@mock.patch("os.chmod")
+@mock.patch("subprocess.check_output")
+@mock.patch("time.sleep")
+def test_join_dqlite_master_node(
+    mock_sleep,
+    mock_subprocess_check_output,
+    mock_chmod,
+    mock_chown,
+    mock_subprocess_check_call,
+    tmp_path,
+):
+    """
+    Test the join operation. Create a directory layout and let the join operation work with it.
+    """
+    snapcommon = tmp_path / "snapcommon"
+    snapdata = tmp_path / "snapdata" / "rev-123"
+    snapdatacurrnet = tmp_path / "snapdata" / "current"
+    snap = tmp_path / "snap"
+    args = snapdata / "args"
+    certs = snapdata / "certs"
+    credentials = snapdata / "credentials"
+    dqlite = snapdata / "var" / "kubernetes" / "backend"
+
+    join.snapdata_path = snapdata
+    join.snap_path = snap
+    join.cluster_dir = f"{snapdata}/var/kubernetes/backend"
+    join.cluster_backup_dir = f"{snapdata}/var/kubernetes/backend.backup"
+    join.cluster_cert_file = f"{join.cluster_dir}/cluster.crt"
+    join.cluster_key_file = f"{join.cluster_dir}/cluster.key"
+
+    os.environ["SNAP"] = str(snap)
+    os.environ["SNAP_DATA"] = str(snapdata)
+    os.environ["SNAP_COMMON"] = str(snapcommon)
+
+    def create_dir_layout(tokens):
+        for d in [
+            snapcommon,
+            snapdata,
+            dqlite,
+            snap,
+            args / "cni-network",
+            snapdata / "var" / "lock",
+            certs,
+            credentials,
+        ]:
+            if os.path.exists(d):
+                rmtree(d, ignore_errors=True)
+            os.makedirs(d, exist_ok=True)
+
+        if os.path.exists(snapdatacurrnet):
+            os.remove(snapdatacurrnet)
+        snapdatacurrnet
+        os.symlink(snapdata, snapdatacurrnet)
+        for cert in ["ca", "client", "controller", "proxy", "scheduler", "kubelet"]:
+            with open(certs / f"{cert}.crt", "w") as ca:
+                ca.write(f"{cert}_data")
+            with open(certs / f"{cert}.key", "w") as ca:
+                ca.write(f"{cert}_key_data")
+
+        with open(certs / "serviceaccount.key", "w") as f:
+            f.write("service_account_key_data")
+        with open(args / "kube-apiserver", "w") as f:
+            f.write("--some-argument")
+        with open(dqlite / "info.yaml", "w") as f:
+            f.write("Address: 127.0.0.1:19001\nID: 3297041220608546238\nRole: 0\n")
+        with open(args / "cni-network" / "cni.yaml", "w") as f:
+            f.write("can-reach\n")
+        with open(snap / "client.config.template", "w") as f:
+            f.write("token\nUSERNAME")
+        with open(snap / "client-x509.config.template", "w") as f:
+            f.write("x509\nUSERNAME")
+        for config in [
+            "client.config",
+            "controller.config",
+            "proxy.config",
+            "scheduler.config",
+            "kubelet.config",
+        ]:
+            with open(credentials / config, "w") as f:
+                f.write("kubeconfig")
+
+    create_dir_layout(tokens=False)
+
+    info = {
+        "hostname_override": "no-host",
+        "ca": "new_ca_bytes",
+        "ca_key": "new_ca_key_bytes",
+        "service_account_key": "srv_account_key_bytes",
+        "kubelet_args": "--some-kubelet-arg",
+        "callback_token": "123callback456",
+        "cluster_cert": "dqlite_cert",
+        "cluster_key": "dqlite_cert_key",
+        "voters": "none",
+    }
+
+    join.join_dqlite_master_node(info, "123.123.123.123")
+
+    # Assert we stored the CA and the dqlite certs
+    mock_chmod.assert_any_call(str(certs / "ca.crt"), 0o660)
+    mock_chmod.assert_any_call(str(certs / "ca.key"), 0o660)
+    mock_chmod.assert_any_call(str(dqlite / "cluster.crt"), 0o660)
+    mock_chmod.assert_any_call(str(dqlite / "cluster.key"), 0o660)
+
+    # Assert we restart services
+    mock_subprocess_check_call.assert_any_call("snapctl stop microk8s.daemon-kubelite".split())
+    mock_subprocess_check_call.assert_any_call("snapctl start microk8s.daemon-kubelite".split())
+    mock_subprocess_check_call.assert_any_call("snapctl stop microk8s.daemon-k8s-dqlite".split())
+    mock_subprocess_check_call.assert_any_call("snapctl start microk8s.daemon-k8s-dqlite".split())
+
+    # Assert we created admin kubeconfig from certificate
+    cmd = f"{snap / 'usr/bin/openssl'} req -new -sha256 -key {snapdatacurrnet / 'certs' / 'client.key'} \
+        -out {snapdatacurrnet / 'certs' / 'client.csr'} \
+        -subj /CN=admin/O=system:masters"
+    mock_subprocess_check_call.assert_any_call(cmd.split(), stdout=-3, stderr=-3)
+    with open(credentials / "client.config", "r") as f:
+        content = f.read()
+        assert "x509" in content
+        assert "token" not in content
+        assert "admin" in content
+
+    # Check joining with tokens based
+    create_dir_layout(tokens=True)
+    mock_subprocess_check_call.reset_mock()
+    info["admin_token"] = "some-token"
+    join.join_dqlite_master_node(info, "123.123.123.123")
+
+    # Assert we created admin kubeconfig from certificate
+    with open(credentials / "client.config", "r") as f:
+        content = f.read()
+        assert "token" in content
+        assert "x509" not in content
+        assert "admin" in content

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 [testenv:lint]
 commands =
     flake8 --max-line-length=120 --ignore=C901,N801,N802,N803,N806,N816,W503,E203
-    codespell --ignore-words-list="aks" --quiet-level=2 --skip="*.patch,*.spec,.tox_env,.git,*.nsi"
+    codespell --ignore-words-list="aks,ccompiler" --quiet-level=2 --skip="*.patch,*.spec,.tox_env,.git,*.nsi"
     black --diff --check --exclude "/(\.eggs|\.git|\.tox|\.venv|\.build|dist|charmhelpers|mod)/" .
 
 [testenv:scripts]


### PR DESCRIPTION
#### Summary
By default issue certificates for authentication. Replace the token based approach we have but keep backwards compatibility.

#### Changes
When initializing the cluster x509 certs are created and placed in the kubeconfig files.
When joining a cluster use the `auth_token` filed to decide if we are joining a cluster that is using tokens and configure properly the cluster.

#### Testing
Unit test to check the two join paths (token and certificate). 
The clustering tests check the join operations.
Manual testing.

#### Possible Regressions
Yes!
