### PR TITLE
Prefer InternalIP over Hostname for Kubelet connections

### DIFF
--- a/microk8s-resources/default-args/kube-apiserver
+++ b/microk8s-resources/default-args/kube-apiserver
@@ -28,3 +28,4 @@
 --enable-admission-plugins=EventRateLimit
 --admission-control-config-file=${SNAP_DATA}/args/admission-control-config-file.yaml
 --kubelet-certificate-authority=${SNAP_DATA}/certs/ca.crt
+--kubelet-preferred-address-types=InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP


### PR DESCRIPTION
## Summary

Prefer InternalIP over Hostname for Kubelet connections (e.g. for `kubectl logs`)

Test and review along with https://github.com/canonical/microk8s-cluster-agent/pull/38