### PR TITLE
Only verify partial CA chain

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -713,9 +713,10 @@ produce_certs() {
 
 ensure_server_ca() {
     # ensure the server.crt is issued by ca.crt
+    # in a ca chain it is only verified that the server.crt is issued by the intermediate ca
     # if current csr.conf is invalid, regenerate front-proxy-client certificates as well
 
-    if ! ${SNAP}/usr/bin/openssl verify -CAfile ${SNAP_DATA}/certs/ca.crt ${SNAP_DATA}/certs/server.crt &>/dev/null
+    if ! ${SNAP}/usr/bin/openssl verify -no-CAfile -no-CApath -partial_chain -trusted ${SNAP_DATA}/certs/ca.crt ${SNAP_DATA}/certs/server.crt &>/dev/null
     then
         csr_modified="$(ensure_csr_conf_conservative)"
         gen_server_cert


### PR DESCRIPTION
If an intermediate CA is used, we cannot verify the whole chain since the CA needs to be self-signed for `openssl verify` to work.

We only want to verify that the server certificate is actually issued by the parent CA (either a root CA or intermediate), thus verifying the partial chain is sufficient.

See also: https://stackoverflow.com/a/60831762
