### PR TITLE
Permissions fixes in CIS hardened deployments

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -9,6 +9,16 @@ get_microk8s_group() {
   fi
 }
 
+get_microk8s_or_cis_group() {
+  if [ -e $SNAP_DATA/var/lock/cis-hardening ]
+  then
+    echo "root"
+  else
+    get_microk8s_group
+  fi
+}
+
+
 exit_if_no_permissions() {
   # test if we can access the default kubeconfig
   if [ ! -r $SNAP_DATA/credentials/client.config ]; then

--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -38,7 +38,7 @@ do
     # every 5 seconds
     sleep 5
     if [ -e "${SNAP_DATA}/var/lock/ha-cluster" ] &&
-      [ ! -e "${SNAP_DATA}/var/lock/cis-hardening ] &&
+      [ ! -e "${SNAP_DATA}/var/lock/cis-hardening" ] &&
       getent group ${group} >/dev/null 2>&1
     then
       chmod -R ug+rwX ${SNAP_DATA}/var/kubernetes/backend || true

--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -23,7 +23,7 @@ then
 	exit 0
 fi
 
-group=$(get_microk8s_group)
+group=$(get_microk8s_or_cis_group)
 restart_attempt=0
 installed_registry_help=0
 
@@ -38,6 +38,7 @@ do
     # every 5 seconds
     sleep 5
     if [ -e "${SNAP_DATA}/var/lock/ha-cluster" ] &&
+      [ ! -e "${SNAP_DATA}/var/lock/cis-hardening ] &&
       getent group ${group} >/dev/null 2>&1
     then
       chmod -R ug+rwX ${SNAP_DATA}/var/kubernetes/backend || true

--- a/microk8s-resources/wrappers/microk8s-add-node.wrapper
+++ b/microk8s-resources/wrappers/microk8s-add-node.wrapper
@@ -51,7 +51,7 @@ if [ ! -f "$SNAP_DATA/credentials/cluster-tokens.txt" ]; then
   touch $SNAP_DATA/credentials/cluster-tokens.txt
 fi
 
-group=$(get_microk8s_group)
+group=$(get_microk8s_or_cis_group)
 
 if getent group ${group} >/dev/null 2>&1
 then

--- a/scripts/wrappers/addons.py
+++ b/scripts/wrappers/addons.py
@@ -11,7 +11,8 @@ import click
 import jsonschema
 import yaml
 
-from common.utils import get_current_arch, snap_common, get_group, snap, exit_if_no_root
+from common.utils import get_current_arch, snap_common, snap, exit_if_no_root
+from common.cluster.utils import get_group
 
 GIT = os.path.expandvars("$SNAP/git.wrapper")
 

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -12,22 +12,14 @@ import logging
 import click
 import yaml
 
-from .cluster.utils import try_set_file_permissions
+from common.cluster.utils import (
+    try_set_file_permissions,
+    is_strict,
+)
 
 LOG = logging.getLogger(__name__)
 
 KUBECTL = os.path.expandvars("$SNAP/microk8s-kubectl.wrapper")
-
-
-def get_group():
-    return "snap_microk8s" if is_strict() else "microk8s"
-
-
-def is_strict():
-    snap_yaml = snap() / "meta/snap.yaml"
-    with open(snap_yaml) as f:
-        snap_meta = yaml.safe_load(f)
-    return snap_meta["confinement"] == "strict"
 
 
 def get_current_arch():
@@ -227,8 +219,8 @@ def exit_if_stopped():
 def exit_if_no_permission():
     user = getpass.getuser()
     # test if we can access the default kubeconfig
-    clientConfigFile = os.path.expandvars("${SNAP_DATA}/credentials/client.config")
-    if not os.access(clientConfigFile, os.R_OK):
+    client_config_file = os.path.expandvars("${SNAP_DATA}/credentials/client.config")
+    if not os.access(client_config_file, os.R_OK):
         print("Insufficient permissions to access MicroK8s.")
         print(
             "You can either try again with sudo or add the user {} to the 'microk8s' group:".format(

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -268,7 +268,7 @@ do
   chmod -R o-rwX ${dir}
 done
 
-group=$(get_microk8s_group)
+group=$(get_microk8s_or_cis_group)
 
 # Try to create the snap_microk8s group. Do not fail the installation if something goes wrong
 if ! getent group ${group} >/dev/null 2>&1

--- a/tests/unit/cluster/test_join.py
+++ b/tests/unit/cluster/test_join.py
@@ -63,7 +63,7 @@ def test_join_dqlite_master_node(
             snapcommon,
             snapdata,
             dqlite,
-            snap,
+            snap / "meta",
             args / "cni-network",
             snapdata / "var" / "lock",
             certs,
@@ -83,6 +83,8 @@ def test_join_dqlite_master_node(
             with open(certs / f"{cert}.key", "w") as ca:
                 ca.write(f"{cert}_key_data")
 
+        with open(snap / "meta" / "snap.yaml", "w") as f:
+            f.write("confinement: classic")
         with open(certs / "serviceaccount.key", "w") as f:
             f.write("service_account_key_data")
         with open(args / "kube-apiserver", "w") as f:


### PR DESCRIPTION
#### Summary
This PR makes sure that when we create or edit files and we have applied CIS hardening we keep the file ownership group root and set access permissions to 600

#### Notes
This PR builds on top of https://github.com/canonical/microk8s/pull/4013 so it has to be merged after it.