### PR TITLE
[1.27-strict] fix bind mounts for calico and kubelet

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -635,7 +635,9 @@ passthrough:
     /var/log/containers:
       bind: $SNAP_COMMON/var/log/containers
     /var/lib/kubelet:
-      bind: $SNAP_DATA/kubelet
+      bind: $SNAP_COMMON/var/lib/kubelet
+    /var/lib/calico:
+      bind: $SNAP_DATA/var/lib/calico
     /var/lib/kube-proxy:
       bind: $SNAP_DATA/kube-proxy
     /etc/service/enabled:


### PR DESCRIPTION
Backport #4149 to 1.27-strict branch