### PR TITLE
Print message when node joined successfully

### DIFF
--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -1007,6 +1007,7 @@ If you would still like to join the cluster as a control plane node, use:
         join_etcd(connection_parts, verify)
 
     unmark_join_in_progress()
+    print("Successfully joined the cluster.")
     sys.exit(0)
 
 


### PR DESCRIPTION

#### Summary
The user currently doesn't get sufficient feedback that the `microk8s join` command was successful.
Adding a short success message at the end IMHO improves the user-experience.

#### Changes
Current output when joining a node (on the joining node):
```
ubuntu@ubuntu:~$ sudo microk8s join 192.168.178.69:25000/615bccdafddbfb07c6645c0d9d813c70/4d874d404e8c
Contacting cluster at 192.168.178.69
Waiting for this node to finish joining the cluster. .. .. ..  
```
Now we get
```
ubuntu@ubuntu:~/microk8s$ sudo microk8s join 192.168.178.69:25000/c7a6eab1455305afbb0ad4edd33413ad/4d874d404e8c
Contacting cluster at 192.168.178.69
Waiting for this node to finish joining the cluster. .. .. .. .  
Successfully joined the cluster.
```

#### Testing
Manually joined two microK8s nodes and verified the output of the joining node.


#### Checklist
<!-- Please verify that you have done the following -->

* [✓] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [✓] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.

