### PR TITLE
[Backport 1.27] symlink /var/lib/calico

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -35,6 +35,19 @@ need_kubelet_restart=false
 need_controller_restart=false
 need_scheduler_restart=false
 
+# Try to symlink /var/lib/kubelet so that most kubelet device plugins work out of the box.
+if ! [ -e /var/lib/kubelet ] && ln -s $SNAP_COMMON/var/lib/kubelet /var/lib/kubelet; then
+  echo "/var/lib/kubelet linked to $SNAP_COMMON"
+fi
+
+# Try to symlink /var/lib/calico so that the Calico CNI plugin picks up the mtu configuration.
+if ! [ -e /var/lib/calico ]; then
+  SNAP_DATA_CURRENT=`echo "${SNAP_DATA}" | sed -e "s,${SNAP_REVISION},current,"`
+  if ln -s $SNAP_DATA_CURRENT/var/lib/calico /var/lib/calico; then
+    echo "/var/lib/calico linked to $SNAP_DATA_CURRENT/var/lib/calico"
+  fi
+fi
+
 # If the configurations directory is missing from SNAP_COMMON, we are upgrading from an older MicroK8s version.
 if [ ! -d "${SNAP_COMMON}/etc/launcher" ]
 then

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -31,14 +31,17 @@ fi
 cp -r --preserve=mode ${SNAP}/default-args ${SNAP_DATA}/args
 mv ${SNAP_DATA}/args/certs.d/localhost__32000 ${SNAP_DATA}/args/certs.d/localhost:32000
 
-# Sym link the host's /var/lib/kubelet to the Snap's.  This will be fixed with layouts when
-# this Snap is strictly confined.  Warn if there's already a directory.
-if ! [ -e /var/lib/kubelet ] &&
-   ln -s $SNAP_COMMON/var/lib/kubelet /var/lib/kubelet
-then
-  echo "\`/var/lib/kubelet\` linked to $SNAP_COMMON"
-else
-  echo "\`/var/lib/kubelet\` already exists.  Will not be linking to $SNAP_COMMON"
+# Try to symlink /var/lib/kubelet so that most kubelet device plugins work out of the box.
+if ! [ -e /var/lib/kubelet ] && ln -s $SNAP_COMMON/var/lib/kubelet /var/lib/kubelet; then
+  echo "/var/lib/kubelet linked to $SNAP_COMMON"
+fi
+
+# Try to symlink /var/lib/calico so that the Calico CNI plugin picks up the mtu configuration.
+if ! [ -e /var/lib/calico ]; then
+  SNAP_DATA_CURRENT=`echo "${SNAP_DATA}" | sed -e "s,${SNAP_REVISION},current,"`
+  if ln -s $SNAP_DATA_CURRENT/var/lib/calico /var/lib/calico; then
+    echo "/var/lib/calico linked to $SNAP_DATA_CURRENT/var/lib/calico"
+  fi
 fi
 
 # Create the certificates

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -7,11 +7,14 @@ export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH:/usr/bin:/u
 
 snapctl stop ${SNAP_NAME}.daemon-kubelite 2>&1 || true
 
-# Sym link the host's /var/lib/kubelet to the Snap's.  This will be fixed with layouts when
-# this Snap is strictly confined.
-if test -L /var/lib/kubelet
-then
+# Try to symlink /var/lib/kubelet so that most kubelet device plugins work out of the box.
+if test -L /var/lib/kubelet; then
   unlink /var/lib/kubelet || true
+fi
+
+# Try to symlink /var/lib/calico so that the Calico CNI plugin picks up the mtu configuration.
+if test -L /var/lib/calico; then
+  unlink /var/lib/calico || true
 fi
 
 pod_cidr="$(cat $SNAP_DATA/args/kubelet | grep "pod-cidr" | tr "=" " "| gawk '{print $2}')"


### PR DESCRIPTION
Backport #4149 to 1.27 branch