### PR TITLE
fix stat binary path

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -450,7 +450,7 @@ arch() {
 
 snapshotter() {
   # Determine the underlying filesystem that containerd will be running on
-  FSTYPE=$($SNAP/bin/stat -f -c %T "${SNAP_COMMON}")
+  FSTYPE=$($SNAP/usr/bin/stat -f -c %T "${SNAP_COMMON}")
   # ZFS is supported through the native snapshotter
   if [ "$FSTYPE" = "zfs" ]; then
     echo "native"


### PR DESCRIPTION
### Summary

Followup of #4192, fix stat binary path:

```
root@t1:~# m ctr --help
/snap/microk8s/x1/actions/common/utils.sh: line 431: /snap/microk8s/x1/bin/stat: No such file or directory
```