### PR TITLE
Use openssl.wrapper script for all openssl invocations

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -579,13 +579,13 @@ get_ips() {
 }
 
 gen_server_cert() (
-    ${SNAP}/usr/bin/openssl req -new -sha256 -key ${SNAP_DATA}/certs/server.key -out ${SNAP_DATA}/certs/server.csr -config ${SNAP_DATA}/certs/csr.conf
-    ${SNAP}/usr/bin/openssl x509 -req -sha256 -in ${SNAP_DATA}/certs/server.csr -CA ${SNAP_DATA}/certs/ca.crt -CAkey ${SNAP_DATA}/certs/ca.key -CAcreateserial -out ${SNAP_DATA}/certs/server.crt -days 365 -extensions v3_ext -extfile ${SNAP_DATA}/certs/csr.conf
+    "${SNAP}/openssl.wrapper" req -new -sha256 -key ${SNAP_DATA}/certs/server.key -out ${SNAP_DATA}/certs/server.csr -config ${SNAP_DATA}/certs/csr.conf
+    "${SNAP}/openssl.wrapper" x509 -req -sha256 -in ${SNAP_DATA}/certs/server.csr -CA ${SNAP_DATA}/certs/ca.crt -CAkey ${SNAP_DATA}/certs/ca.key -CAcreateserial -out ${SNAP_DATA}/certs/server.crt -days 365 -extensions v3_ext -extfile ${SNAP_DATA}/certs/csr.conf
 )
 
 gen_proxy_client_cert() (
-    ${SNAP}/usr/bin/openssl req -new -sha256 -key ${SNAP_DATA}/certs/front-proxy-client.key -out ${SNAP_DATA}/certs/front-proxy-client.csr -config <(sed '/^prompt = no/d' ${SNAP_DATA}/certs/csr.conf) -subj "/CN=front-proxy-client"
-    ${SNAP}/usr/bin/openssl x509 -req -sha256 -in ${SNAP_DATA}/certs/front-proxy-client.csr -CA ${SNAP_DATA}/certs/front-proxy-ca.crt -CAkey ${SNAP_DATA}/certs/front-proxy-ca.key -CAcreateserial -out ${SNAP_DATA}/certs/front-proxy-client.crt -days 365 -extensions v3_ext -extfile ${SNAP_DATA}/certs/csr.conf
+    "${SNAP}/openssl.wrapper" req -new -sha256 -key ${SNAP_DATA}/certs/front-proxy-client.key -out ${SNAP_DATA}/certs/front-proxy-client.csr -config <(sed '/^prompt = no/d' ${SNAP_DATA}/certs/csr.conf) -subj "/CN=front-proxy-client"
+    "${SNAP}/openssl.wrapper" x509 -req -sha256 -in ${SNAP_DATA}/certs/front-proxy-client.csr -CA ${SNAP_DATA}/certs/front-proxy-ca.crt -CAkey ${SNAP_DATA}/certs/front-proxy-ca.key -CAcreateserial -out ${SNAP_DATA}/certs/front-proxy-client.crt -days 365 -extensions v3_ext -extfile ${SNAP_DATA}/certs/csr.conf
 )
 
 create_user_certs_and_configs() {
@@ -664,18 +664,18 @@ produce_certs() {
     # Generate RSA keys if not yet
     for key in serviceaccount.key ca.key server.key front-proxy-ca.key front-proxy-client.key; do
         if ! [ -f ${SNAP_DATA}/certs/$key ]; then
-            ${SNAP}/usr/bin/openssl genrsa -out ${SNAP_DATA}/certs/$key 2048
+            "${SNAP}/openssl.wrapper" genrsa -out ${SNAP_DATA}/certs/$key 2048
         fi
     done
 
     # Generate apiserver CA
     if ! [ -f ${SNAP_DATA}/certs/ca.crt ]; then
-        ${SNAP}/usr/bin/openssl req -x509 -new -sha256 -nodes -days 3650 -key ${SNAP_DATA}/certs/ca.key -subj "/CN=10.152.183.1" -out ${SNAP_DATA}/certs/ca.crt
+        "${SNAP}/openssl.wrapper" req -x509 -new -sha256 -nodes -days 3650 -key ${SNAP_DATA}/certs/ca.key -subj "/CN=10.152.183.1" -out ${SNAP_DATA}/certs/ca.crt
     fi
 
     # Generate front proxy CA
     if ! [ -f ${SNAP_DATA}/certs/front-proxy-ca.crt ]; then
-        ${SNAP}/usr/bin/openssl req -x509 -new -sha256 -nodes -days 3650 -key ${SNAP_DATA}/certs/front-proxy-ca.key -subj "/CN=front-proxy-ca" -out ${SNAP_DATA}/certs/front-proxy-ca.crt
+        "${SNAP}/openssl.wrapper" req -x509 -new -sha256 -nodes -days 3650 -key ${SNAP_DATA}/certs/front-proxy-ca.key -subj "/CN=front-proxy-ca" -out ${SNAP_DATA}/certs/front-proxy-ca.crt
     fi
 
     # Produce certificates based on the rendered csr.conf.rendered.
@@ -703,7 +703,7 @@ produce_certs() {
         gen_proxy_client_cert
         echo "1"
     elif [ ! -f "${SNAP_DATA}/certs/front-proxy-client.crt" ] ||
-         [ "$(${SNAP}/usr/bin/openssl < ${SNAP_DATA}/certs/front-proxy-client.crt x509 -noout -issuer)" == "issuer=CN = 127.0.0.1" ]; then
+         [ "$("${SNAP}/openssl.wrapper" < ${SNAP_DATA}/certs/front-proxy-client.crt x509 -noout -issuer)" == "issuer=CN = 127.0.0.1" ]; then
         gen_proxy_client_cert
         echo "1"
     else
@@ -716,7 +716,7 @@ ensure_server_ca() {
     # in a ca chain it is only verified that the server.crt is issued by the intermediate ca
     # if current csr.conf is invalid, regenerate front-proxy-client certificates as well
 
-    if ! ${SNAP}/usr/bin/openssl verify -no-CAfile -no-CApath -partial_chain -trusted ${SNAP_DATA}/certs/ca.crt ${SNAP_DATA}/certs/server.crt &>/dev/null
+    if ! "${SNAP}/openssl.wrapper" verify -no-CAfile -no-CApath -partial_chain -trusted ${SNAP_DATA}/certs/ca.crt ${SNAP_DATA}/certs/server.crt &>/dev/null
     then
         csr_modified="$(ensure_csr_conf_conservative)"
         gen_server_cert
@@ -735,7 +735,7 @@ ensure_server_ca() {
 check_csr_conf() {
     # if no argument is given, default csr.conf will be checked
     csr_conf="${1:-${SNAP_DATA}/certs/csr.conf}"
-    ${SNAP}/usr/bin/openssl req -new -config $csr_conf -noout -nodes -keyout /dev/null &>/dev/null
+    "${SNAP}/openssl.wrapper" req -new -config $csr_conf -noout -nodes -keyout /dev/null &>/dev/null
 }
 
 refresh_csr_conf() {
@@ -875,7 +875,7 @@ init_cluster() {
   $SNAP/bin/cp $SNAP/certs/csr-dqlite.conf.template $SNAP_DATA/var/tmp/csr-dqlite.conf
   $SNAP/bin/sed -i 's/HOSTNAME/'"${DNS}"'/g' $SNAP_DATA/var/tmp/csr-dqlite.conf
   $SNAP/bin/sed -i 's/HOSTIP/'"${IP}"'/g' $SNAP_DATA/var/tmp/csr-dqlite.conf
-  ${SNAP}/usr/bin/openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout ${SNAP_DATA}/var/kubernetes/backend/cluster.key -out ${SNAP_DATA}/var/kubernetes/backend/cluster.crt -subj "/CN=k8s" -config $SNAP_DATA/var/tmp/csr-dqlite.conf -extensions v3_ext
+  "${SNAP}/openssl.wrapper" req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout ${SNAP_DATA}/var/kubernetes/backend/cluster.key -out ${SNAP_DATA}/var/kubernetes/backend/cluster.crt -subj "/CN=k8s" -config $SNAP_DATA/var/tmp/csr-dqlite.conf -extensions v3_ext
   $SNAP/bin/chmod -R o-rwX ${SNAP_DATA}/var/kubernetes/backend/
   local group=$(get_microk8s_group)
   if getent group ${group} >/dev/null 2>&1
@@ -1051,7 +1051,7 @@ cluster_agent_port() {
 }
 
 server_cert_check() {
-  ${SNAP}/usr/bin/openssl x509 -in "$SNAP_DATA"/certs/server.crt -outform der | ${SNAP}/usr/bin/sha256sum | $SNAP/usr/bin/cut -d' ' -f1 | $SNAP/usr/bin/cut -c1-12
+  "${SNAP}/openssl.wrapper" x509 -in "$SNAP_DATA"/certs/server.crt -outform der | ${SNAP}/usr/bin/sha256sum | $SNAP/usr/bin/cut -d' ' -f1 | $SNAP/usr/bin/cut -c1-12
 }
 
 generate_csr_with_sans() {
@@ -1077,13 +1077,13 @@ generate_csr_with_sans() {
 
   # generate key if it does not exist
   if [ ! -f "$2" ]; then
-    ${SNAP}/usr/bin/openssl genrsa -out "$2" 2048
+    "${SNAP}/openssl.wrapper" genrsa -out "$2" 2048
     $SNAP/bin/chown 0:0 "$2" || true
     $SNAP/bin/chmod 0600 "$2" || true
   fi
 
   # generate csr
-  ${SNAP}/usr/bin/openssl req -new -sha256 -subj "$1" -key "$2" -addext "subjectAltName = $subjectAltName"
+  "${SNAP}/openssl.wrapper" req -new -sha256 -subj "$1" -key "$2" -addext "subjectAltName = $subjectAltName"
 }
 
 generate_csr() {
@@ -1097,13 +1097,13 @@ generate_csr() {
 
   # generate key if it does not exist
   if [ ! -f "$2" ]; then
-    ${SNAP}/usr/bin/openssl genrsa -out "$2" 2048
+    "${SNAP}/openssl.wrapper" genrsa -out "$2" 2048
     $SNAP/bin/chown 0:0 "$2" || true
     $SNAP/bin/chmod 0600 "$2" || true
   fi
 
   # generate csr
-  ${SNAP}/usr/bin/openssl req -new -sha256 -subj "$1" -key "$2"
+  "${SNAP}/openssl.wrapper" req -new -sha256 -subj "$1" -key "$2"
 }
 
 sign_certificate() {
@@ -1123,13 +1123,13 @@ sign_certificate() {
 
   # Parse SANs from the CSR and add them to the certificate extensions (if any)
   extensions=""
-  alt_names="$(echo "$csr" | ${SNAP}/usr/bin/openssl req -text | $SNAP/bin/grep "X509v3 Subject Alternative Name:" -A1 | $SNAP/usr/bin/tail -n 1 | $SNAP/bin/sed 's,IP Address:,IP:,g')"
+  alt_names="$(echo "$csr" | "${SNAP}/openssl.wrapper" req -text | $SNAP/bin/grep "X509v3 Subject Alternative Name:" -A1 | $SNAP/usr/bin/tail -n 1 | $SNAP/bin/sed 's,IP Address:,IP:,g')"
   if test "x$alt_names" != "x"; then
     extensions="subjectAltName = $alt_names"
   fi
 
   # Sign certificate and print to stdout
-  echo "$csr" | ${SNAP}/usr/bin/openssl x509 -req -sha256 -CA "${SNAP_DATA}/certs/ca.crt" -CAkey "${SNAP_DATA}/certs/ca.key" -CAcreateserial -days 3650 -extfile <(echo "${extensions}")
+  echo "$csr" | "${SNAP}/openssl.wrapper" x509 -req -sha256 -CA "${SNAP_DATA}/certs/ca.crt" -CAkey "${SNAP_DATA}/certs/ca.key" -CAcreateserial -days 3650 -extfile <(echo "${extensions}")
 }
 
 
@@ -1343,13 +1343,10 @@ increase_sysctl_parameter() {
 }
 
 use_snap_env() {
-  # Configure snap paths for PATH LD_LIBRARY_PATH
-  export PATH="$SNAP/bin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/usr/sbin:$PATH"
+  # Configure LD_LIBRARY_PATH
   export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/ceph:${LD_LIBRARY_PATH:-}"
-  export OPENSSL_CONF="$SNAP/etc/ssl/openssl.cnf"
 
   # Python configuration
-  export PYTHONPATH="$SNAP/usr/lib/python3.8:$SNAP/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages"
   export PYTHONNOUSERSITE=false
 
   # NOTE(neoaggelos/2023-08-14):

--- a/microk8s-resources/wrappers/microk8s-add-node.wrapper
+++ b/microk8s-resources/wrappers/microk8s-add-node.wrapper
@@ -22,7 +22,7 @@ exit_if_not_root
 
 exit_if_no_permissions
 
-subject=$(openssl x509 -sha256 -days 365 -noout -subject -in "$SNAP_DATA/certs/ca.crt")
+subject=$("${SNAP}/openssl.wrapper" x509 -sha256 -days 365 -noout -subject -in "$SNAP_DATA/certs/ca.crt")
 if [[ $subject == *"127.0.0.1"* ]]; then
   echo "Clustering requires a fresh MicroK8s installation. Reinstall with:"
   echo "sudo snap remove microk8s"

--- a/microk8s-resources/wrappers/openssl.wrapper
+++ b/microk8s-resources/wrappers/openssl.wrapper
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eu
+
+source $SNAP/actions/common/utils.sh
+
+use_snap_env
+
+export OPENSSL_CONF="${SNAP}/etc/ssl/openssl.cnf"
+
+"${SNAP}/usr/bin/openssl" "${@}"

--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -196,7 +196,7 @@ def get_etcd_client_cert(master_ip, master_port, token):
     """
     cer_req_file = "{}/certs/server.remote.csr".format(snapdata_path)
     cmd_cert = (
-        "{snap}/usr/bin/openssl req -new -sha256 -key {snapdata}/certs/server.key -out {csr} "
+        "{snap}/openssl.wrapper req -new -sha256 -key {snapdata}/certs/server.key -out {csr} "
         "-config {snapdata}/certs/csr.conf".format(
             snap=snap_path, snapdata=snapdata_path, csr=cer_req_file
         )

--- a/scripts/wrappers/leave.py
+++ b/scripts/wrappers/leave.py
@@ -220,7 +220,7 @@ def reinit_cluster():
             stderr=subprocess.DEVNULL,
         )
         subprocess.check_call(
-            "{0}/usr/bin/openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes "
+            "{0}/openssl.wrapper req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes "
             "-keyout {1}/var/kubernetes/backend/cluster.key "
             "-out {1}/var/kubernetes/backend/cluster.crt "
             "-subj /CN=k8s -config {1}/var/tmp/csr-dqlite.conf -extensions v3_ext".format(

--- a/scripts/wrappers/refresh_certs.py
+++ b/scripts/wrappers/refresh_certs.py
@@ -31,7 +31,7 @@ def check_certificate():
     """
     try:
         for file in certs.keys():
-            cmd = "{}/usr/bin/openssl x509 -enddate -noout -in {}/certs/{}".format(
+            cmd = "{}/openssl.wrapper x509 -enddate -noout -in {}/certs/{}".format(
                 snap_path, snapdata_path, file
             )
             cert_expire = subprocess.check_output(cmd.split())
@@ -217,7 +217,7 @@ def validate_certificates(ca_dir):
         exit(30)
 
     try:
-        cmd = "{}/usr/bin/openssl rsa -in {}/ca.key -check -noout -out /dev/null".format(
+        cmd = "{}/openssl.wrapper rsa -in {}/ca.key -check -noout -out /dev/null".format(
             snap_path, ca_dir
         )
         subprocess.check_call(cmd.split(), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -226,7 +226,7 @@ def validate_certificates(ca_dir):
         exit(31)
 
     try:
-        cmd = "{}/usr/bin/openssl x509 -in {}/ca.crt -text -noout -out /dev/null".format(
+        cmd = "{}/openssl.wrapper x509 -in {}/ca.crt -text -noout -out /dev/null".format(
             snap_path, ca_dir
         )
         subprocess.check_call(cmd.split(), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,9 +13,8 @@ confinement: classic
 base: core20
 assumes: [snapd2.52]
 environment:
-  PYTHONPATH: $SNAP/usr/lib/python3.8:$SNAP/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+  PYTHONPATH: $SNAP/usr/lib/python3.8:$SNAP/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages
   PATH: $SNAP/usr/bin:$SNAP/bin:$SNAP/usr/sbin:$SNAP/sbin:$PATH
-  OPENSSL_CONF: $SNAP/etc/ssl/openssl.cnf
   SNAPCRAFT_ARCH_TRIPLET: $SNAPCRAFT_ARCH_TRIPLET
 
 parts:


### PR DESCRIPTION
## Summary

Use a wrapper script for all openssl invocations. This is to reduce the diff with the FIPS-ready branch (https://github.com/canonical/microk8s/compare/fips)

## Changes

Also cleanup some duplicate configs between `use_snap_env` and `snapcraft.yaml:environment`