### PR TITLE
Remove the IPv6 calico interface when removing the snap

### DIFF
--- a/microk8s-resources/default-hooks/remove.d/10-cni-link
+++ b/microk8s-resources/default-hooks/remove.d/10-cni-link
@@ -12,7 +12,7 @@ then
     fi
   done
   for calink in $("${SNAP}/sbin/ip" -j link show |\
-                  "${SNAP}/usr/bin/jq" -r '.[].ifname | select(test("^vxlan.calico|cali[a-f0-9]*$"))')
+                  "${SNAP}/usr/bin/jq" -r '.[].ifname | select(test("^vxlan[-v6]*.calico|cali[a-f0-9]*$"))')
   do "${SNAP}/sbin/ip" link delete "${calink}" || true
   done
 fi


### PR DESCRIPTION
#### Summary
Calico creates an vxlan-v6.calico interface for IPv6. On remove we need to remove that interface too.

#### Testing
The test-clustering we prepare for dual stack caught that.

