### PR TITLE
Add test for dual-stack

### DIFF
--- a/tests/templates/dual-stack.yaml
+++ b/tests/templates/dual-stack.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginxdualstack
+spec:
+  selector:
+    matchLabels:
+      run: nginxdualstack
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: nginxdualstack
+    spec:
+      containers:
+      - name: nginxdualstack
+        image: rocks.canonical.com/cdk/diverdane/nginxdualstack:1.0.0
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx6
+  labels:
+    run: nginxdualstack
+spec:
+  type: NodePort
+  ipFamilies:
+  - IPv6
+  ipFamilyPolicy: RequireDualStack
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    run: nginxdualstack

--- a/tests/templates/dual-stack.yaml
+++ b/tests/templates/dual-stack.yaml
@@ -13,10 +13,10 @@ spec:
         run: nginxdualstack
     spec:
       containers:
-      - name: nginxdualstack
-        image: rocks.canonical.com/cdk/diverdane/nginxdualstack:1.0.0
-        ports:
-        - containerPort: 80
+        - name: nginxdualstack
+          image: rocks.canonical.com/cdk/diverdane/nginxdualstack:1.0.0
+          ports:
+            - containerPort: 80
 ---
 apiVersion: v1
 kind: Service
@@ -27,10 +27,10 @@ metadata:
 spec:
   type: NodePort
   ipFamilies:
-  - IPv6
+    - IPv6
   ipFamilyPolicy: RequireDualStack
   ports:
-  - port: 80
-    protocol: TCP
+    - port: 80
+      protocol: TCP
   selector:
     run: nginxdualstack

--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -114,23 +114,23 @@ class VM:
                 subprocess.check_call(cmd)
 
     def _load_launch_configuration_lxc(self, launch_configs):
-            # Set launch configurations before installing microk8s
-            if launch_configs is not None:
-                print("Setting launch configurations")
-                cmd_prefix = "/snap/bin/lxc exec {}  -- script -e -c".format(self.vm_name).split()
-                cmd = ["mkdir -p /root/snap/microk8s/common/"]
-                subprocess.check_output(cmd_prefix + cmd)
-                file_path = "/microk8s.yaml"
-                print(launch_configs)
-                with open(file_path, "w") as file:
-                    file.write(launch_configs)
+        # Set launch configurations before installing microk8s
+        if launch_configs is not None:
+            print("Setting launch configurations")
+            cmd_prefix = "/snap/bin/lxc exec {}  -- script -e -c".format(self.vm_name).split()
+            cmd = ["mkdir -p /root/snap/microk8s/common/"]
+            subprocess.check_output(cmd_prefix + cmd)
+            file_path = "/microk8s.yaml"
+            print(launch_configs)
+            with open(file_path, "w") as file:
+                file.write(launch_configs)
 
-                # Copy the file to the VM
-                cmd = "lxc file push {} {}/root/snap/microk8s/common/.microk8s.yaml".format(
-                    file_path, self.vm_name
-                ).split()
-                subprocess.check_output(cmd)
-                os.remove(file_path)
+            # Copy the file to the VM
+            cmd = "lxc file push {} {}/root/snap/microk8s/common/.microk8s.yaml".format(
+                file_path, self.vm_name
+            ).split()
+            subprocess.check_output(cmd)
+            os.remove(file_path)
 
     def _transfer_install_local_snap_lxc(self, channel_or_snap):
         print("Installing snap from {}".format(channel_or_snap))
@@ -171,25 +171,25 @@ class VM:
                 )
 
     def _load_launch_configuration_multipass(self, launch_configs):
-            # Set launch configurations before installing microk8s
-            if launch_configs is not None:
-                print("Setting launch configurations")
-                subprocess.check_call(
-                    "/snap/bin/multipass exec {}  -- sudo "
-                    "mkdir -p /root/snap/microk8s/common/".format(self.vm_name).split()
-                )
-                file_path = "/microk8s.yaml"
-                print(launch_configs)
-                with open(file_path, "w") as file:
-                    file.write(launch_configs)
+        # Set launch configurations before installing microk8s
+        if launch_configs is not None:
+            print("Setting launch configurations")
+            subprocess.check_call(
+                "/snap/bin/multipass exec {}  -- sudo "
+                "mkdir -p /root/snap/microk8s/common/".format(self.vm_name).split()
+            )
+            file_path = "/microk8s.yaml"
+            print(launch_configs)
+            with open(file_path, "w") as file:
+                file.write(launch_configs)
 
