### PR TITLE
Fixes and follow-up FIPS-ready patches

### DIFF
--- a/build-scripts/components/etcd/build.sh
+++ b/build-scripts/components/etcd/build.sh
@@ -3,7 +3,8 @@
 export INSTALL="${1}"
 mkdir -p "${INSTALL}"
 
-GO_LDFLAGS="-s -w" GO_BUILD_FLAGS="-v" ./build.sh
+sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/' build.sh
+GOEXPERIMENT=opensslcrypto GO_LDFLAGS="-s -w" GO_BUILD_FLAGS="-v" ./build.sh
 
 for bin in etcd etcdctl; do
   cp "bin/${bin}" "${INSTALL}/${bin}"

--- a/build-scripts/components/flanneld/build.sh
+++ b/build-scripts/components/flanneld/build.sh
@@ -5,7 +5,8 @@ mkdir -p "${INSTALL}"
 
 VERSION="${2}"
 
-export CGO_ENABLED=0
+export CGO_ENABLED=1
+export GOEXPERIMENT=opensslcrypto
 go build -o dist/flanneld -ldflags "-s -w -X github.com/flannel-io/flannel/version.Version=${VERSION} -extldflags -static"
 
 cp dist/flanneld "${INSTALL}/flanneld"

--- a/microk8s-resources/wrappers/run-apiserver-proxy-with-args
+++ b/microk8s-resources/wrappers/run-apiserver-proxy-with-args
@@ -23,6 +23,7 @@ fi
 
 sed 's@${SNAP}@'"${SNAP}"'@g;s@${SNAP_DATA}@'"${SNAP_DATA}"'@g' $SNAP_DATA/args/traefik/traefik-template.yaml > $SNAP_DATA/args/traefik/traefik.yaml
 
+set -a
 if [ -e ${SNAP_DATA}/args/fips-env ]
 then
   . ${SNAP_DATA}/args/fips-env

--- a/microk8s-resources/wrappers/run-apiserver-proxy-with-args
+++ b/microk8s-resources/wrappers/run-apiserver-proxy-with-args
@@ -23,6 +23,12 @@ fi
 
 sed 's@${SNAP}@'"${SNAP}"'@g;s@${SNAP_DATA}@'"${SNAP_DATA}"'@g' $SNAP_DATA/args/traefik/traefik-template.yaml > $SNAP_DATA/args/traefik/traefik.yaml
 
+if [ -e ${SNAP_DATA}/args/fips-env ]
+then
+  . ${SNAP_DATA}/args/fips-env
+fi
+set +a
+
 # This is really the only way I could find to get the args passed in correctly.
 declare -a args="($(cat $SNAP_DATA/args/apiserver-proxy))"
 exec "$SNAP/bin/cluster-agent" apiserver-proxy "${args[@]}"

--- a/microk8s-resources/wrappers/run-etcd-with-args
+++ b/microk8s-resources/wrappers/run-etcd-with-args
@@ -28,6 +28,19 @@ fi
 
 export DEFAULT_INTERFACE_IP_ADDR="$(get_default_ip)"
 
+set -a
+if [ -e ${SNAP_DATA}/args/etcd-env ]
+then
+  . ${SNAP_DATA}/args/etcd-env
+fi
+
+if [ -e ${SNAP_DATA}/args/fips-env ]
+then
+  . ${SNAP_DATA}/args/fips-env
+fi
+set +a
+
+
 # This is really the only way I could find to get the args passed in correctly.
 declare -a args="($(cat $SNAP_DATA/args/etcd))"
 exec "$SNAP/etcd" "${args[@]}"

--- a/microk8s-resources/wrappers/run-flanneld-with-args
+++ b/microk8s-resources/wrappers/run-flanneld-with-args
@@ -8,6 +8,13 @@ source $SNAP/actions/common/utils.sh
 
 exit_if_service_not_expected_to_start flanneld
 
+set -a
+if [ -e "${SNAP_DATA}/args/fips-env" ]
+then
+  . "${SNAP_DATA}/args/fips-env"
+fi
+set +a
+
 # Allow some slack for containerd and etcd to start
 # so we avoid this edge case: https://forum.snapcraft.io/t/restarting-services-from-configure-hook-race-condition/2513/13
 sleep 5
@@ -52,9 +59,4 @@ set +a
 
 # This is really the only way I could find to get the args passed in correctly.
 declare -a args="($(cat $SNAP_DATA/args/flanneld))"
-if ! is_strict
-then
-  export CORE_LD_LIBRARY_PATH="$SNAP/../../core20/current/lib/$ARCH-linux-gnu"
-  export LD_LIBRARY_PATH="$CORE_LD_LIBRARY_PATH:$LD_LIBRARY_PATH"
-fi
 exec "$SNAP_DATA/opt/cni/bin/flanneld" "${args[@]}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -89,6 +89,7 @@ parts:
 
   etcd:
     after: [build-deps]
+    build-attributes: [no-patchelf]
     plugin: nil
     source: build-scripts/components/etcd
     override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh etcd

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -108,6 +108,7 @@ parts:
 
   flanneld:
     after: [build-deps]
+    build-attributes: [no-patchelf]
     plugin: nil
     source: build-scripts/components/flanneld
     override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh flanneld


### PR DESCRIPTION
### Summary

Follow up from #4096 

### Changes

- Fix apiserver-proxy broken in FIPS mode (otherwise worker nodes cannot start an apiserver proxy)
- Support etcd and flanneld running in FIPS mode (based on the existing FIPS configuration)
- Fix ignored etcd-env on the etcd service

Assumes https://github.com/canonical/microk8s-cluster-agent/pull/43