### PR TITLE
[1.26-strict] fix bind mounts for calico and kubelet

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -580,7 +580,9 @@ passthrough:
     /var/log/containers:
       bind: $SNAP_COMMON/var/log/containers
     /var/lib/kubelet:
-      bind: $SNAP_DATA/kubelet
+      bind: $SNAP_COMMON/var/lib/kubelet
+    /var/lib/calico:
+      bind: $SNAP_DATA/var/lib/calico
     /var/lib/kube-proxy:
       bind: $SNAP_DATA/kube-proxy
     /etc/service/enabled:


### PR DESCRIPTION
Backport #4149 to 1.26-strict branch