### PR TITLE
Improve handling of necessary system pod restarts on snap refresh

### DIFF
--- a/microk8s-resources/default-hooks/reconcile.d/10-pods-restart
+++ b/microk8s-resources/default-hooks/reconcile.d/10-pods-restart
@@ -4,7 +4,7 @@
 
 if ! [ -e "${SNAP_DATA}/var/lock/no-cni-reload" ] &&
   [ -e "${SNAP_DATA}/var/lock/snapdata-mounts-need-reload" ]; then
-  if (is_apiserver_ready) && "${SNAP}/scripts/kill-host-pods.py" --with-snap-data-mounts -- -A; then
+  if (is_apiserver_ready) && "${SNAP}/scripts/kill-host-pods.py" --with-snap-data-mounts --with-owner -- -A; then
     rm "${SNAP_DATA}/var/lock/snapdata-mounts-need-reload"
   fi
 fi


### PR DESCRIPTION
### Summary

Minor improvements on https://github.com/canonical/microk8s/pull/4184

### Changes

- Only restart pods with an owner reference, to protect standalone pods from being deleted and not recreated.
- Also restart pods that mount paths that are symlinks for `$SNAP_DATA` paths