### PR TITLE
fix broken in LD_LIBRARY_PATH in non-ubuntu

### DIFF
--- a/microk8s-resources/wrappers/microk8s.wrapper
+++ b/microk8s-resources/wrappers/microk8s.wrapper
@@ -37,7 +37,10 @@ elif [ "${APP}" == "help" ] || [ "${APP}" == "--help" ] || [ "$APP" == "-h" ]; t
     help
     readonly EXIT="0"
 elif [ -f "${SNAP_COMMON}/plugins/${APP}" ]; then
-    "${SNAP_COMMON}/plugins/${APP}" "$@"
+    export ARCH="$(uname -m)"
+    export IN_SNAP_LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu/ceph"
+    LD_LIBRARY_PATH="${IN_SNAP_LD_LIBRARY_PATH}" "${SNAP_COMMON}/plugins/${APP}" "$@"
+
     readonly EXIT="$?"
 else
     echo "'${APP}' is not a valid MicroK8s subcommand."

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,6 @@ environment:
   PYTHONPATH: $SNAP/usr/lib/python3.8:$SNAP/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
   PATH: $SNAP/usr/bin:$SNAP/bin:$SNAP/usr/sbin:$SNAP/sbin:$PATH
   OPENSSL_CONF: $SNAP/etc/ssl/openssl.cnf
-  LD_LIBRARY_PATH: $SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/ceph
 
 parts:
   build-deps:


### PR DESCRIPTION
### Summary

#4124 changed how we set LD_LIBRARY_PATH.

However, setting the LD_LIBRARY_PATH on snapcraft.yaml causes issues on non-Ubuntu distros with different libc versions. This PR mitigates the issue by reverting the old change, and then setting the LD_LIBRARY_PATH for the code-path where we needed it.

