### PR TITLE
Add github and snapcraft badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <img src="docs/images/MicroK8s-logo-RGB-2022.png" width="400px;" />
 
+[![](https://github.com/canonical/microk8s/actions/workflows/build-snap.yml/badge.svg)](https://github.com/canonical/microk8s/actions/workflows/build-snap.yml)
+[![](https://snapcraft.io/microk8s/badge.svg)](https://snapcraft.io/microk8s)
 ![](https://img.shields.io/badge/Kubernetes-1.28-326de6.svg)
 
 <img src="/docs/images/certified_kubernetes_color-222x300.png" align="right" width="200px">


### PR DESCRIPTION
#### Summary
Adding Badges to snapcraft.io and gh actions builds

#### Changes
Improves the publicity of the snap, and adds these badges to https://releases.juju.is/?team=Kubernetes

#### Testing
Confirmed that the Badges render appropriate icons and reference valid links

#### Notes
No tests are added
