### PR TITLE
Add --kubelet-certificate-authority as default in api-server

### DIFF
--- a/microk8s-resources/default-args/kube-apiserver
+++ b/microk8s-resources/default-args/kube-apiserver
@@ -27,3 +27,4 @@
 #~Enable the aggregation layer
 --enable-admission-plugins=EventRateLimit
 --admission-control-config-file=${SNAP_DATA}/args/admission-control-config-file.yaml
+--kubelet-certificate-authority=${SNAP_DATA}/certs/ca.crt


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
Add the argument `--kubelet-certificate-authority` as default in kube api-server.

#### Testing
<!-- Please explain how you tested your changes. -->
Tested locally by building the snap and enabling and disabling CIS addon.