-                # Copy the file to the VM
-                subprocess.check_call(
-                    "/snap/bin/multipass transfer {} {}:/root/snap/microk8s/common/.microk8s.yaml".format(
-                        file_path, self.vm_name
-                    ).split()
-                )
-                os.remove(file_path)
+            # Copy the file to the VM
+            subprocess.check_call(
+                "/snap/bin/multipass transfer {} {}:/root/snap/microk8s/common/.microk8s.yaml".format(
+                    file_path, self.vm_name
+                ).split()
+            )
+            os.remove(file_path)
 
     def _transfer_install_local_snap_multipass(self, channel_or_snap):
         print("Installing snap from {}".format(channel_or_snap))

--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -27,6 +27,7 @@ profile = os.environ.get("LXC_PROFILE", "lxc/microk8s.profile")
 
 TEMPLATES = Path(__file__).absolute().parent / "templates"
 
+
 class VM:
     """
     This class abstracts the backend we are using. It could be either multipass or lxc.
@@ -94,11 +95,11 @@ class VM:
                 cmd = ["mkdir -p /root/snap/microk8s/common/"]
                 subprocess.check_output(cmd_prefix + cmd)
 
-                file_path = '/microk8s.yaml'
+                file_path = "/microk8s.yaml"
 
                 print("Writing launch configurations to {}".format(file_path))
                 print(launch_configs)
-                with open(file_path, 'w') as file:
+                with open(file_path, "w") as file:
                     file.write(launch_configs)
 
                 # Copy the file to the VM
@@ -579,7 +580,7 @@ extraSANs:
                 attempt += 1
                 if attempt == 10:
                     raise
-        
+
         # Wait for CNI pods
         print("Waiting for cni")
         while True:
@@ -595,9 +596,7 @@ extraSANs:
 
         # Deploy the test deployment and service
         manifest = TEMPLATES / "dual-stack.yaml"
-        cmd = "lxc file push {} {}/dual-stack.yaml".format(
-                manifest, vm.vm_name
-            ).split()
+        cmd = "lxc file push {} {}/dual-stack.yaml".format(manifest, vm.vm_name).split()
         subprocess.check_output(cmd)
         vm.run("/snap/bin/microk8s.kubectl apply -f /dual-stack.yaml")
 
@@ -613,11 +612,15 @@ extraSANs:
                 print(pods.decode())
                 break
             time.sleep(5)
-        
+
         # ping the service attached with the deployment
-        ipv6_endpoint=vm.run("/snap/bin/microk8s.kubectl get service nginx6 -o jsonpath='{.spec.clusterIP}' --output='jsonpath=['{.spec.clusterIP}']'").decode()
+        ep = (
+            "/snap/bin/microk8s.kubectl get service nginx6 "
+            "-o jsonpath='{.spec.clusterIP}' --output='jsonpath=['{.spec.clusterIP}']'"
+        )
+        ipv6_endpoint = vm.run(ep).decode()
         print("Pinging endpoint: http://{}/".format(ipv6_endpoint))
-        url = f'http://{ipv6_endpoint}/'
+        url = f"http://{ipv6_endpoint}/"
         attempt = 10
         while attempt >= 0:
             try:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -262,3 +262,11 @@ def is_strict():
     if "STRICT" in os.environ and os.environ["STRICT"] == "yes":
         return True
     return False
+
+
+def is_ipv6_configured():
+    try:
+        output = check_output(["ip", "-6", "address"])
+        return b"inet6" in output
+    except CalledProcessError:
+        return False


### PR DESCRIPTION
#### Summary
Add the tests for dual-stack configuration. For the test, we configure a `lxd` container with the required launch configuration. We then deploy a nginx deployment and services and ping on its IPv6 address to verify that IPv6 addresses are also supported.