### PR TITLE
Set EventRateLimit by default

### DIFF
--- a/microk8s-resources/default-args/admission-control-config-file.yaml
+++ b/microk8s-resources/default-args/admission-control-config-file.yaml
@@ -1,0 +1,5 @@
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+  - name: EventRateLimit
+    path: eventconfig.yaml

--- a/microk8s-resources/default-args/eventconfig.yaml
+++ b/microk8s-resources/default-args/eventconfig.yaml
@@ -1,0 +1,6 @@
+apiVersion: eventratelimit.admission.k8s.io/v1alpha1
+kind: Configuration
+limits:
+  - type: Server
+    qps: 5000
+    burst: 20000

--- a/microk8s-resources/default-args/kube-apiserver
+++ b/microk8s-resources/default-args/kube-apiserver
@@ -25,3 +25,5 @@
 --proxy-client-cert-file=${SNAP_DATA}/certs/front-proxy-client.crt
 --proxy-client-key-file=${SNAP_DATA}/certs/front-proxy-client.key
 #~Enable the aggregation layer
+--enable-admission-plugins=EventRateLimit
+--admission-control-config-file=${SNAP_DATA}/args/admission-control-config-file.yaml


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
We make the CIS Checks 1.2.9 for `eventratelimit` default argument for kube-apiserver.
The default configuration is set to 
```
limits:
  - type: Server
    qps: 5000
    burst: 20000
```
to limit the requests to API server. This can definitely be changed according to the user's needs.

#### Testing
<!-- Please explain how you tested your changes. -->
Locally build the snap to verify the presence of arguments and configuration in `/var/snap/microk8s/current/args`

#### Notes
<!-- Please add any other information that you think may be relevant -->
Other Relevant PR: https://github.com/canonical/microk8s-core-addons/pull/195