### PR TITLE
1.25 strict update with latest 1.25 changes

### DIFF
--- a/build-scripts/components/cluster-agent/version.sh
+++ b/build-scripts/components/cluster-agent/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "main"
+echo "1.25"

--- a/build-scripts/components/containerd/build.sh
+++ b/build-scripts/components/containerd/build.sh
@@ -3,6 +3,13 @@
 INSTALL="${1}/bin"
 mkdir -p "${INSTALL}"
 
+VERSION="${2}"
+REVISION=$(git rev-parse HEAD)
+
+sed -i "s,^VERSION.*$,VERSION=${VERSION}," Makefile
+sed -i "s,^REVISION.*$,REVISION=${REVISION}," Makefile
+
+export STATIC=1
 for bin in ctr containerd containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2; do
   make "bin/${bin}"
   cp "bin/${bin}" "${INSTALL}/${bin}"

--- a/build-scripts/components/runc/build.sh
+++ b/build-scripts/components/runc/build.sh
@@ -3,5 +3,5 @@
 export INSTALL="${1}/bin"
 mkdir -p "${INSTALL}"
 
-make BUILDTAGS="seccomp apparmor" EXTRA_LDFLAGS="-s -w"
+make BUILDTAGS="seccomp apparmor" EXTRA_LDFLAGS="-s -w" static
 cp runc "${INSTALL}/runc"

--- a/microk8s-resources/wrappers/microk8s-start.wrapper
+++ b/microk8s-resources/wrappers/microk8s-start.wrapper
@@ -55,7 +55,7 @@ else
     if run_with_sudo test -e ${SNAP_DATA}/var/lock/stopped.lock
     then
         # Mark the api server as starting
-        run_with_sudo rm ${SNAP_DATA}/var/lock/stopped.lock &> /dev/null
+        run_with_sudo rm -f ${SNAP_DATA}/var/lock/stopped.lock &> /dev/null
     fi
 fi
 

--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -826,7 +826,6 @@ def join_dqlite_worker_node(info, master_ip, master_port, token):
         exit(1)
 
     store_remote_ca(info["ca"])
-    store_cert("serviceaccount.key", info["service_account_key"])
 
     store_base_kubelet_args(info["kubelet_args"])
     update_kubelet_node_ip(info["kubelet_args"], hostname_override)

--- a/tests/lxc/install-deps/ubuntu_16.04
+++ b/tests/lxc/install-deps/ubuntu_16.04
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export $(grep -v '^#' /etc/environment | xargs)
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y

--- a/tests/lxc/install-deps/ubuntu_18.04
+++ b/tests/lxc/install-deps/ubuntu_18.04
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export $(grep -v '^#' /etc/environment | xargs)
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y

--- a/tests/lxc/install-deps/ubuntu_20.04
+++ b/tests/lxc/install-deps/ubuntu_20.04
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export $(grep -v '^#' /etc/environment | xargs)
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y

--- a/tests/lxc/install-deps/ubuntu_22.04
+++ b/tests/lxc/install-deps/ubuntu_22.04
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export $(grep -v '^#' /etc/environment | xargs)
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y

--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -419,7 +419,7 @@ class TestCluster(object):
                 connected_nodes = vm_master.run("/snap/bin/microk8s.kubectl get no")
                 if (
                     "NotReady" in connected_nodes.decode()
-                    and vm.vm_name not in connected_nodes.decode()
+                    or vm.vm_name not in connected_nodes.decode()
                 ):
                     time.sleep(5)
                     continue

--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -449,13 +449,9 @@ class TestCluster(object):
             try:
                 connected_nodes = vm_master.run("/snap/bin/microk8s.kubectl get no")
                 print(connected_nodes.decode())
-                if (
-                    "NotReady" in connected_nodes.decode()
-                    and vm.vm_name in connected_nodes.decode()
-                ):
+                if "NotReady" in connected_nodes.decode() or vm.vm_name in connected_nodes.decode():
                     time.sleep(5)
                     continue
-                print(connected_nodes.decode())
                 break
             except ChildProcessError:
                 time.sleep(10)

--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -393,7 +393,7 @@ class TestCluster(object):
                     continue
             break
 
-    def test_worker_noode(self):
+    def test_worker_node(self):
         """
         Test a worker node is setup
         """
@@ -417,7 +417,10 @@ class TestCluster(object):
         while attempt < 10:
             try:
                 connected_nodes = vm_master.run("/snap/bin/microk8s.kubectl get no")
-                if "NotReady" in connected_nodes.decode():
+                if (
+                    "NotReady" in connected_nodes.decode()
+                    and vm.vm_name not in connected_nodes.decode()
+                ):
                     time.sleep(5)
                     continue
                 print(connected_nodes.decode())
@@ -434,6 +437,43 @@ class TestCluster(object):
         assert master_ip in provider.decode()
         kubelet = vm.run("cat /var/snap/microk8s/current/credentials/kubelet.config")
         assert "127.0.0.1" in kubelet.decode()
+
+        # Leave the worker node from the cluster
+        print("Leaving the worker node {} from the cluster".format(vm.vm_name))
+        vm.run("/snap/bin/microk8s.leave")
+        vm_master.run("/snap/bin/microk8s.remove-node {}".format(vm.vm_name))
+
+        # Wait for worker node to leave the cluster
+        attempt = 0
+        while attempt < 10:
+            try:
+                connected_nodes = vm_master.run("/snap/bin/microk8s.kubectl get no")
+                print(connected_nodes.decode())
+                if (
+                    "NotReady" in connected_nodes.decode()
+                    and vm.vm_name in connected_nodes.decode()
+                ):
+                    time.sleep(5)
+                    continue
+                print(connected_nodes.decode())
+                break
+            except ChildProcessError:
+                time.sleep(10)
+                attempt += 1
+                if attempt == 10:
+                    raise
+
+        # Check that the worker node is Ready
+        print("Checking that the worker node {} is working and Ready".format(vm.vm_name))
+        worker_node = vm.run("/snap/bin/microk8s status --wait-ready")
+        print(worker_node.decode())
+        assert "microk8s is running" in worker_node.decode()
+
+        # The removed node now isn't part of the cluster and will re-issue certificates.
+        # This will interfere when testing `test_no_cert_reissue_in_nodes`.
+        # Hence, we remove this machine from the VM list.
+        print("Remove machine {}".format(vm.vm_name))
+        self.VM.remove(vm)
 
     def test_no_cert_reissue_in_nodes(self):
         """

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -52,6 +52,7 @@ if [ "$#" -ne 3 ]
 then
   PROXY=$4
 fi
+export DEBIAN_FRONTEND=noninteractive
 
 # Test airgap installation.
 # DISABLE_AIRGAP_TESTS=1 can be set to disable them.


### PR DESCRIPTION
#### Summary
Backport:
- CI fixes
- static builds of containerd/runc
- leave worker node test