### PR TITLE
Configure LD_LIBRARY_PATH on snap environment

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,6 +16,7 @@ environment:
   PYTHONPATH: $SNAP/usr/lib/python3.8:$SNAP/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
   PATH: $SNAP/usr/bin:$SNAP/bin:$SNAP/usr/sbin:$SNAP/sbin:$PATH
   OPENSSL_CONF: $SNAP/etc/ssl/openssl.cnf
+  LD_LIBRARY_PATH: $SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/ceph
 
 parts:
   build-deps:


### PR DESCRIPTION
- Set proper LD_LIBRARY_PATH across the snap
- Fixes missing libceph-common.so on strict

Worth to note, this would help us reduce some of the common boilerplate in places like https://github.com/canonical/microk8s/blob/7dab3b8993d164af058ca1566f2ea94cb2984fd8/microk8s-resources/wrappers/microk8s-addons.wrapper#L9-L17

But we are too close to the 1.28 release to attempt such changes now, so we will defer it for a later time.