### PR TITLE
Update microk8s version to 1.28 and multipass 1.12.2

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Download kubectl
         uses: carlosperate/download-file-action@v2.0.1
         with:
-          file-url: https://storage.googleapis.com/kubernetes-release/release/v1.27.3/bin/windows/amd64/kubectl.exe
+          file-url: https://storage.googleapis.com/kubernetes-release/release/v1.28.3/bin/windows/amd64/kubectl.exe
           file-name: kubectl.exe
           location: ${{ github.workspace }}/installer/windows
       - name: Create installer

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Download Multipass installer
         uses: carlosperate/download-file-action@v2.0.1
         with:
-          file-url: https://github.com/canonical/multipass/releases/download/v1.12.0/multipass-1.12.0+win-win64.exe
+          file-url: https://github.com/canonical/multipass/releases/download/v1.12.2/multipass-1.12.2+win-win64.exe
           file-name: multipass.exe
           location: ${{ github.workspace }}/installer/windows
       - name: Download kubectl

--- a/installer/common/definitions.py
+++ b/installer/common/definitions.py
@@ -28,7 +28,7 @@ DEFAULT_CORES: int = 2
 DEFAULT_MEMORY_GB: int = 4
 DEFAULT_DISK_GB: int = 50
 DEFAULT_ASSUME: bool = False
-DEFAULT_CHANNEL: str = "1.27/stable"
+DEFAULT_CHANNEL: str = "1.28/stable"
 DEFAULT_IMAGE: str = "22.04"
 
 MIN_CORES: int = 2

--- a/installer/vm_providers/_multipass/_windows.py
+++ b/installer/vm_providers/_multipass/_windows.py
@@ -39,12 +39,12 @@ logger = logging.getLogger(__name__)
 
 
 _MULTIPASS_RELEASES_API_URL = "https://api.github.com/repos/canonical/multipass/releases"
-_MULTIPASS_DL_VERSION = "1.12.0"
+_MULTIPASS_DL_VERSION = "1.12.2"
 _MULTIPASS_DL_NAME = "multipass-{version}+win-win64.exe".format(version=_MULTIPASS_DL_VERSION)
 
 # Download multipass installer and calculate hash:
 #   python3 -c "from installer.common.file_utils import calculate_sha3_384; print(calculate_sha3_384('$HOME/Downloads/multipass-1.11.1+win-win64.exe'))"  # noqa: E501
-_MULTIPASS_DL_SHA3_384 = "ddba66059052a67fa6a363729b75aca374591bc5a2531c938dd70d63f683c22108d5c2ab77025b818b31f69103228eee"  # noqa: E501
+_MULTIPASS_DL_SHA3_384 = "9031c8fc98b941df1094a832c356e12f281c70d0eb10bee15b5576c61af4c8a17ef32b833f0043c8df0e04897e69c8bc"  # noqa: E501
 
 
 def windows_reload_multipass_path_env():

--- a/installer/windows/microk8s.nsi
+++ b/installer/windows/microk8s.nsi
@@ -162,7 +162,7 @@ Function "ConfigureVm"
         ${NSD_CreateLabel} 42% 50 50u 10u "Snap Track"
         Pop $VmConfigureDialogTrackLabel
 
-        ${NSD_CreateText} 42% 67.5 50u 10u "1.27/stable"
+        ${NSD_CreateText} 42% 67.5 50u 10u "1.28/stable"
         Pop $VmConfigureDialogTrack
 
         ${NSD_CreateLabel} 8% 102.5 100% 10u "These are the minimum recommended parameters for the VM running ${PRODUCT_NAME}"


### PR DESCRIPTION
#### Summary
update homebrew formula to newest microk8s version (1.27) and ubuntu version (22.04)- otherwise Mac Users can't use it.
Closes #4231
References #4231

#### Changes
microk8s version changes from 1.27 --> 1.28
multipass version changes 1.12.0 --> 1.12.2


#### Checklist

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.

