### PR TITLE
Test k8s-dqlite upgrade

### DIFF
--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "master"
+echo "MK-1394/update-dqlite"


### PR DESCRIPTION
Do not merge. This PR is just to run the CI tests against the upgraded k8s-dqlite.

https://github.com/canonical/k8s-dqlite/pull/70