### PR TITLE
Build with Go 1.21

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,8 +21,8 @@ parts:
   build-deps:
     plugin: nil
     override-build: |
-      snap install go --classic --channel 1.20/stable
-      snap refresh go --channel 1.20/stable
+      snap install go --classic --channel 1.21/stable
+      snap refresh go --channel 1.21/stable
     build-packages:
       - autoconf
       - automake


### PR DESCRIPTION
### Summary

Required for Kubernetes 1.29