### PR TITLE
Update migrator invocations

### DIFF
--- a/scripts/wrappers/dbctl.py
+++ b/scripts/wrappers/dbctl.py
@@ -76,8 +76,10 @@ def backup(fname=None, debug=False):
     fname_tar = "{}.tar.gz".format(fname)
 
     with tempfile.TemporaryDirectory() as tmpdirname:
-        backup_cmd = "{}/bin/migrator --endpoint {} --mode backup-dqlite --db-dir {}".format(
-            snap_path, kine_ep, "{}/{}".format(tmpdirname, fname)
+        backup_cmd = (
+            "{}/bin/k8s-dqlite migrator --endpoint {} --mode backup-dqlite --db-dir {}".format(
+                snap_path, kine_ep, "{}/{}".format(tmpdirname, fname)
+            )
         )
         if debug:
             backup_cmd = "{} {}".format(backup_cmd, "--debug")
@@ -114,8 +116,10 @@ def restore(fname_tar, debug=False):
         else:
             fname = fname_tar
         fname = os.path.basename(fname)
-        restore_cmd = "{}/bin/migrator --endpoint {} --mode restore-to-dqlite --db-dir {}".format(
-            snap_path, kine_ep, "{}/{}".format(tmpdirname, fname)
+        restore_cmd = (
+            "{}/bin/k8s-dqlite migrator --endpoint {} --mode restore-to-dqlite --db-dir {}".format(
+                snap_path, kine_ep, "{}/{}".format(tmpdirname, fname)
+            )
         )
         if debug:
             restore_cmd = "{} {}".format(restore_cmd, "--debug")

--- a/upgrade-scripts/001-switch-to-dqlite/commit-master.sh
+++ b/upgrade-scripts/001-switch-to-dqlite/commit-master.sh
@@ -56,7 +56,7 @@ then
   sleep 15
 
   rm -rf "$DB_DIR"
-  $SNAP/bin/migrator --mode backup --endpoint "http://127.0.0.1:12379" --db-dir "$DB_DIR" --debug
+  $SNAP/bin/k8s-dqlite migrator --mode backup --endpoint "http://127.0.0.1:12379" --db-dir "$DB_DIR" --debug
   chmod 600 "$DB_DIR"
   # Wait up to two minutes for the apiserver to come up.
   # TODO: this polling is not good enough. We should find a new way to ensure the apiserver is up.
@@ -76,7 +76,7 @@ then
   if [[ "$now" < "$(($start_timer + $timeout))" ]] ; then
     if (is_apiserver_ready)
     then
-        $SNAP/bin/migrator --mode restore --endpoint "unix://${SNAP_DATA}/var/kubernetes/backend/kine.sock:12379" --db-dir "$DB_DIR" --debug
+        $SNAP/bin/k8s-dqlite migrator --mode restore --endpoint "unix://${SNAP_DATA}/var/kubernetes/backend/kine.sock:12379" --db-dir "$DB_DIR" --debug
     fi
   fi
 


### PR DESCRIPTION
### Summary

Update call sites of `migrator` tool, now that it's [built into k8s-dqlite](https://github.com/canonical/k8s-dqlite/pull/63)