### PR TITLE
quickfix multipass launch parameter

### DIFF
--- a/installer/vm_providers/_multipass/_multipass_command.py
+++ b/installer/vm_providers/_multipass/_multipass_command.py
@@ -159,7 +159,7 @@ class MultipassCommand:
         if cpus is not None:
             cmd.extend(["--cpus", cpus])
         if mem is not None:
-            cmd.extend(["--mem", mem])
+            cmd.extend(["--memory", mem])
         if disk is not None:
             cmd.extend(["--disk", disk])
         try:


### PR DESCRIPTION
#### Summary
#Fixes 4320
MacOS fix multipass launch parameter mem deprecated warning

#### Changes
update installer/vm_providers/_multipass/_multipass_command.py file to pass memory instead of mem

#### Testing
verified the multipass deprecated warning no longer appears

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes

