### PR TITLE
Prioritize in-snap PYTHONPATH and PATH vars

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,8 @@ confinement: classic
 base: core20
 assumes: [snapd2.52]
 environment:
-  PYTHONPATH: $PYTHONPATH:/usr/lib/python3.8:/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.8:$SNAP/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages
+  PYTHONPATH: $SNAP/usr/lib/python3.8:$SNAP/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+  PATH: $SNAP/usr/bin:$SNAP/bin:$SNAP/usr/sbin:$SNAP/sbin:$PATH
 
 parts:
   build-deps:


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

References #4047, https://github.com/canonical/microk8s-core-addons/issues/192

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

Setup PYTHONPATH and PATH so that binaries and libraries from the snap are always prioritized

#### Testing
<!-- Please explain how you tested your changes. -->

Fixes the two referenced issues, does not seem to cause regressions elsewhere (commands work ok, no warnings/errors in the logs

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

Yes, in case we are silently using and depending on binaries outside of the snap, but in this case we want to know about it either way.

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
