### PR TITLE
[Backport 1.28-strict] CI and tooling fixes to make 1.28-strict branch usable

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -2,7 +2,6 @@ name: Build and test MicroK8s snap
 
 on:
   - pull_request
-  - push
 
 jobs:
   build:

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -22,7 +22,8 @@ jobs:
           sudo snap install snapcraft --classic
       - name: Install snapd from candidate
         run: |
-          sudo snap refresh snapd --channel=latest/beta
+          # TODO(neoaggelos): revert this after latest/beta is working again
+          sudo snap refresh snapd --channel=latest/stable
       - name: Build snap
         run: |
           sg lxd -c 'snapcraft --use-lxd'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributor Guide
 
-MicroK8s is open source ([Apache License 2.0](./LICENSE)) and actively seeks any community contibutions for code, add-ons, suggestions and documentation.
-Many of the features currently part of MicroK8s originated in the community, and we are very keen for that to continue. This page details a few notes, 
+MicroK8s is open source ([Apache License 2.0](./LICENSE)) and actively seeks any community contributions for code, add-ons, suggestions and documentation.
+Many of the features currently part of MicroK8s originated in the community, and we are very keen for that to continue. This page details a few notes,
 workflows and suggestions for how to make contributions most effective and help us all build a better MicroK8s for everyone - please give them a read before
 working on any contributions.
 
@@ -10,7 +10,7 @@ working on any contributions.
 MicroK8s has been created under the [Apache License 2.0](./LICENSE), which will cover any contributions you may make to this project. Please familiarise
 yourself with the terms of the license.
 
-Additionally, MicroK8s uses the Harmony CLA agreement.  It’s the easiest way for you to give us permission to use your contributions. 
+Additionally, MicroK8s uses the Harmony CLA agreement.  It’s the easiest way for you to give us permission to use your contributions.
 In effect, you’re giving us a licence, but you still own the copyright — so you retain the right to modify your code and use it in
 other projects. Please [sign the CLA here](https://ubuntu.com/legal/contributors/agreement) before making any contributions.
 
@@ -28,7 +28,7 @@ The workflow for contributing code is as follows:
 3. **Make a new branch for your contribution**. Write your code there.
 4. For details on how to **build and test MicroK8s**, see the [build instructions](./docs/build.md). Add new tests as needed,
    and make sure the existing tests continue to pass when your changes are complete.
-5. **Submit a pull request** to get changes from your branch into master. You can add "#Fixes xxx" where `xxx` is the issue number to 
+5. **Submit a pull request** to get changes from your branch into master. You can add "#Fixes xxx" where `xxx` is the issue number to
    automatically link to the issue you chose or created earlier.
 6. Someone will review your PR and may make suggestions or have comments, so **keep an eye on the PR status** in case there are changes to make
 7. **Please make sure you have submitted your [CLA form](https://ubuntu.com/legal/contributors/agreement) if you are a first time contributor**.
@@ -36,8 +36,7 @@ The workflow for contributing code is as follows:
 
 ## Documentation
 
-Docs for MicroK8s are published online at [https://microk8s.io/docs](https://microk8s.io/docs). You can make suggestions and edit the pages themselves by joining 
+Docs for MicroK8s are published online at [https://microk8s.io/docs](https://microk8s.io/docs). You can make suggestions and edit the pages themselves by joining
 the Kubernetes discourse at [discuss.kubernetes.io](https://discuss.kubernetes.io/t/introduction-to-microk8s/11243) or follow the link at
 the bottom of any of the pages published at [https://microk8s.io/docs](https://microk8s.io/docs)
 There is a documentation page which describes how to write and edit docs, [published as part of the documentation](https://microk8s.io/docs/docs).
-

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -248,8 +248,8 @@ remove_args() {
 }
 
 
-sanatise_argskubeapi_server() {
-  # Function to sanitize arguments for API server
+sanitise_args_kubeapi_server() {
+  # Function to sanitise arguments for API server
   local args=(
     # Removed klog flags from 1.26+
     # https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md
@@ -283,8 +283,8 @@ sanatise_argskubeapi_server() {
 }
 
 
-sanatise_argskubelet() {
-  # Function to sanitize arguments for kubelet
+sanitise_args_kubelet() {
+  # Function to sanitise arguments for kubelet
   local args=(
     # Removed klog flags from 1.26+
     # https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md
@@ -325,8 +325,8 @@ sanatise_argskubelet() {
 }
 
 
-sanatise_argskube_proxy() {
-  # Function to sanitize arguments for kube-proxy
+sanitise_args_kube_proxy() {
+  # Function to sanitise arguments for kube-proxy
 
   # userspace proxy-mode is not allowed on the 1.26+ k8s
   # https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/#removal-of-kube-proxy-userspace-modes
@@ -357,8 +357,8 @@ sanatise_argskube_proxy() {
 }
 
 
-sanatise_argskube_controller_manager() {
-  # Function to sanitize arguments for kube-controller-manager
+sanitise_args_kube_controller_manager() {
+  # Function to sanitise arguments for kube-controller-manager
   local args=(
     # Removed klog flags from 1.26+
     # https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md
@@ -386,8 +386,8 @@ sanatise_argskube_controller_manager() {
 }
 
 
-sanatise_argskube_scheduler() {
-  # Function to sanitize arguments for kube-scheduler
+sanitise_args_kube_scheduler() {
+  # Function to sanitise arguments for kube-scheduler
   local args=(
     # Removed klog flags from 1.26+
     # https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md

--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -67,17 +67,17 @@ then
   fi
 fi
 
-# Sanatize arguments
-if [ -e $SNAP_DATA/var/lock/no-arg-sanitisation ] 
-then 
+# Sanitise arguments
+if [ -e $SNAP_DATA/var/lock/no-arg-sanitisation ]
+then
   echo "Skipping argument sanitisation."
 else
   echo "Sanitise arguments."
-  sanatise_argskubeapi_server
-  sanatise_argskubelet
-  sanatise_argskube_proxy
-  sanatise_argskube_scheduler
-  sanatise_argskube_controller_manager
+  sanitise_args_kubeapi_server
+  sanitise_args_kubelet
+  sanitise_args_kube_proxy
+  sanitise_args_kube_scheduler
+  sanitise_args_kube_controller_manager
 fi
 
 ## Kubelet configuration


### PR DESCRIPTION
### Summary

Backport https://github.com/canonical/microk8s/pull/4265 https://github.com/canonical/microk8s/issues/4253 to 1.28-strict branch