### PR TITLE
Set sane defaults for fs and asyncio parameters

### DIFF
--- a/microk8s-resources/wrappers/run-k8s-dqlite-with-args
+++ b/microk8s-resources/wrappers/run-k8s-dqlite-with-args
@@ -29,6 +29,17 @@ fi
 # We add some delay so that systemd really retries the restarts
 sleep 6
 
+if [ ! -e "${SNAP_DATA}/var/lock/skip-aio-tune.lock" ]
+then
+  increase_sysctl_parameter "fs.aio-max-nr" "1048576"
+fi
+
+if [ ! -e "${SNAP_DATA}/var/lock/skip-inotify-tune.lock" ]
+then
+  increase_sysctl_parameter "fs.inotify.max_user_instances" "1024"
+  increase_sysctl_parameter "fs.inotify.max_user_watches" "1048576"
+fi
+
 set -a
 if [ -e "${SNAP_DATA}/args/${app}-env" ]
 then

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -53,6 +53,28 @@ then
   fi
 fi
 
+if ! is_strict
+then
+  # set sysctl parameters 
+  if ! grep -q '^fs.aio-max-nr=' /etc/sysctl.d/10-microk8s.conf
+  then 
+      echo "fs.aio-max-nr=1048576" >> /etc/sysctl.d/10-microk8s.conf
+  fi
+
+  if ! grep -q '^fs.inotify.max_user_instances=' /etc/sysctl.d/10-microk8s.conf
+  then 
+      echo "fs.inotify.max_user_instances=1024" >> /etc/sysctl.d/10-microk8s.conf
+  fi
+
+  if ! grep -q '^fs.inotify.max_user_watches=' /etc/sysctl.d/10-microk8s.conf
+  then 
+      echo "fs.inotify.max_user_watches=1048576" >> /etc/sysctl.d/10-microk8s.conf
+  fi
+
+  # reload sysctl parameters to take effect
+  sysctl --system
+fi
+
 # If the addons directory is missing from SNAP_COMMON, then we are upgrading from an older MicroK8s version.
 if [ ! -d "${SNAP_COMMON}/addons" ]
 then

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -53,28 +53,6 @@ then
   fi
 fi
 
-if ! is_strict
-then
-  # set sysctl parameters 
-  if ! grep -q '^fs.aio-max-nr=' /etc/sysctl.d/10-microk8s.conf
-  then 
-      echo "fs.aio-max-nr=1048576" >> /etc/sysctl.d/10-microk8s.conf
-  fi
-
-  if ! grep -q '^fs.inotify.max_user_instances=' /etc/sysctl.d/10-microk8s.conf
-  then 
-      echo "fs.inotify.max_user_instances=1024" >> /etc/sysctl.d/10-microk8s.conf
-  fi
-
-  if ! grep -q '^fs.inotify.max_user_watches=' /etc/sysctl.d/10-microk8s.conf
-  then 
-      echo "fs.inotify.max_user_watches=1048576" >> /etc/sysctl.d/10-microk8s.conf
-  fi
-
-  # reload sysctl parameters to take effect
-  sysctl --system
-fi
-
 # If the addons directory is missing from SNAP_COMMON, then we are upgrading from an older MicroK8s version.
 if [ ! -d "${SNAP_COMMON}/addons" ]
 then

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -37,6 +37,13 @@ snapctl stop ${SNAP_NAME}.daemon-containerd 2>&1 || true
 # because the mount points are busy
 sleep 10
 
+if ! is_strict
+then
+  # remove custom sysctl parameters
+  rm -f /etc/sysctl.d/10-microk8s.conf
+  sysctl --system
+fi
+
 # Clean the container location so we do not snapshot it.
 rm -rf ${SNAP_COMMON}/var/lib/containerd/* || true
 rm -rf ${SNAP_COMMON}/run/containerd/* || true


### PR DESCRIPTION
Set sane defaults for fs and asyncio parameters.

Does not work in strict, not enough permissions to modify any of these values/files or do `sysctl` calls. 
`system-files` interface might let us create one of these files, although this should be discussed with the snapd team first.