### PR TITLE
Add python3-rados and python3-rbd packages to snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -205,6 +205,8 @@ parts:
       - net-tools
       - openssl
       - procps
+      - python3-rados
+      - python3-rbd
       - sed
       - socat
       - squashfs-tools


### PR DESCRIPTION
Include `python3-rados` and `python3-rbd` python packages in the snap