### PR TITLE
use default broadcast source address for add-node hint

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -547,8 +547,7 @@ wait_for_service_shutdown() {
 
 get_default_ip() {
     # Get the IP of the default interface
-    local DEFAULT_INTERFACE="$($SNAP/sbin/ip route show default | $SNAP/usr/bin/gawk '{for(i=1; i<NF; i++) if($i=="dev") print$(i+1)}' | head -1)"
-    local IP_ADDR="$($SNAP/sbin/ip -o -4 addr list "$DEFAULT_INTERFACE" | $SNAP/usr/bin/gawk '{print $4}' | $SNAP/usr/bin/cut -d/ -f1 | head -1)"
+    local IP_ADDR="$($SNAP/sbin/ip route get 255.255.255.255 | $SNAP/usr/bin/gawk '{for(i=1; i<NF; i++) if($i=="src") print$(i+1)}' | head -1)"
     if [[ -z "$IP_ADDR" ]]
     then
         echo "none"

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -547,7 +547,13 @@ wait_for_service_shutdown() {
 
 get_default_ip() {
     # Get the IP of the default interface
-    local IP_ADDR="$($SNAP/sbin/ip route get 255.255.255.255 | $SNAP/usr/bin/gawk '{for(i=1; i<NF; i++) if($i=="src") print$(i+1)}' | head -1)"
+    local DEFAULT_INTERFACE="$($SNAP/sbin/ip route show default | $SNAP/usr/bin/gawk '{for(i=1; i<NF; i++) if($i=="dev") print$(i+1)}' | head -1)"
+    local IP_ADDR="$($SNAP/sbin/ip -o -4 addr list "$DEFAULT_INTERFACE" | $SNAP/usr/bin/gawk '{print $4}' | $SNAP/usr/bin/cut -d/ -f1 | head -1)"
+
+    if [[ -z "$IP_ADDR" ]]; then
+        local IP_ADDR="$($SNAP/sbin/ip route get 255.255.255.255 | $SNAP/usr/bin/gawk '{for(i=1; i<NF; i++) if($i=="src") print$(i+1)}' | head -1)"
+    fi
+
     if [[ -z "$IP_ADDR" ]]
     then
         echo "none"


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary

This simplifies the address detection a bit for the 'add-node' command hint, enabling a use case where FRR or similar is installing the default route via multiple 'unnumbered' interfaces:

```
# microk8s add-node
From the node you wish to join to this cluster, run the following:
microk8s join none:25000/........

# ip route show default
default nhid 151 proto bgp metric 20 
	nexthop via inet6 fe80::290:bff:fea5:e2d3 dev bgpenp36s0 weight 1 
	nexthop via inet6 fe80::290:bff:fea5:deab dev bgpenp35s0 weight 1 

# ip route get 255.255.255.255
broadcast 255.255.255.255 dev bgpenp35s0 src 10.0.200.1 uid 0 
    cache <local,brd> 
```

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

Instead of fetching the default route interface and then its address, the suggested change simply finds the system-wide default source address for 255.255.255.255.  In a typical dhcp or static ip scenario, this will be the expected interface; in my 'L3 to the hypervisor' scenario, this will be a loopback /32 ipv4 address.

#### Testing
<!-- Please explain how you tested your changes. -->

I've tested this by simply running `snapcraft build` and installing the artifact.  First on a machine running bgp, with 10.0.200.255/32 on `lo`:

```
$ snapcraft build
$ sudo snap install microk8s_v1.28.2_amd64.snap --dangerous --classic
$ microk8s add-node
From the node you wish to join to this cluster, run the following:
microk8s join 10.0.200.255:25000/e6f7f77b060d7b53bba6c97db29bfc47/aab0f29f6056
```

Then on an lxd vm with basic networking:

```
$ lxc file push microk8s_v1.28.2_amd64.snap microk8s/root/
$ lxc shell microk8s
root@microk8s:~# snap install microk8s_v1.28.2_amd64.snap --dangerous --classic
root@microk8s:~# microk8s add-node
From the node you wish to join to this cluster, run the following:
microk8s join 10.11.228.100:25000/7bf37091dd4c3f0abad312f16beb23ee/e369d5eb414d
```

I need guidance on running the legitimate test suite, it seems the [testing documentation is outdated](https://github.com/canonical/microk8s/issues/4216).

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [x ] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
