### PR TITLE
Do not warn for cgroups if cgroups v2 is available

### DIFF
--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -271,9 +271,11 @@ function suggest_fixes {
 
   if ! grep -q 'cgroup/memory' /proc/self/mountinfo; then
     if ! grep -q 'cgroup2' /proc/self/mountinfo; then
-      printf -- '\033[0;33mWARNING: \033[0m The memory cgroup is not enabled. \n'
-      printf -- 'The cluster may not be functioning properly. Please ensure cgroups are enabled \n'
-      printf -- 'See for example: https://microk8s.io/docs/install-alternatives#heading--arm \n'
+      if ! mount -t cgroup2 | grep -q 'type cgroup2'; then
+        printf -- '\033[0;33mWARNING: \033[0m The memory cgroup is not enabled. \n'
+        printf -- 'The cluster may not be functioning properly. Please ensure cgroups are enabled \n'
+        printf -- 'See for example: https://microk8s.io/docs/install-alternatives#heading--arm \n'
+      fi
     fi
   fi
 


### PR DESCRIPTION
Suppress some false positives in the inspect hook, using the check from https://github.com/canonical/microk8s/pull/3413

References https://github.com/canonical/microk8s/issues/1691, and probably some more issues