### PR TITLE
Rework cluster certificates generation

### DIFF
--- a/build-scripts/components/cluster-agent/version.sh
+++ b/build-scripts/components/cluster-agent/version.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-echo "main"
+# TODO: revert after https://github.com/canonical/microk8s-cluster-agent/pull/41 is merged
+echo "MK-1294/kubelet-tls"

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -1061,21 +1061,20 @@ server_cert_check() {
   openssl x509 -in "$SNAP_DATA"/certs/server.crt -outform der | sha256sum | cut -d' ' -f1 | cut -c1-12
 }
 
-########################################################################
-# Description:
-#   Generate CSR for component certificates, including hostname and node IP addresses
-#   as SubjectAlternateNames. The CSR PEM is printed to stdout. Arguments are:
-#   1. The certificate subject, e.g. "/CN=system:node:$hostname/O=system:nodes"
-#   2. The path to write the private key, e.g. "$SNAP_DATA/certs/kubelet.key"
-#
-# Notes:
-#   - Subject is /CN=system:node:$hostname/O=system:nodes
-#   - Node hostname and IP addresses are added as Subject Alternate Names
-#
-# Example usage:
-#   generate_csr_with_sans /CN=system:node:$hostname/O=system:nodes $SNAP_DATA/certs/kubelet.key > $SNAP_DATA/certs/kubelet.csr
-########################################################################
 generate_csr_with_sans() {
+  # Description:
+  #   Generate CSR for component certificates, including hostname and node IP addresses
+  #   as SubjectAlternateNames. The CSR PEM is printed to stdout. Arguments are:
+  #   1. The certificate subject, e.g. "/CN=system:node:$hostname/O=system:nodes"
+  #   2. The path to write the private key, e.g. "$SNAP_DATA/certs/kubelet.key"
+  #
+  # Notes:
+  #   - Subject is /CN=system:node:$hostname/O=system:nodes
+  #   - Node hostname and IP addresses are added as Subject Alternate Names
+  #
+  # Example usage:
+  #   generate_csr_with_sans /CN=system:node:$hostname/O=system:nodes $SNAP_DATA/certs/kubelet.key > $SNAP_DATA/certs/kubelet.csr
+
   # Add DNS name and IP addresses as subjectAltName
   hostname=$(hostname | tr '[:upper:]' '[:lower:]')
   subjectAltName="DNS:$hostname"
@@ -1094,16 +1093,15 @@ generate_csr_with_sans() {
   openssl req -new -sha256 -subj "$1" -key "$2" -addext "subjectAltName = $subjectAltName"
 }
 
-########################################################################
-# Description:
-#   Generate CSR for component certificates. The CSR PEM is written to stdout. Arguments are:
-#   1. The certificate subject, e.g. "/CN=system:kube-scheduler"
-#   2. The path to write the private key, e.g. "$SNAP_DATA/certs/scheduler.key"
-#
-# Example usage:
-#   generate_csr /CN=system:kube-scheduler $SNAP_DATA/certs/scheduler.key > $SNAP_DATA/certs/scheduler.csr
-########################################################################
 generate_csr() {
+  # Description:
+  #   Generate CSR for component certificates. The CSR PEM is written to stdout. Arguments are:
+  #   1. The certificate subject, e.g. "/CN=system:kube-scheduler"
+  #   2. The path to write the private key, e.g. "$SNAP_DATA/certs/scheduler.key"
+  #
+  # Example usage:
+  #   generate_csr /CN=system:kube-scheduler $SNAP_DATA/certs/scheduler.key > $SNAP_DATA/certs/scheduler.csr
+
   # generate key if it does not exist
   if [ ! -f "$2" ]; then
     openssl genrsa -out "$2" 2048
@@ -1115,20 +1113,19 @@ generate_csr() {
   openssl req -new -sha256 -subj "$1" -key "$2"
 }
 
-########################################################################
-# Description:
-#   Sign a certificate signing request (CSR) using the MicroK8s cluster CA.
-#   The CSR is read through stdin, and the signed certificate is printed to stdout.
-#
-# Notes:
-#   - Read from stdin and write to stdout, so no temporary files are required.
-#   - Any SubjectAlternateNames that are included in the CSR are added to the certificate.
-#
-# Example usage:
-#   cat component.csr | sign_certificate > component.crt
-########################################################################
 sign_certificate() {
-  # We need to use the request more than once, so read it into a variable
+  # Description:
+  #   Sign a certificate signing request (CSR) using the MicroK8s cluster CA.
+  #   The CSR is read through stdin, and the signed certificate is printed to stdout.
+  #
+  # Notes:
+  #   - Read from stdin and write to stdout, so no temporary files are required.
+  #   - Any SubjectAlternateNames that are included in the CSR are added to the certificate.
+  #
+  # Example usage:
+  #   cat component.csr | sign_certificate > component.crt
+
+  # We need to use the request more than once, use this trick to grab stdin and save it in '$csr'
   csr="$(cat)"
 
   # Parse SANs from the CSR and add them to the certificate extensions (if any)

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -600,19 +600,16 @@ get_ips() {
 }
 
 gen_server_cert() (
-    export OPENSSL_CONF="${SNAP}/etc/ssl/openssl.cnf"
     ${SNAP}/usr/bin/openssl req -new -sha256 -key ${SNAP_DATA}/certs/server.key -out ${SNAP_DATA}/certs/server.csr -config ${SNAP_DATA}/certs/csr.conf
     ${SNAP}/usr/bin/openssl x509 -req -sha256 -in ${SNAP_DATA}/certs/server.csr -CA ${SNAP_DATA}/certs/ca.crt -CAkey ${SNAP_DATA}/certs/ca.key -CAcreateserial -out ${SNAP_DATA}/certs/server.crt -days 365 -extensions v3_ext -extfile ${SNAP_DATA}/certs/csr.conf
 )
 
 gen_proxy_client_cert() (
-    export OPENSSL_CONF="${SNAP}/etc/ssl/openssl.cnf"
     ${SNAP}/usr/bin/openssl req -new -sha256 -key ${SNAP_DATA}/certs/front-proxy-client.key -out ${SNAP_DATA}/certs/front-proxy-client.csr -config <(sed '/^prompt = no/d' ${SNAP_DATA}/certs/csr.conf) -subj "/CN=front-proxy-client"
     ${SNAP}/usr/bin/openssl x509 -req -sha256 -in ${SNAP_DATA}/certs/front-proxy-client.csr -CA ${SNAP_DATA}/certs/front-proxy-ca.crt -CAkey ${SNAP_DATA}/certs/front-proxy-ca.key -CAcreateserial -out ${SNAP_DATA}/certs/front-proxy-client.crt -days 365 -extensions v3_ext -extfile ${SNAP_DATA}/certs/csr.conf
 )
 
 create_user_kubeconfigs() {
-  export OPENSSL_CONF="${SNAP}/etc/ssl/openssl.cnf"
   for user in client kubelet scheduler controller proxy; do
     if ! [ -f ${SNAP_DATA}/certs/${user} ]; then
       ${SNAP}/usr/bin/openssl genrsa -out ${SNAP_DATA}/certs/${user}.key 2048
@@ -681,7 +678,6 @@ create_x509_cert() {
 }
 
 produce_certs() {
-    export OPENSSL_CONF="${SNAP}/etc/ssl/openssl.cnf"
     # Generate RSA keys if not yet
     for key in serviceaccount.key ca.key server.key front-proxy-ca.key front-proxy-client.key; do
         if ! [ -f ${SNAP_DATA}/certs/$key ]; then
@@ -736,7 +732,6 @@ ensure_server_ca() {
     # ensure the server.crt is issued by ca.crt
     # if current csr.conf is invalid, regenerate front-proxy-client certificates as well
 
-    export OPENSSL_CONF="${SNAP}/etc/ssl/openssl.cnf"
     if ! ${SNAP}/usr/bin/openssl verify -CAfile ${SNAP_DATA}/certs/ca.crt ${SNAP_DATA}/certs/server.crt &>/dev/null
     then
         csr_modified="$(ensure_csr_conf_conservative)"
@@ -755,8 +750,6 @@ ensure_server_ca() {
 
 check_csr_conf() {
     # if no argument is given, default csr.conf will be checked
-    export OPENSSL_CONF="${SNAP}/etc/ssl/openssl.cnf"
-
     csr_conf="${1:-${SNAP_DATA}/certs/csr.conf}"
     ${SNAP}/usr/bin/openssl req -new -config $csr_conf -noout -nodes -keyout /dev/null &>/dev/null
 }

--- a/microk8s-resources/wrappers/microk8s-add-node.wrapper
+++ b/microk8s-resources/wrappers/microk8s-add-node.wrapper
@@ -5,7 +5,6 @@ set -eu
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 ARCH="$($SNAP/bin/uname -m)"
 export LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
-export OPENSSL_CONF="$SNAP/etc/ssl/openssl.cnf"
 export IN_SNAP_LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
 export PYTHONNOUSERSITE=false
 

--- a/microk8s-resources/wrappers/microk8s-join.wrapper
+++ b/microk8s-resources/wrappers/microk8s-join.wrapper
@@ -4,7 +4,6 @@ set -eu
 
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 ARCH="$($SNAP/bin/uname -m)"
-export OPENSSL_CONF="$SNAP/etc/ssl/openssl.cnf"
 export IN_SNAP_LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
 export PYTHONNOUSERSITE=false
 export LC_ALL="${LC_ALL:-C.UTF-8}"

--- a/microk8s-resources/wrappers/run-cluster-agent-with-args
+++ b/microk8s-resources/wrappers/run-cluster-agent-with-args
@@ -12,7 +12,6 @@ export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 ARCH="$($SNAP/bin/uname -m)"
 export LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
-export OPENSSL_CONF="$SNAP/etc/ssl/openssl.cnf"
 
 # This is really the only way I could find to get the args passed in correctly.
 declare -a args="($(cat $SNAP_DATA/args/cluster-agent))"

--- a/scripts/wrappers/common/cluster/utils.py
+++ b/scripts/wrappers/common/cluster/utils.py
@@ -446,66 +446,6 @@ def get_token(name, tokens_file="known_tokens.csv"):
     return None
 
 
-def get_locally_signed_client_cert(fname, username, group=None, extfile=None):
-    """
-    Get a cert signed by the local CA.
-
-    :param fname: file name prefix for the certificate
-    :param username: the username of the cert's owner
-    :param group: the group the owner belongs to
-    """
-    snapdata_path = os.environ.get("SNAP_DATA")
-    snap_path = os.environ.get("SNAP")
-    subject = "/CN={}".format(username)
-    if group:
-        subject = "{}/O={}".format(subject, group)
-
-    # the filenames must survive snap refreshes, so replace revision number with current
-    snapdata_current = os.path.abspath(os.path.join(snapdata_path, "..", "current"))
-
-    cer_req_file = "{}/certs/{}.csr".format(snapdata_current, fname)
-    cer_key_file = "{}/certs/{}.key".format(snapdata_current, fname)
-    cer_file = "{}/certs/{}.crt".format(snapdata_current, fname)
-    ca_key_file = "{}/certs/ca.key".format(snapdata_current)
-    ca_file = "{}/certs/ca.crt".format(snapdata_current)
-    if not os.path.exists(cer_key_file):
-        cmd_gen_cert_key = "{snap}/usr/bin/openssl genrsa -out {key} 2048".format(
-            snap=snap_path, key=cer_key_file
-        )
-        subprocess.check_call(
-            cmd_gen_cert_key.split(), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
-        )
-        try_set_file_permissions(cer_key_file)
-
-    cmd_cert = (
-        "{snap}/usr/bin/openssl req -new -sha256 -key {key} -out {csr} -subj {subject}".format(
-            snap=snap_path,
-            key=cer_key_file,
-            csr=cer_req_file,
-            subject=subject,
-        )
-    )
-    subprocess.check_call(cmd_cert.split(), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-
-    cmd = "{snap}/usr/bin/openssl x509 -req -in {csr} -CA {ca} -CAkey {k} -CAcreateserial -out {crt} -days 3650".format(
-        snap=snap_path,
-        csr=cer_req_file,
-        ca=ca_file,
-        k=ca_key_file,
-        crt=cer_file,
-    )
-    if extfile:
-        cmd = cmd + " -extfile {}".format(extfile)
-
-    subprocess.check_call(cmd.split(), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    try_set_file_permissions(cer_file)
-
-    return {
-        "certificate_location": cer_file,
-        "certificate_key_location": cer_key_file,
-    }
-
-
 def get_arg(key, file):
     """
     Get an argument from a file
@@ -557,56 +497,6 @@ def set_arg(key, value, file):
     os.remove(filename_remote)
 
 
-def create_x509_kubeconfig(
-    ca, master_ip, api_port, filename, user, path_to_cert, path_to_cert_key, embed=False
-):
-    """
-    Create a kubeconfig file. The file in stored under credentials named after the user
-
-    :param ca: the ca
-    :param master_ip: the master node IP
-    :param api_port: the API server port
-    :param filename: the name of the config file
-    :param user: the user to use al login
-    :param path_to_cert: path to certificate file
-    :param path_to_cert_key: path to certificate key file
-    :param embed: place the base64 encoding of certs in kubeconfig instead of linking to them
-    """
-    snapdata_path = os.environ.get("SNAP_DATA")
-    snap_path = os.environ.get("SNAP")
-    config_template = "{}/{}".format(snap_path, "client-x509.config.template")
-    config = "{}/credentials/{}".format(snapdata_path, filename)
-    shutil.copyfile(config, "{}.backup".format(config))
-    try_set_file_permissions("{}.backup".format(config))
-    ca_line = ca_one_line(ca)
-    with open(config_template, "r") as tfp:
-        with open(config, "w+") as fp:
-            config_txt = tfp.read()
-            config_txt = config_txt.replace("CADATA", ca_line)
-            config_txt = config_txt.replace("NAME", user)
-            if embed:
-                with open(path_to_cert, "r") as f:
-                    cert = f.read()
-                    cert_line = base64.b64encode(cert.encode("utf-8")).decode("utf-8")
-                with open(path_to_cert_key, "r") as f:
-                    cert = f.read()
-                    key_line = base64.b64encode(cert.encode("utf-8")).decode("utf-8")
-                config_txt = config_txt.replace("PATHTOCERT", cert_line)
-                config_txt = config_txt.replace("PATHTOKEYCERT", key_line)
-                config_txt = config_txt.replace(
-                    "client-certificate",
-                    "client-certificate-data",
-                )
-                config_txt = config_txt.replace("client-key", "client-key-data")
-            else:
-                config_txt = config_txt.replace("PATHTOCERT", path_to_cert)
-                config_txt = config_txt.replace("PATHTOKEYCERT", path_to_cert_key)
-            config_txt = config_txt.replace("127.0.0.1", master_ip)
-            config_txt = config_txt.replace("16443", api_port)
-            fp.write(config_txt)
-        try_set_file_permissions(config)
-
-
 def is_token_auth_enabled():
     """
     Return True if token auth is enabled
@@ -649,53 +539,8 @@ def rebuild_x509_auth_client_configs():
     if is_token_auth_enabled():
         set_arg("--token-auth-file", None, "kube-apiserver")
 
-    snapdata_path = os.environ.get("SNAP_DATA")
-    cert_file = "{}/certs/ca.crt".format(snapdata_path)
-    with open(cert_file) as fp:
-        ca = fp.read()
-
-    apiserver_port = get_arg("--secure-port", "kube-apiserver")
-    if not apiserver_port:
-        apiserver_port = "6443"
-
-    hostname = socket.gethostname().lower()
-    csr_file = "{}/certs/kubelet.csr.conf".format(snapdata_path)
-    with open(csr_file, "w") as fp:
-        fp.write("subjectAltName=DNS:{}\n".format(hostname))
-
-    components = [
-        {"username": "admin", "group": "system:masters", "filename": "client", "extfile": None},
-        {
-            "username": "system:kube-controller-manager",
-            "group": None,
-            "filename": "controller",
-            "extfile": None,
-        },
-        {"username": "system:kube-proxy", "group": None, "filename": "proxy", "extfile": None},
-        {
-            "username": "system:kube-scheduler",
-            "group": None,
-            "filename": "scheduler",
-            "extfile": None,
-        },
-        {
-            "username": f"system:node:{hostname}",
-            "group": "system:nodes",
-            "filename": "kubelet",
-            "extfile": csr_file,
-        },
-    ]
-    for c in components:
-        cert = get_locally_signed_client_cert(
-            c["filename"], c["username"], c["group"], c["extfile"]
-        )
-        create_x509_kubeconfig(
-            ca,
-            "127.0.0.1",
-            apiserver_port,
-            filename=f"{c['filename']}.config",
-            user=c["username"],
-            path_to_cert=cert["certificate_location"],
-            path_to_cert_key=cert["certificate_key_location"],
-            embed=True,
-        )
+    subprocess.check_call(
+        [f"{snap()}/actions/common/utils.sh", "create_user_certs_and_configs"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )

--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -18,12 +18,9 @@ import urllib3
 import yaml
 from common.cluster.utils import (
     ca_one_line,
-    create_x509_kubeconfig,
     enable_token_auth,
-    get_arg,
     get_cluster_agent_port,
     get_cluster_cidr,
-    get_locally_signed_client_cert,
     get_token,
     is_low_memory_guard_enabled,
     is_node_running_dqlite,
@@ -34,6 +31,8 @@ from common.cluster.utils import (
     set_arg,
     try_initialise_cni_autodetect_for_clustering,
     try_set_file_permissions,
+    snap,
+    snap_data,
 )
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -217,71 +216,49 @@ def get_etcd_client_cert(master_ip, master_port, token):
         try_set_file_permissions(server_cert_file)
 
 
-def get_client_cert(master_ip, master_port, fname, token, username, group=None):
+def get_client_cert(master_ip, master_port, fname: str, token: str, subject: str, with_sans: bool):
     """
-    Get a signed cert.
+    Get a signed cert signed by a remote cluster-agent.
     See https://kubernetes.io/docs/reference/access-authn-authz/authentication/#x509-client-certs
 
     :param master_ip: master ip
     :param master_port: master port
     :param fname: file name prefix for the certificate
     :param token: token to contact the master with
-    :param username: the username of the cert's owner
-    :param group: the group the owner belongs to
+    :param subject: the subject of the certificate
+    :param with_sans: whether to include hostname and node IPs as subject alternate names
     """
-    info = "/CN={}".format(username)
-    if group:
-        info = "{}/O={}".format(info, group)
 
-    # the filenames must survive snap refreshes, so replace revision number with current
-    snapdata_current = os.path.abspath(os.path.join(snapdata_path, "..", "current"))
-
-    cer_req_file = "{}/certs/{}.csr".format(snapdata_current, fname)
-    cer_key_file = "{}/certs/{}.key".format(snapdata_current, fname)
-    cer_file = "{}/certs/{}.crt".format(snapdata_current, fname)
-    if not os.path.exists(cer_key_file):
-        cmd_gen_cert_key = "{snap}/usr/bin/openssl genrsa -out {key} 2048".format(
-            snap=snap_path, key=cer_key_file
-        )
-        subprocess.check_call(
-            cmd_gen_cert_key.split(), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
-        )
-        try_set_file_permissions(cer_key_file)
-
-    cmd_cert = "{snap}/usr/bin/openssl req -new -sha256 -key {key} -out {csr} -subj {info}".format(
-        snap=snap_path,
-        key=cer_key_file,
-        csr=cer_req_file,
-        info=info,
+    cert_crt = (snap_data() / "certs" / fname).with_suffix(".crt")
+    cert_key = (snap_data() / "certs" / fname).with_suffix(".key")
+    # generate csr
+    script = "generate_csr_with_sans" if with_sans else "generate_csr"
+    p = subprocess.run(
+        [f"{snap()}/actions/common/utils.sh", script, subject, cert_key],
+        check=True,
+        capture_output=True,
     )
-    subprocess.check_call(cmd_cert.split(), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    with open(cer_req_file) as fp:
-        csr = fp.read()
-        req_data = {"token": token, "request": csr}
-        # TODO: enable ssl verification
-        signed = requests.post(
-            "https://{}:{}/{}/sign-cert".format(master_ip, master_port, CLUSTER_API),
-            json=req_data,
-            verify=False,
-        )
-        if signed.status_code != 200:
-            error = "Failed to sign {} certificate ({}).".format(fname, signed.status_code)
-            try:
-                if "error" in signed.json():
-                    error = "{} {}".format(error, format(signed.json()["error"]))
-            except ValueError:
-                print("Make sure the cluster you connect to supports joining worker nodes.")
-            print(error)
-            exit(1)
-        info = signed.json()
-        with open(cer_file, "w") as cert_fp:
-            cert_fp.write(info["certificate"])
-        try_set_file_permissions(cer_file)
+    csr = p.stdout.decode()
 
-        return {
-            "certificate_location": cer_file,
-            "certificate_key_location": cer_key_file,
-        }
+    req_data = {"token": token, "request": csr}
+    # TODO: enable ssl verification
+    signed = requests.post(
+        "https://{}:{}/{}/sign-cert".format(master_ip, master_port, CLUSTER_API),
+        json=req_data,
+        verify=False,
+    )
+    if signed.status_code != 200:
+        error = "Failed to sign {} certificate ({}).".format(fname, signed.status_code)
+        try:
+            if "error" in signed.json():
+                error = "{} {}".format(error, format(signed.json()["error"]))
+        except ValueError:
+            print("Make sure the cluster you connect to supports joining worker nodes.")
+        print(error)
+        exit(1)
+    info = signed.json()
+    cert_crt.write_text(info["certificate"])
+    try_set_file_permissions(cert_crt)
 
 
 def update_flannel(etcd, master_ip, master_port, token):
@@ -348,7 +325,7 @@ def update_kubeproxy(token, ca, master_ip, api_port, hostname_override):
     service("restart", "proxy")
 
 
-def update_cert_auth_kubeproxy(token, ca, master_ip, master_port, hostname_override):
+def update_cert_auth_kubeproxy(token, master_ip, master_port, hostname_override):
     """
     Configure the kube-proxy
 
@@ -359,17 +336,7 @@ def update_cert_auth_kubeproxy(token, ca, master_ip, master_port, hostname_overr
     :param hostname_override: the hostname override in case the hostname is not resolvable
     """
     proxy_token = "{}-proxy".format(token)
-    traefik_port = get_traefik_port()
-    cert = get_client_cert(master_ip, master_port, "kube-proxy", proxy_token, "system:kube-proxy")
-    create_x509_kubeconfig(
-        ca,
-        "127.0.0.1",
-        traefik_port,
-        "proxy.config",
-        "kubeproxy",
-        cert["certificate_location"],
-        cert["certificate_key_location"],
-    )
+    get_client_cert(master_ip, master_port, "proxy", proxy_token, "/CN=system:kube-proxy", False)
     set_arg("--master", None, "kube-proxy")
     if hostname_override:
         set_arg("--hostname-override", hostname_override, "kube-proxy")
@@ -381,7 +348,7 @@ def update_kubeproxy_cidr(cidr):
         service("restart", "proxy")
 
 
-def update_cert_auth_kubelet(token, ca, master_ip, master_port):
+def update_cert_auth_kubelet(token, master_ip, master_port):
     """
     Configure the kubelet
 
@@ -391,20 +358,8 @@ def update_cert_auth_kubelet(token, ca, master_ip, master_port):
     :param master_port: the master node port where the cluster agent listens
     """
     kubelet_token = "{}-kubelet".format(token)
-    traefik_port = get_traefik_port()
-    kubelet_user = "system:node:{}".format(socket.gethostname().lower())
-    cert = get_client_cert(
-        master_ip, master_port, "kubelet", kubelet_token, kubelet_user, "system:nodes"
-    )
-    create_x509_kubeconfig(
-        ca,
-        "127.0.0.1",
-        traefik_port,
-        "kubelet.config",
-        "kubelet",
-        cert["certificate_location"],
-        cert["certificate_key_location"],
-    )
+    subject = f"/CN=system:node:{socket.gethostname().lower()}/O=system:nodes"
+    get_client_cert(master_ip, master_port, "kubelet", kubelet_token, subject, True)
     set_arg("--client-ca-file", "${SNAP_DATA}/certs/ca.remote.crt", "kubelet")
     set_arg(
         "--node-labels",
@@ -432,13 +387,17 @@ def update_kubelet(token, ca, master_ip, api_port):
     service("restart", "kubelet")
 
 
-def update_apiserver(api_authz_mode):
+def update_apiserver(api_authz_mode, apiserver_port):
     """
     Configure the API server
 
     :param api_authz_mode: the authorization mode to be used
+    :param apiserver_port: the apiserver port
     """
-    set_arg("--authorization-mode", api_authz_mode, "kube-apiserver")
+    if api_authz_mode:
+        set_arg("--authorization-mode", api_authz_mode, "kube-apiserver")
+    if apiserver_port:
+        set_arg("--secure-port", apiserver_port, "kube-apiserver")
     service("restart", "apiserver")
 
 
@@ -747,53 +706,16 @@ def update_apiserver_proxy(master_ip, api_port):
 
 def rebuild_token_based_auth_configs(info):
     # We need to make sure token-auth is enabled in this node too.
-    apiserver_port = get_arg("--secure-port", "kube-apiserver")
-    if not apiserver_port:
-        apiserver_port = "6443"
-
     if not is_token_auth_enabled():
         enable_token_auth(info["admin_token"])
-        create_admin_kubeconfig(info["ca"], info["admin_token"])
-        hostname = socket.gethostname().lower()
-        components = [
-            {"username": "system:kube-controller-manager", "group": None, "filename": "controller"},
-            {"username": "system:kube-proxy", "group": None, "filename": "proxy"},
-            {"username": "system:kube-scheduler", "group": None, "filename": "scheduler"},
-            {"username": f"system:node:{hostname}", "group": "system:nodes", "filename": "kubelet"},
-        ]
-        for c in components:
-            cert = get_locally_signed_client_cert(c["filename"], c["username"], c["group"])
-            create_x509_kubeconfig(
-                info["ca"],
-                "127.0.0.1",
-                apiserver_port,
-                filename=f"{c['filename']}.config",
-                user=c["username"],
-                path_to_cert=cert["certificate_location"],
-                path_to_cert_key=cert["certificate_key_location"],
-                embed=True,
-            )
     else:
         replace_admin_token(info["admin_token"])
-        create_admin_kubeconfig(info["ca"], info["admin_token"])
 
-        # triplets of [username in known_tokens.csv, username in kubeconfig, kubeconfig filename name]
-        for component in [
-            ("kube-proxy", "kubeproxy", "proxy.config"),
-            ("kubelet", "kubelet", "kubelet.config"),
-            ("kube-controller-manager", "controller", "controller.config"),
-            ("kube-scheduler", "scheduler", "scheduler.config"),
-        ]:
-            component_token = get_token(component[0])
-            if not component_token:
-                print(
-                    "Error, could not locate {} token. Joining cluster failed.".format(component[0])
-                )
-                exit(3)
-            # We assume the API listens on all nodes on the same port
-            create_kubeconfig(
-                component_token, info["ca"], "127.0.0.1", apiserver_port, component[2], component[1]
-            )
+    subprocess.check_call(
+        [f"{snap_path}/actions/common/utils.sh", "create_user_certs_and_configs"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
 
 
 def print_worker_usage():
@@ -831,11 +753,17 @@ def join_dqlite_worker_node(info, master_ip, master_port, token):
 
     store_remote_ca(info["ca"])
 
+    update_apiserver(info.get("api_authz_mode"), info.get("apiport"))
     store_base_kubelet_args(info["kubelet_args"])
     update_kubelet_node_ip(info["kubelet_args"], hostname_override)
     update_kubelet_hostname_override(info["kubelet_args"])
-    update_cert_auth_kubeproxy(token, info["ca"], master_ip, master_port, hostname_override)
-    update_cert_auth_kubelet(token, info["ca"], master_ip, master_port)
+    update_cert_auth_kubeproxy(token, master_ip, master_port, hostname_override)
+    update_cert_auth_kubelet(token, master_ip, master_port)
+    subprocess.check_call(
+        [f"{snap()}/actions/common/utils.sh", "create_worker_kubeconfigs"],
+        stderr=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+    )
 
     store_callback_token(info["callback_token"])
     update_apiserver_proxy(master_ip, info["apiport"])
@@ -877,9 +805,7 @@ def join_dqlite_master_node(info, master_ip):
         # We are joining a x509-auth based cluster
         rebuild_x509_auth_client_configs()
 
-    if "api_authz_mode" in info:
-        update_apiserver(info["api_authz_mode"])
-
+    update_apiserver(info.get("api_authz_mode"), info.get("apiport"))
     store_base_kubelet_args(info["kubelet_args"])
     update_kubelet_node_ip(info["kubelet_args"], hostname_override)
     update_kubelet_hostname_override(info["kubelet_args"])

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -89,7 +89,7 @@ done
 produce_certs
 rm -rf .srl
 
-create_user_kubeconfigs
+create_user_certs_and_configs
 
 # Install default-hooks
 cp -r --preserve=mode ${SNAP}/default-hooks ${SNAP_COMMON}/hooks

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -12,7 +12,6 @@ fi
 ARCH="$(${SNAP}/bin/uname -m)"
 export LD_LIBRARY_PATH="${SNAP}/lib:${SNAP}/usr/lib:${SNAP}/lib/$ARCH-linux-gnu:${SNAP}/usr/lib/$ARCH-linux-gnu"
 export PATH="${SNAP}/usr/sbin:${SNAP}/usr/bin:${SNAP}/sbin:${SNAP}/bin:$PATH:/usr/bin:/usr/local/bin"
-export OPENSSL_CONF="${SNAP}/etc/ssl/openssl.cnf"
 
 # LXD Specific Checks
 if ! is_strict && cat /proc/1/environ | grep "container=lxc" &> /dev/null

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,7 @@ assumes: [snapd2.52]
 environment:
   PYTHONPATH: $SNAP/usr/lib/python3.8:$SNAP/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
   PATH: $SNAP/usr/bin:$SNAP/bin:$SNAP/usr/sbin:$SNAP/sbin:$PATH
+  OPENSSL_CONF: $SNAP/etc/ssl/openssl.cnf
 
 parts:
   build-deps:


### PR DESCRIPTION
fixes a number of issues/bugs:

- properly update --secure-port on control plane nodes that join
- always ensure kubelet certificates include subject alternate names for hostname and IP
- remove duplicate python code for certificate generation
- misc cleanup and tidy code
- cleanup OPENSSL_CONF env configuration

Requires https://github.com/canonical/microk8s-cluster-agent/pull/41