### PR TITLE
Symlinks for CNI conf and binary directories

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -40,11 +40,24 @@ if ! [ -e /var/lib/kubelet ] && ln -s $SNAP_COMMON/var/lib/kubelet /var/lib/kube
   echo "/var/lib/kubelet linked to $SNAP_COMMON"
 fi
 
+SNAP_DATA_CURRENT=`echo "${SNAP_DATA}" | sed -e "s,${SNAP_REVISION},current,"`
+
 # Try to symlink /var/lib/calico so that the Calico CNI plugin picks up the mtu configuration.
 if ! [ -e /var/lib/calico ]; then
-  SNAP_DATA_CURRENT=`echo "${SNAP_DATA}" | sed -e "s,${SNAP_REVISION},current,"`
   if ln -s $SNAP_DATA_CURRENT/var/lib/calico /var/lib/calico; then
     echo "/var/lib/calico linked to $SNAP_DATA_CURRENT/var/lib/calico"
+  fi
+fi
+
+# Try to symlink standard CNI Kubernetes directories.
+if ! [ -e /etc/cni/net.d ]; then
+  if mkdir -p /etc/cni && ln -s $SNAP_DATA_CURRENT/args/cni-network /etc/cni/net.d; then
+    echo "/etc/cni/net.d linked to $SNAP_DATA_CURRENT/args/cni-network"
+  fi
+fi
+if ! [ -e /opt/cni/bin ]; then
+  if mkdir -p /opt/cni && ln -s $SNAP_DATA_CURRENT/opt/cni/bin /opt/cni/bin; then
+    echo "/opt/cni/bin linked to $SNAP_DATA_CURRENT/opt/cni/bin"
   fi
 fi
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -30,6 +30,7 @@ fi
 cp -r --preserve=mode ${SNAP}/default-args ${SNAP_DATA}/args
 mv ${SNAP_DATA}/args/certs.d/localhost__32000 ${SNAP_DATA}/args/certs.d/localhost:32000
 
+SNAP_DATA_CURRENT=`echo "${SNAP_DATA}" | sed -e "s,${SNAP_REVISION},current,"`
 
 # Try to symlink /var/lib/kubelet so that most kubelet device plugins work out of the box.
 if ! [ -e /var/lib/kubelet ] && ln -s $SNAP_COMMON/var/lib/kubelet /var/lib/kubelet; then
@@ -38,12 +39,22 @@ fi
 
 # Try to symlink /var/lib/calico so that the Calico CNI plugin picks up the mtu configuration.
 if ! [ -e /var/lib/calico ]; then
-  SNAP_DATA_CURRENT=`echo "${SNAP_DATA}" | sed -e "s,${SNAP_REVISION},current,"`
   if ln -s $SNAP_DATA_CURRENT/var/lib/calico /var/lib/calico; then
     echo "/var/lib/calico linked to $SNAP_DATA_CURRENT/var/lib/calico"
   fi
 fi
 
+# Try to symlink standard CNI Kubernetes directories.
+if ! [ -e /etc/cni/net.d ]; then
+  if mkdir -p /etc/cni && ln -s $SNAP_DATA_CURRENT/args/cni-network /etc/cni/net.d; then
+    echo "/etc/cni/net.d linked to $SNAP_DATA_CURRENT/args/cni-network"
+  fi
+fi
+if ! [ -e /opt/cni/bin ]; then
+  if mkdir -p /opt/cni && ln -s $SNAP_DATA_CURRENT/opt/cni/bin /opt/cni/bin; then
+    echo "/opt/cni/bin linked to $SNAP_DATA_CURRENT/opt/cni/bin"
+  fi
+fi
 
 # Create the credentials directory
 mkdir -p ${SNAP_DATA}/credentials

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -17,6 +17,14 @@ if test -L /var/lib/calico; then
   unlink /var/lib/calico || true
 fi
 
+# Try to symlink standard CNI Kubernetes directories.
+if test -L /etc/cni/net.d; then
+  unlink /etc/cni/net.d || true
+fi
+if test -L /opt/cni/bin; then
+  unlink /opt/cni/bin || true
+fi
+
 pod_cidr="$(cat $SNAP_DATA/args/kube-proxy | grep "cluster-cidr" | tr "=" " "| gawk '{print $2}')"
 if [ -z "$pod_cidr" ]
 then


### PR DESCRIPTION
### Summary

Create symlinks for `/etc/cni/net.d` and `/opt/cni/bin` directories (if possible), to ensure compatibility with standard Kubernetes CNI paths.

### Notes

- For strict this will use bind mounts instead