### PR TITLE
Bug fix: use extfile in kubelet cert creation

### DIFF
--- a/scripts/wrappers/common/cluster/utils.py
+++ b/scripts/wrappers/common/cluster/utils.py
@@ -486,7 +486,7 @@ def get_locally_signed_client_cert(fname, username, group=None, extfile=None):
         crt=cer_file,
     )
     if extfile:
-        cmd_cert = cmd_cert + " -extfile {}".format(extfile)
+        cmd = cmd + " -extfile {}".format(extfile)
 
     subprocess.check_call(cmd.split(), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     try_set_file_permissions(cer_file)


### PR DESCRIPTION
#### Summary
The kubelet cert needs to be created with a reference to the node it is made for. With the CIS hardening work we introduced a bug where during joining of a node  we skip the node reference.

Possibly related https://github.com/canonical/microk8s/issues/4091

#### Changes
Corrected env variable.

#### Testing
Manual

#### Possible Regressions
No

