### PR TITLE
Add label to disable juju webhooks on node objects

### DIFF
--- a/microk8s-resources/default-args/kubelet
+++ b/microk8s-resources/default-args/kubelet
@@ -8,7 +8,7 @@
 --eviction-hard="memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi"
 --container-runtime-endpoint=${SNAP_COMMON}/run/containerd.sock
 --containerd=${SNAP_COMMON}/run/containerd.sock
---node-labels="microk8s.io/cluster=true,node.kubernetes.io/microk8s-controlplane=microk8s-controlplane"
+--node-labels="microk8s.io/cluster=true,node.kubernetes.io/microk8s-controlplane=microk8s-controlplane,model.juju.is/disable-webhook=true"
 --authentication-token-webhook=true
 --read-only-port=0
 --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256

--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -408,7 +408,13 @@ def update_cert_auth_kubelet(token, ca, master_ip, master_port):
     set_arg("--client-ca-file", "${SNAP_DATA}/certs/ca.remote.crt", "kubelet")
     set_arg(
         "--node-labels",
-        "microk8s.io/cluster=true,node.kubernetes.io/microk8s-worker=microk8s-worker",
+        ",".join(
+            [
+                "microk8s.io/cluster=true",
+                "node.kubernetes.io/microk8s-worker=microk8s-worker",
+                "model.juju.is/disable-webhook=true",
+            ]
+        ),
         "kubelet",
     )
 


### PR DESCRIPTION
### Summary

Add `model.juju.is/disable-webhook=true` node label when the kubelet is trying to register the node.
