### PR TITLE
Configure kubelet webhook auth-mode

### DIFF
--- a/microk8s-resources/default-args/manifests/kube-apiserver-to-kubelet.yaml
+++ b/microk8s-resources/default-args/manifests/kube-apiserver-to-kubelet.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:kube-apiserver-to-kubelet
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/proxy
+      - nodes/stats
+      - nodes/log
+      - nodes/spec
+      - nodes/metrics
+    verbs:
+      - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:kube-apiserver
+  namespace: ""
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-apiserver-to-kubelet
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: 127.0.0.1

--- a/microk8s-resources/default-hooks/reconcile.d/20-apiserver-to-kubelet
+++ b/microk8s-resources/default-hooks/reconcile.d/20-apiserver-to-kubelet
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+. "${SNAP}/actions/common/utils.sh"
+
+KUBECTL="${SNAP}/microk8s-kubectl.wrapper"
+
+if ! [ -e "${SNAP_DATA}/var/lock/kube-apiserver-to-kubelet-roles" ]
+then
+  echo "Apply kube-apiserver to kubelet communication RBAC rules"
+  mkdir -p "${SNAP_DATA}/args/manifests"
+  if ! [ -e "${SNAP_DATA}/args/manifests/kube-apiserver-to-kubelet.yaml" ]
+  then
+    cp "${SNAP}/default-args/manifests/kube-apiserver-to-kubelet.yaml" "${SNAP_DATA}/args/manifests/kube-apiserver-to-kubelet.yaml"
+  fi
+
+  if (is_apiserver_ready) && "${KUBECTL}" apply -f "${SNAP_DATA}/args/manifests/kube-apiserver-to-kubelet.yaml"
+  then
+    touch "${SNAP_DATA}/var/lock/kube-apiserver-to-kubelet-roles"
+  fi
+fi

--- a/scripts/wrappers/common/cluster/utils.py
+++ b/scripts/wrappers/common/cluster/utils.py
@@ -650,8 +650,8 @@ def rebuild_x509_auth_client_configs():
         apiserver_port = "6443"
 
     hostname = socket.gethostname().lower()
-    csr_conf_file = "{}/certs/kubelet.csr.conf".format(snapdata_path)
-    with open(csr_conf_file, 'w') as fp:
+    csr_file = "{}/certs/kubelet.csr.conf".format(snapdata_path)
+    with open(csr_file, 'w') as fp:
         fp.write("subjectAltName=DNS:{}\n".format(hostname))
 
     components = [
@@ -659,7 +659,7 @@ def rebuild_x509_auth_client_configs():
         {"username": "system:kube-controller-manager", "group": None, "filename": "controller", "extfile": None},
         {"username": "system:kube-proxy", "group": None, "filename": "proxy", "extfile": None},
         {"username": "system:kube-scheduler", "group": None, "filename": "scheduler", "extfile": None},
-        {"username": f"system:node:{hostname}", "group": "system:nodes", "filename": "kubelet", "extfile": csr_conf_file},
+        {"username": f"system:node:{hostname}", "group": "system:nodes", "filename": "kubelet", "extfile": csr_file},
     ]
     for c in components:
         cert = get_locally_signed_client_cert(c["filename"], c["username"], c["group"], c["extfile"])

--- a/scripts/wrappers/common/cluster/utils.py
+++ b/scripts/wrappers/common/cluster/utils.py
@@ -651,18 +651,35 @@ def rebuild_x509_auth_client_configs():
 
     hostname = socket.gethostname().lower()
     csr_file = "{}/certs/kubelet.csr.conf".format(snapdata_path)
-    with open(csr_file, 'w') as fp:
+    with open(csr_file, "w") as fp:
         fp.write("subjectAltName=DNS:{}\n".format(hostname))
 
     components = [
         {"username": "admin", "group": "system:masters", "filename": "client", "extfile": None},
-        {"username": "system:kube-controller-manager", "group": None, "filename": "controller", "extfile": None},
+        {
+            "username": "system:kube-controller-manager",
+            "group": None,
+            "filename": "controller",
+            "extfile": None,
+        },
         {"username": "system:kube-proxy", "group": None, "filename": "proxy", "extfile": None},
-        {"username": "system:kube-scheduler", "group": None, "filename": "scheduler", "extfile": None},
-        {"username": f"system:node:{hostname}", "group": "system:nodes", "filename": "kubelet", "extfile": csr_file},
+        {
+            "username": "system:kube-scheduler",
+            "group": None,
+            "filename": "scheduler",
+            "extfile": None,
+        },
+        {
+            "username": f"system:node:{hostname}",
+            "group": "system:nodes",
+            "filename": "kubelet",
+            "extfile": csr_file,
+        },
     ]
     for c in components:
-        cert = get_locally_signed_client_cert(c["filename"], c["username"], c["group"], c["extfile"])
+        cert = get_locally_signed_client_cert(
+            c["filename"], c["username"], c["group"], c["extfile"]
+        )
         create_x509_kubeconfig(
             ca,
             "127.0.0.1",

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -204,6 +204,12 @@ then
   cp -r --preserve=mode ${SNAP}/default-hooks ${SNAP_COMMON}/hooks
 fi
 
+# Install the kube-apiserver to kubelet roles hook
+if ! [ -e "${SNAP_COMMON}/hooks/reconcile.d/20-apiserver-to-kubelet" ]
+then
+  cp -r --preserve=mode ${SNAP}/default-hooks/reconcile.d/20-apiserver-to-kubelet ${SNAP_COMMON}/hooks/reconcile.d/20-apiserver-to-kubelet
+fi
+
 # Make sure the server certificate includes the IP we are using
 if [ "$(produce_certs)" == "1" ]
 then


### PR DESCRIPTION
#### Summary
This PR configures MicroK8s correctly so it can support kubelet webhook auth mode properly.

First we make sure the certificate kubelet presents to its 10250 interface is valid for the host it runs on. This requires we use the `-extfile` flag of `openssl x509 -req`.

Second we make sure there are RBAC rules so that when the API server asks for things like for example pod logs that request is allowed. We apply the respective ClusterRules as part of the reconciliation loop run by the apiserver-kicker. 
 
Fixes: https://github.com/canonical/microk8s/issues/3965
