### PR TITLE
Backport fixes to strict

### DIFF
--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -162,6 +162,8 @@ def get_connection_info(
                 "hostname": socket.gethostname().lower(),
                 "port": cluster_agent_port,
                 "worker": worker,
+                "can_handle_x509_auth": True,
+                "can_handle_custom_etcd": True,
             }
 
             return join_request(conn, CLUSTER_API_V2, req_data, master_ip, verify_peer, fingerprint)
@@ -505,9 +507,10 @@ def store_cert(filename, payload):
     :param payload: certificate payload
     """
     file_with_path = "{}/certs/{}".format(snapdata_path, filename)
-    backup_file_with_path = "{}.backup".format(file_with_path)
-    shutil.copyfile(file_with_path, backup_file_with_path)
-    try_set_file_permissions(backup_file_with_path)
+    if os.path.exists(file_with_path):
+        backup_file_with_path = "{}.backup".format(file_with_path)
+        shutil.copyfile(file_with_path, backup_file_with_path)
+        try_set_file_permissions(backup_file_with_path)
     with open(file_with_path, "w+") as fp:
         fp.write(payload)
     try_set_file_permissions(file_with_path)
@@ -819,7 +822,25 @@ def join_dqlite_master_node(info, master_ip):
     update_kubelet_node_ip(info["kubelet_args"], hostname_override)
     update_kubelet_hostname_override(info["kubelet_args"])
     store_callback_token(info["callback_token"])
-    update_dqlite(info["cluster_cert"], info["cluster_key"], info["voters"], hostname_override)
+
+    if "etcd_servers" in info:
+        set_arg("--etcd-servers", info["etcd_servers"], "kube-apiserver")
+        if info.get("etcd_ca"):
+            store_cert("remote-etcd-ca.crt", info["etcd_ca"])
+            set_arg("--etcd-cafile", "${SNAP_DATA}/certs/remote-etcd-ca.crt", "kube-apiserver")
+        if info.get("etcd_cert"):
+            store_cert("remote-etcd.crt", info["etcd_cert"])
+            set_arg("--etcd-certfile", "${SNAP_DATA}/certs/remote-etcd.crt", "kube-apiserver")
+        if info.get("etcd_key"):
+            store_cert("remote-etcd.key", info["etcd_key"])
+            set_arg("--etcd-keyfile", "${SNAP_DATA}/certs/remote-etcd.key", "kube-apiserver")
+
+        mark_no_dqlite()
+        service("restart", "k8s-dqlite")
+        service("restart", "apiserver")
+    else:
+        update_dqlite(info["cluster_cert"], info["cluster_key"], info["voters"], hostname_override)
+
     # We want to update the local CNI yaml but we do not want to apply it.
     # The cni is applied already in the cluster we join
     try_initialise_cni_autodetect_for_clustering(master_ip, apply_cni=False)
@@ -910,6 +931,15 @@ def unmark_join_in_progress():
     lock_file = "{}/var/lock/join-in-progress".format(snapdata_path)
     if os.path.exists(lock_file):
         os.unlink(lock_file)
+
+
+def mark_no_dqlite():
+    """
+    Mark node to not run k8s-dqlite service.
+    """
+    lock_file = "{}/var/lock/no-k8s-dqlite".format(snapdata_path)
+    open(lock_file, "a").close()
+    os.chmod(lock_file, 0o700)
 
 
 @click.command(

--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -1,6 +1,7 @@
 import string
 import random
 import time
+import platform
 import pytest
 import os
 import datetime
@@ -616,6 +617,11 @@ class TestCluster(object):
         # it won't be able to create VMs with IPv6 connectivity.
         not is_ipv6_configured,
         reason="Skipping dual stack tests on VMs which are not lxc based and not dual-stack enabled",
+    )
+    @pytest.mark.skipif(
+        # We do not have IPv6 nginx image for ARM64
+        platform.machine() != "x86_64",
+        reason="Skipping dual stack tests on VMs which are not AMD64",
     )
     def test_dual_stack_cluster(self):
         vm = self.VM[0]

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -132,12 +132,12 @@ extraSANs:
             except CalledProcessError:
                 print("Will not test the metallb addon")
 
-        if is_ipv6_configured:
-            try:
-                validate_dual_stack()
-                test_matrix["dual_stack"] = validate_dual_stack
-            except CalledProcessError:
-                print("Will not test the dual stack configuration")
+            if is_ipv6_configured:
+                try:
+                    validate_dual_stack()
+                    test_matrix["dual_stack"] = validate_dual_stack
+                except CalledProcessError:
+                    print("Will not test the dual stack configuration")
 
         # Refresh the snap to the target
         if upgrade_to.endswith(".snap"):


### PR DESCRIPTION
The following fixes are back ported:
- use of x509 certs flag
- skip dual stack tests on arm64
- external etcd endpoints during joining