### PR TITLE
Run microceph integration test

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -91,7 +91,7 @@ jobs:
 
   test-addons-community:
     name: Test community addons
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build
 
     steps:
@@ -110,13 +110,14 @@ jobs:
         with:
           name: microk8s.snap
           path: build
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3
       - name: Running addons tests
         run: |
           set -x
           sudo snap install build/microk8s.snap --classic --dangerous
           sudo microk8s enable community
+          export UNDER_TIME_PRESSURE="True"
           sudo -E bash -c "cd /var/snap/microk8s/common/addons/community/; pytest -s -ra ./tests/"
 
   test-addons-core-upgrade:

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -110,6 +110,8 @@ jobs:
         with:
           name: microk8s.snap
           path: build
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Running addons tests
         run: |
           set -x

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -91,7 +91,7 @@ jobs:
 
   test-addons-community:
     name: Test community addons
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributor Guide
 
-MicroK8s is open source ([Apache License 2.0](./LICENSE)) and actively seeks any community contibutions for code, add-ons, suggestions and documentation.
+MicroK8s is open source ([Apache License 2.0](./LICENSE)) and actively seeks any community contributions for code, add-ons, suggestions and documentation.
 Many of the features currently part of MicroK8s originated in the community, and we are very keen for that to continue. This page details a few notes, 
 workflows and suggestions for how to make contributions most effective and help us all build a better MicroK8s for everyone - please give them a read before
 working on any contributions.

--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -60,7 +60,7 @@ then
   fi
 fi
 
-# Sanatize arguments
+# Sanitize arguments
 if [ -e $SNAP_DATA/var/lock/no-arg-sanitisation ]
 then
   echo "Skipping argument sanitisation."

--- a/tests/libs/addons.sh
+++ b/tests/libs/addons.sh
@@ -60,6 +60,15 @@ function run_gpu_addon_test() {
   fi
 }
 
+function run_microceph_addon_test() {
+  if [ -f "/var/snap/microk8s/common/addons/core/tests/test-addons.py" ] &&
+   grep test_rook_ceph_integration /var/snap/microk8s/common/addons/core/tests/test-addons.py -q
+  then
+    timeout 3600 pytest -s /var/snap/microk8s/common/addons/core/tests/test-addons.py -k test_rook_ceph_integration
+  fi
+}
+
+
 function post_addons_tests() {
   local NAME=$1
   lxc exec "$NAME" -- microk8s reset
@@ -114,5 +123,6 @@ then
   run_community_addons_tests "$NAME"
   run_eksd_addons_tests
   run_gpu_addon_test
+  run_microceph_addon_test
   post_addons_tests "$NAME"
 fi


### PR DESCRIPTION
#### Summary
Introduce a MicroCeph integration test. 

#### Changes
The addons tests will call the respective pytest from the core addos repository. Needs to be merged after: https://github.com/canonical/microk8s-core-addons/pull/242

