### PR TITLE
Fix passing of arguments in wrapper scripts

### DIFF
--- a/microk8s-resources/wrappers/git.wrapper
+++ b/microk8s-resources/wrappers/git.wrapper
@@ -5,4 +5,4 @@ export GIT_EXEC_PATH="$SNAP/usr/lib/git-core"
 export GIT_TEMPLATE_DIR="$SNAP/usr/share/git-core/templates"
 export GIT_CONFIG_NOSYSTEM=1
 
-"$SNAP/usr/bin/git" $@
+"$SNAP/usr/bin/git" "${@}"

--- a/microk8s-resources/wrappers/microk8s-add-node.wrapper
+++ b/microk8s-resources/wrappers/microk8s-add-node.wrapper
@@ -55,4 +55,4 @@ then
 fi
 
 # Use python's built-in (3.6+) secrets generator to produce the token.
-LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/add_token.py $@
+LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/add_token.py "${@}"

--- a/microk8s-resources/wrappers/microk8s-addons.wrapper
+++ b/microk8s-resources/wrappers/microk8s-addons.wrapper
@@ -14,4 +14,4 @@ export LANG="${LANG:-C.UTF-8}"
 
 exit_if_no_permissions
 
-LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/addons.py $@
+LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/addons.py "${@}"

--- a/microk8s-resources/wrappers/microk8s-dbctl.wrapper
+++ b/microk8s-resources/wrappers/microk8s-dbctl.wrapper
@@ -13,4 +13,4 @@ exit_if_not_root
 
 exit_if_no_permissions
 
-LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/dbctl.py $@
+LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/dbctl.py "${@}"

--- a/microk8s-resources/wrappers/microk8s-disable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-disable.wrapper
@@ -22,4 +22,4 @@ exit_if_not_root
 
 exit_if_no_permissions
 
-LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/disable.py $@
+LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/disable.py "${@}"

--- a/microk8s-resources/wrappers/microk8s-enable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-enable.wrapper
@@ -22,4 +22,4 @@ exit_if_not_root
 
 exit_if_no_permissions
 
-LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/enable.py $@
+LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/enable.py "${@}"

--- a/microk8s-resources/wrappers/microk8s-images.wrapper
+++ b/microk8s-resources/wrappers/microk8s-images.wrapper
@@ -12,4 +12,4 @@ export PYTHONNOUSERSITE=false
 
 exit_if_no_permissions
 
-LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/images.py $@
+LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/images.py "${@}"

--- a/microk8s-resources/wrappers/microk8s-join.wrapper
+++ b/microk8s-resources/wrappers/microk8s-join.wrapper
@@ -21,7 +21,7 @@ exit_if_no_permissions
 
 if is_strict
 then
-  LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/join.py $@
+  LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/join.py "${@}"
 else
-  sudo -E LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/join.py $@
+  sudo -E LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/join.py "${@}"
 fi

--- a/microk8s-resources/wrappers/microk8s-leave.wrapper
+++ b/microk8s-resources/wrappers/microk8s-leave.wrapper
@@ -24,4 +24,4 @@ then
   exit 1
 fi
 
-run_with_sudo preserve_env ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/leave.py $@
+run_with_sudo preserve_env ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/leave.py "${@}"

--- a/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
+++ b/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
@@ -20,4 +20,4 @@ fi
 
 exit_if_not_root
 
-LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/refresh_certs.py $@
+LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/refresh_certs.py "${@}"

--- a/microk8s-resources/wrappers/microk8s-reset.wrapper
+++ b/microk8s-resources/wrappers/microk8s-reset.wrapper
@@ -9,4 +9,4 @@ export PYTHONNOUSERSITE=false
 export LC_ALL="${LC_ALL:-C.UTF-8}"
 export LANG="${LANG:-C.UTF-8}"
 
-LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/reset.py $@
+LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/reset.py "${@}"

--- a/microk8s-resources/wrappers/microk8s-status.wrapper
+++ b/microk8s-resources/wrappers/microk8s-status.wrapper
@@ -20,4 +20,4 @@ fi
 
 exit_if_low_memory_guard
 
-LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/status.py $@
+LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/status.py "${@}"

--- a/microk8s-resources/wrappers/microk8s-version.wrapper
+++ b/microk8s-resources/wrappers/microk8s-version.wrapper
@@ -11,4 +11,4 @@ source $SNAP/actions/common/utils.sh
 
 exit_if_no_permissions
 
-LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/version.py $@
+LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/version.py "${@}"


### PR DESCRIPTION
When passing arguments with whitespace/empty values, they are passed incorrectly to the underlying scripts