### PR TITLE
[Backport 1.27-strict] Prioritize in-snap PYTHONPATH and PATH vars (#4055)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,8 @@ confinement: strict
 base: core20
 assumes: [snapd2.52]
 environment:
-  PYTHONPATH: $PYTHONPATH:/usr/lib/python3.8:/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.8:$SNAP/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages
+  PYTHONPATH: $SNAP/usr/lib/python3.8:$SNAP/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+  PATH: $SNAP/usr/bin:$SNAP/bin:$SNAP/usr/sbin:$SNAP/sbin:$PATH
 
 parts:
   build-deps:


### PR DESCRIPTION
Backport #4055 to 1.27-strict branch