### PR TITLE
Enhance is_enabled to allow regex matches

### DIFF
--- a/scripts/wrappers/addons.py
+++ b/scripts/wrappers/addons.py
@@ -95,6 +95,7 @@ def validate_addons_file(repo_dir: Path) -> None:
                                 "description": {"type": "string"},
                                 "version": {"type": "string"},
                                 "check_status": {"type": "string"},
+                                "regex_check_status": {"type": "string"},
                                 "supported_architectures": {
                                     "type": "array",
                                     "items": {

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -555,7 +555,7 @@ def is_enabled(addon, row):
     check_status = addon["check_status"]
     if "regex_check_status" in addon and addon["regex_check_status"]:
         regex_check_status = addon["regex_check_status"]
-        return re.search(regex_check_status, row)
+        return bool(re.search(regex_check_status, row))
     elif check_status in row:
         return True
     else:

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -553,15 +553,10 @@ def unprotected_xable(action: str, addon_args: list):
 
 def is_enabled(addon, row):
     check_status = addon["check_status"]
-    print(addon)
     if "regex_check_status" in addon and addon["regex_check_status"]:
         regex_check_status = addon["regex_check_status"]
-        print(addon["regex_check_status"])
-        print("regex_check_status in row")
-        print(bool(re.search(regex_check_status, row)))
-        return bool(re.search(regex_check_status, row))
+        return re.search(regex_check_status, row)
     elif check_status in row:
-        print("check_status in row")
         return True
     else:
         filepath = os.path.expandvars(check_status)

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -553,10 +553,15 @@ def unprotected_xable(action: str, addon_args: list):
 
 def is_enabled(addon, row):
     check_status = addon["check_status"]
+    print(addon)
     if "regex_check_status" in addon and addon["regex_check_status"]:
         regex_check_status = addon["regex_check_status"]
+        print(addon["regex_check_status"])
+        print("regex_check_status in row")
+        print(bool(re.search(regex_check_status, row)))
         return bool(re.search(regex_check_status, row))
     elif check_status in row:
+        print("check_status in row")
         return True
     else:
         filepath = os.path.expandvars(check_status)

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -3,6 +3,7 @@ import getpass
 import json
 import os
 import platform
+import re
 import subprocess
 import sys
 import time
@@ -550,11 +551,15 @@ def unprotected_xable(action: str, addon_args: list):
         wait_for_ready(timeout=30, with_ready_node=False)
 
 
-def is_enabled(addon, item):
-    if addon in item:
+def is_enabled(addon, row):
+    check_status = addon["check_status"]
+    if "regex_check_status" in addon and addon["regex_check_status"]:
+        regex_check_status = addon["regex_check_status"]
+        return re.search(regex_check_status, row)
+    elif check_status in row:
         return True
     else:
-        filepath = os.path.expandvars(addon)
+        filepath = os.path.expandvars(check_status)
         return os.path.isfile(filepath)
 
 
@@ -569,7 +574,7 @@ def get_status(available_addons, isReady):
         for addon in available_addons:
             found = False
             for row in kube_output.split("\n"):
-                if is_enabled(addon["check_status"], row):
+                if is_enabled(addon, row):
                     enabled.append(addon)
                     found = True
                     break

--- a/scripts/wrappers/status.py
+++ b/scripts/wrappers/status.py
@@ -143,6 +143,7 @@ def print_yaml(isReady, enabled_addons, disabled_addons):
             print("{:>4}description: {:<1}".format("", disabled["description"]))
             print("{:>4}version: {:<1}".format("", disabled["version"]))
             print("{:>4}status: disabled".format(""))
+            print(disabled)
     else:
         print(
             "{:>2}{} {}".format(

--- a/scripts/wrappers/status.py
+++ b/scripts/wrappers/status.py
@@ -143,7 +143,6 @@ def print_yaml(isReady, enabled_addons, disabled_addons):
             print("{:>4}description: {:<1}".format("", disabled["description"]))
             print("{:>4}version: {:<1}".format("", disabled["version"]))
             print("{:>4}status: disabled".format(""))
-            print(disabled)
     else:
         print(
             "{:>2}{} {}".format(


### PR DESCRIPTION
#### Summary

This PR combined with [community addons pr166](https://github.com/canonical/microk8s-community-addons/pull/166) closes #4245 and [#165](https://github.com/canonical/microk8s-community-addons/issues/165).
Introduce a regex check for the is_enabled util function to see if an addon is enabled, if the "regex_check_status" field exists and has a value. Otherwise run the existing "check_status value" in row check, or a file check.

#### Changes
- Update the is_enabled function.
- Also note the related changes in the [community addons pr166](https://github.com/canonical/microk8s-community-addons/pull/166) that introduce the regex_check_status field, and update the portainer addon to use it.

#### Testing
- checked out and my fork/branch of microk8s `git clone https://github.com/testA113/microk8s.git && git switch fix-portainer-check-status-to-only-target-server`
- built the snap using lxd (following [these intructions](https://github.com/canonical/microk8s/blob/master/docs/build.md#building-the-snap-using-lxd))
- added the custom community addons based on [pr166](https://github.com/canonical/microk8s-community-addons/pull/166) `sudo microk8s addons repo add community https://github.com/testA113/microk8s-community-addons --reference fix-portainer-check-status-to-only-target-server`
- installed the portainer agent `microk8s kubectl apply -f https://downloads.portainer.io/ee2-18/portainer-agent-k8s-nodeport.yaml `
- ensure that the portainer community addons does NOT show as enabled `microk8s status`
- removed the portainer agent `microk8s kubectl remove ns portainer`
- enable the portainer addons with microk8s `microk8s enable portainer`
- ensure that the portainer addons is shown as enabled.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->
The enabled and disabled check in general could be affected but doesn't appear to be from testing.

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.
