### PR TITLE
Cleanup unused snap dependencies

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -1348,8 +1348,10 @@ increase_sysctl_parameter() {
 }
 
 use_snap_env() {
-  # Configure LD_LIBRARY_PATH
-  export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/ceph:${LD_LIBRARY_PATH:-}"
+  # Configure PATH, LD_LIBRARY_PATH and PYTHONPATH
+  export PATH="$SNAP/usr/bin:$SNAP/bin:$SNAP/usr/sbin:$SNAP/sbin:$REAL_PATH"
+  export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/ceph:${REAL_LD_LIBRARY_PATH:-}"
+  export PYTHONPATH="$SNAP/usr/lib/python3.8:$SNAP/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages"
 
   # Python configuration
   export PYTHONNOUSERSITE=false
@@ -1370,6 +1372,11 @@ use_snap_env() {
   # Configure XDG_RUNTIME_DIR
   export XDG_RUNTIME_DIR="${SNAP_COMMON}/run"
   mkdir -p "${XDG_RUNTIME_DIR}"
+}
+
+run_host() {
+  # Run a command using the host execution environment
+  PATH="$REAL_PATH" LD_LIBRARY_PATH="$REAL_LD_LIBRARY_PATH" PYTHONPATH="$REAL_PYTHONPATH" "${@}"
 }
 
 # check if this file is run with arguments

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -1374,11 +1374,6 @@ use_snap_env() {
   mkdir -p "${XDG_RUNTIME_DIR}"
 }
 
-run_host() {
-  # Run a command using the host execution environment
-  PATH="$REAL_PATH" LD_LIBRARY_PATH="$REAL_LD_LIBRARY_PATH" PYTHONPATH="$REAL_PYTHONPATH" "${@}"
-}
-
 # check if this file is run with arguments
 if [[ "$0" == "${BASH_SOURCE}" ]] &&
    [[ ! -z "$1" ]]

--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -108,18 +108,14 @@ then
 fi
 
 #UFW configuration
-if ! is_strict && (ufw version &> /dev/null)
-then
-  ufw=$(ufw status)
-  if echo $ufw | grep -q "Status: active" &&
-     ! [ -e ${SNAP_DATA}/var/lock/skip.ufw ]
-  then
+if ! [ -e ${SNAP_DATA}/var/lock/skip.ufw ] && ! is_strict && (run_host ufw version &> /dev/null); then
+  if run_host ufw status | grep -q "Status: active"; then
     # These succeed regardless of whether the rule exists already or not
     echo "Found enabled UFW: adding rules to allow in/out traffic on 'cali+' and 'vxlan.calico' devices"
-    if ! ufw allow in on vxlan.calico ||
-       ! ufw allow out on vxlan.calico ||
-       ! ufw allow in on cali+ ||
-       ! ufw allow out on cali+
+    if ! run_host ufw allow in on vxlan.calico ||
+       ! run_host ufw allow out on vxlan.calico ||
+       ! run_host ufw allow in on cali+ ||
+       ! run_host ufw allow out on cali+
     then
       echo "Failed to update UFW rules. You may want to set them manually."
     fi
@@ -204,7 +200,7 @@ then
   # NOTE(neoaggelos): https://github.com/canonical/microk8s/issues/3085
   # Attempt to use modprobe from the host, otherwise fallback to the one
   # provided with the snap.
-  if /sbin/modprobe br_netfilter || modprobe br_netfilter
+  if run_host /sbin/modprobe br_netfilter || modprobe br_netfilter
   then
     echo "Successfully loaded br_netfilter module."
   else

--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -110,8 +110,7 @@ fi
 #UFW configuration
 if ! is_strict && (ufw version &> /dev/null)
 then
-  ufw=$(ufw status)
-  if echo $ufw | grep -q "Status: active" &&
+  if ufw status | grep -q "Status: active" &&
      ! [ -e ${SNAP_DATA}/var/lock/skip.ufw ]
   then
     # These succeed regardless of whether the rule exists already or not

--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -108,14 +108,18 @@ then
 fi
 
 #UFW configuration
-if ! [ -e ${SNAP_DATA}/var/lock/skip.ufw ] && ! is_strict && (run_host ufw version &> /dev/null); then
-  if run_host ufw status | grep -q "Status: active"; then
+if ! is_strict && (ufw version &> /dev/null)
+then
+  ufw=$(ufw status)
+  if echo $ufw | grep -q "Status: active" &&
+     ! [ -e ${SNAP_DATA}/var/lock/skip.ufw ]
+  then
     # These succeed regardless of whether the rule exists already or not
     echo "Found enabled UFW: adding rules to allow in/out traffic on 'cali+' and 'vxlan.calico' devices"
-    if ! run_host ufw allow in on vxlan.calico ||
-       ! run_host ufw allow out on vxlan.calico ||
-       ! run_host ufw allow in on cali+ ||
-       ! run_host ufw allow out on cali+
+    if ! ufw allow in on vxlan.calico ||
+       ! ufw allow out on vxlan.calico ||
+       ! ufw allow in on cali+ ||
+       ! ufw allow out on cali+
     then
       echo "Failed to update UFW rules. You may want to set them manually."
     fi
@@ -200,7 +204,7 @@ then
   # NOTE(neoaggelos): https://github.com/canonical/microk8s/issues/3085
   # Attempt to use modprobe from the host, otherwise fallback to the one
   # provided with the snap.
-  if run_host /sbin/modprobe br_netfilter || modprobe br_netfilter
+  if /sbin/modprobe br_netfilter || modprobe br_netfilter
   then
     echo "Successfully loaded br_netfilter module."
   else

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -220,7 +220,7 @@ function suggest_fixes {
     printf -- 'The change can be made persistent with: sudo apt-get install iptables-persistent\n'
   fi
 
-  if ! is_strict && [ /snap/core18/current/usr/bin/which ufw &> /dev/null ]
+  if ! is_strict && [ /snap/core20/current/usr/bin/which ufw &> /dev/null ]
   then
     ufw=$(ufw status)
     if echo $ufw | grep -q "Status: active"

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -222,8 +222,7 @@ function suggest_fixes {
 
   if ! is_strict && [ /snap/core20/current/usr/bin/which ufw &> /dev/null ]
   then
-    ufw=$(ufw status)
-    if echo $ufw | grep -q "Status: active"
+    if ufw status | grep -q "Status: active"
     then
       header='\033[0;33m WARNING: \033[0m Firewall is enabled. Consider allowing pod traffic with: \n'
       content=''

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -160,7 +160,7 @@ parts:
       - libatm1
       - libnss-resolve
       - libnss-myhostname
-      - libnss-machines
+      - libnss-mymachines
       - members
       - nano
       - net-tools

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -145,6 +145,7 @@ parts:
   bash-utils:
     plugin: nil
     stage-packages:
+      - conntrack
       - coreutils
       - curl
       - diffutils
@@ -157,6 +158,9 @@ parts:
       - jq
       - kmod
       - libatm1
+      - libnss-resolve
+      - libnss-myhostname
+      - libnss-machines
       - members
       - nano
       - net-tools

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -180,9 +180,6 @@ parts:
       - -etc/ldap
       - -etc/logrotate.d
       - -etc/init.d
-      - -etc/modprobe.d
-      - -etc/network
-      - -etc/pam.d
       - -etc/perl
       - -etc/rsyslog.d
       - -etc/sudoers.d

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -176,7 +176,6 @@ parts:
     stage:
       - -etc/bash_completion.d
       - -etc/cron.d
-      - -etc/default
       - -etc/depmod.d
       - -etc/ldap
       - -etc/logrotate.d
@@ -187,8 +186,6 @@ parts:
       - -etc/perl
       - -etc/rsyslog.d
       - -etc/sudoers.d
-      - -etc/sysctl.d
-      - -etc/sysctl.conf
       - -lib/systemd/system
       - -usr/bin/perl*
       - -usr/include

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,8 +13,9 @@ confinement: classic
 base: core20
 assumes: [snapd2.52]
 environment:
-  PYTHONPATH: $SNAP/usr/lib/python3.8:$SNAP/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages
-  PATH: $SNAP/usr/bin:$SNAP/bin:$SNAP/usr/sbin:$SNAP/sbin:$PATH
+  REAL_PATH: $PATH
+  REAL_LD_LIBRARY_PATH: $LD_LIBRARY_PATH
+  REAL_PYTHONPATH: $PYTHONPATH
   SNAPCRAFT_ARCH_TRIPLET: $SNAPCRAFT_ARCH_TRIPLET
 
 parts:
@@ -98,6 +99,8 @@ parts:
     after: [build-deps]
     plugin: autotools
     source: https://www.netfilter.org/pub/libmnl/libmnl-1.0.4.tar.bz2
+    prime:
+      - -usr/local/include
 
   libnftnl:
     after: [libmnl]
@@ -105,6 +108,8 @@ parts:
     source: https://www.netfilter.org/projects/libnftnl/files/libnftnl-1.1.8.tar.bz2
     build-environment:
       - LIBMNL_LIBS: $SNAPCRAFT_STAGE/usr/lib
+    prime:
+      - -usr/local/include
 
   iptables:
     after: [libnftnl]
@@ -118,7 +123,9 @@ parts:
       - "--exec-prefix=/"
       - "--disable-shared"
       - "--enable-static"
-    prime:
+    stage:
+      - -usr
+      - -lib/pkgconfig
       - -bin/iptables-xml
 
   containerd:
@@ -127,18 +134,6 @@ parts:
     source: build-scripts/components/containerd
     override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh containerd
     build-attributes: [no-patchelf]
-    stage-packages:
-      - libnss-myhostname
-      - libnss-resolve
-      - libnss-mymachines
-      - conntrack
-      - libssl1.1
-    stage:
-      - -sbin/xtables-multi
-      - -sbin/iptables*
-      - -lib/xtables
-      - -usr/share/doc
-      - -usr/share/man
 
   runc:
     after: [iptables, build-deps]
@@ -150,7 +145,6 @@ parts:
   bash-utils:
     plugin: nil
     stage-packages:
-      - aufs-tools
       - coreutils
       - curl
       - diffutils
@@ -171,35 +165,38 @@ parts:
       - python3-rados
       - python3-rbd
       - sed
-      - socat
-      - squashfs-tools
       - tar
       - util-linux
       - zfsutils-linux
     stage:
+      - -etc/bash_completion.d
+      - -etc/cron.d
+      - -etc/default
+      - -etc/depmod.d
+      - -etc/ldap
+      - -etc/init.d
+      - -etc/modprobe.d
+      - -etc/network
+      - -etc/pam.d
+      - -etc/perl
+      - -etc/sudoers.d
+      - -etc/sysctl.d
+      - -etc/sysctl.conf
+      - -lib/systemd/system
+      - -usr/bin/perl*
+      - -usr/include
+      - -usr/lib/*/*perl*
+      - -usr/share/bash-completion
       - -usr/share/doc
-      - -usr/share/man
-    override-prime: |
-      snapcraftctl prime
-      rm -vf lib/systemd/system/zfs-import.service
-
-  ufw:
-    plugin: nil
-    stage-packages:
-      - ufw
-    stage:
-      - -usr/share/doc
-      - -usr/share/man
-      - -lib/*/*
-      - -sbin/ip*tables*
-      - -sbin/xtables-multi
-      - -usr/bin/iptables-xml
-      - -usr/sbin/ip*tables*
-      - -usr/sbin/nfnl_osf
-      - -usr/lib/*/*
       - -usr/share/doc-base
-      - -usr/share/iptables
+      - -usr/share/info
+      - -usr/share/initramfs-tools
       - -usr/share/lintian
+      - -usr/share/man
+      - -usr/share/nano
+      - -usr/share/perl
+      - -usr/share/perl5
+      - -usr/share/zsh
 
   cluster-agent:
     after: [build-deps]
@@ -290,8 +287,11 @@ parts:
       - python3-click
       - python3-dateutil
     stage:
+      - -usr/lib/python3.9
       - -usr/share/doc
+      - -usr/share/lintian
       - -usr/share/man
+      - -usr/share/python-wheels
 
   bom:
     after:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -166,6 +166,7 @@ parts:
       - python3-rbd
       - sed
       - tar
+      - ufw
       - util-linux
       - zfsutils-linux
     stage:
@@ -174,11 +175,13 @@ parts:
       - -etc/default
       - -etc/depmod.d
       - -etc/ldap
+      - -etc/logrotate.d
       - -etc/init.d
       - -etc/modprobe.d
       - -etc/network
       - -etc/pam.d
       - -etc/perl
+      - -etc/rsyslog.d
       - -etc/sudoers.d
       - -etc/sysctl.d
       - -etc/sysctl.conf

--- a/tests/lxc/install-deps/images_archlinux
+++ b/tests/lxc/install-deps/images_archlinux
@@ -26,7 +26,7 @@ pip3 install pytest requests pyyaml
 n=0
 until [ $n -ge 7 ]
 do
-  sudo snap install core18 && break  # substitute your command here
+  sudo snap install core20 && break  # substitute your command here
   n=$[$n+1]
   sleep 10
 done

--- a/tests/lxc/install-deps/ubuntu_16.04
+++ b/tests/lxc/install-deps/ubuntu_16.04
@@ -8,4 +8,4 @@ apt-get install python3-pip docker.io -y
 pip3 install importlib-metadata==2.1.0 pytest requests pyyaml sh
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
-snap install core18 | true
+snap install core20 | true

--- a/tests/lxc/install-deps/ubuntu_20.04
+++ b/tests/lxc/install-deps/ubuntu_20.04
@@ -8,4 +8,4 @@ apt-get install python3-pip docker.io -y
 pip3 install pytest requests pyyaml sh
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
-snap install core18 | true
+snap install core20 | true


### PR DESCRIPTION
### Summary

Do a pass over dependencies that are not required for the snap to work. Adjust minor parts of the code accordingly.

### Changes

- Remove unused `aufs-tools`, `socat`, `squashfs-tools` packages
- Use `ufw` from the host (when available)
- Cleanup `containerd` part (remove unused stage file filters, drop conntrack and libs as they are not required, containerd is now a static binary)
- Drop perl and perl5 scripts (unused, only pulled due to git dependency)
- Drop python wheel files from result snap
- Remove mutiple doc-related files from the snap

### Result

As a result of this work, the amd64 snap size is reduced from 180MB to 160mb (about ~12% size reduction)