### PR TITLE
Revert "Fixes and follow-up FIPS-ready patches"

### DIFF
--- a/build-scripts/components/etcd/build.sh
+++ b/build-scripts/components/etcd/build.sh
@@ -3,8 +3,7 @@
 export INSTALL="${1}"
 mkdir -p "${INSTALL}"
 
-sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/' build.sh
-GOEXPERIMENT=opensslcrypto GO_LDFLAGS="-s -w" GO_BUILD_FLAGS="-v" ./build.sh
+GO_LDFLAGS="-s -w" GO_BUILD_FLAGS="-v" ./build.sh
 
 for bin in etcd etcdctl; do
   cp "bin/${bin}" "${INSTALL}/${bin}"

--- a/build-scripts/components/flanneld/build.sh
+++ b/build-scripts/components/flanneld/build.sh
@@ -5,8 +5,7 @@ mkdir -p "${INSTALL}"
 
 VERSION="${2}"
 
-export CGO_ENABLED=1
-export GOEXPERIMENT=opensslcrypto
+export CGO_ENABLED=0
 go build -o dist/flanneld -ldflags "-s -w -X github.com/flannel-io/flannel/version.Version=${VERSION} -extldflags -static"
 
 cp dist/flanneld "${INSTALL}/flanneld"

--- a/microk8s-resources/wrappers/run-apiserver-proxy-with-args
+++ b/microk8s-resources/wrappers/run-apiserver-proxy-with-args
@@ -23,13 +23,6 @@ fi
 
 sed 's@${SNAP}@'"${SNAP}"'@g;s@${SNAP_DATA}@'"${SNAP_DATA}"'@g' $SNAP_DATA/args/traefik/traefik-template.yaml > $SNAP_DATA/args/traefik/traefik.yaml
 
-set -a
-if [ -e ${SNAP_DATA}/args/fips-env ]
-then
-  . ${SNAP_DATA}/args/fips-env
-fi
-set +a
-
 # This is really the only way I could find to get the args passed in correctly.
 declare -a args="($(cat $SNAP_DATA/args/apiserver-proxy))"
 exec "$SNAP/bin/cluster-agent" apiserver-proxy "${args[@]}"

--- a/microk8s-resources/wrappers/run-etcd-with-args
+++ b/microk8s-resources/wrappers/run-etcd-with-args
@@ -28,19 +28,6 @@ fi
 
 export DEFAULT_INTERFACE_IP_ADDR="$(get_default_ip)"
 
-set -a
-if [ -e ${SNAP_DATA}/args/etcd-env ]
-then
-  . ${SNAP_DATA}/args/etcd-env
-fi
-
-if [ -e ${SNAP_DATA}/args/fips-env ]
-then
-  . ${SNAP_DATA}/args/fips-env
-fi
-set +a
-
-
 # This is really the only way I could find to get the args passed in correctly.
 declare -a args="($(cat $SNAP_DATA/args/etcd))"
 exec "$SNAP/etcd" "${args[@]}"

--- a/microk8s-resources/wrappers/run-flanneld-with-args
+++ b/microk8s-resources/wrappers/run-flanneld-with-args
@@ -8,13 +8,6 @@ source $SNAP/actions/common/utils.sh
 
 exit_if_service_not_expected_to_start flanneld
 
-set -a
-if [ -e "${SNAP_DATA}/args/fips-env" ]
-then
-  . "${SNAP_DATA}/args/fips-env"
-fi
-set +a
-
 # Allow some slack for containerd and etcd to start
 # so we avoid this edge case: https://forum.snapcraft.io/t/restarting-services-from-configure-hook-race-condition/2513/13
 sleep 5
@@ -59,4 +52,9 @@ set +a
 
 # This is really the only way I could find to get the args passed in correctly.
 declare -a args="($(cat $SNAP_DATA/args/flanneld))"
+if ! is_strict
+then
+  export CORE_LD_LIBRARY_PATH="$SNAP/../../core20/current/lib/$ARCH-linux-gnu"
+  export LD_LIBRARY_PATH="$CORE_LD_LIBRARY_PATH:$LD_LIBRARY_PATH"
+fi
 exec "$SNAP_DATA/opt/cni/bin/flanneld" "${args[@]}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -89,7 +89,6 @@ parts:
 
   etcd:
     after: [build-deps]
-    build-attributes: [no-patchelf]
     plugin: nil
     source: build-scripts/components/etcd
     override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh etcd
@@ -108,7 +107,6 @@ parts:
 
   flanneld:
     after: [build-deps]
-    build-attributes: [no-patchelf]
     plugin: nil
     source: build-scripts/components/flanneld
     override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh flanneld


### PR DESCRIPTION
Reverts canonical/microk8s#4135

Reverting the FIPS work because it is breaking non-Ubuntu deployments.