### PR TITLE
[Backport 1.27] Do not set --hostname-override on kube-proxy (#4360)

### DIFF
--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -395,7 +395,7 @@ def create_x509_kubeconfig(ca, master_ip, api_port, filename, user, path_to_cert
         try_set_file_permissions(config)
 
 
-def update_kubeproxy(token, ca, master_ip, api_port, hostname_override):
+def update_kubeproxy(token, ca, master_ip, api_port):
     """
     Configure the kube-proxy
 
@@ -403,16 +403,14 @@ def update_kubeproxy(token, ca, master_ip, api_port, hostname_override):
     :param ca: the ca
     :param master_ip: the master node IP
     :param api_port: the API server port
-    :param hostname_override: the hostname override in case the hostname is not resolvable
     """
     create_kubeconfig(token, ca, master_ip, api_port, "proxy.config", "kubeproxy")
     set_arg("--master", None, "kube-proxy")
-    if hostname_override:
-        set_arg("--hostname-override", hostname_override, "kube-proxy")
+    set_arg("--hostname-override", None, "kube-proxy")
     service("restart", "proxy")
 
 
-def update_cert_auth_kubeproxy(token, ca, master_ip, master_port, hostname_override):
+def update_cert_auth_kubeproxy(token, ca, master_ip, master_port):
     """
     Configure the kube-proxy
 
@@ -420,7 +418,6 @@ def update_cert_auth_kubeproxy(token, ca, master_ip, master_port, hostname_overr
     :param ca: the ca
     :param master_ip: the master node IP
     :param master_port: the master node port where the cluster agent listens
-    :param hostname_override: the hostname override in case the hostname is not resolvable
     """
     proxy_token = "{}-proxy".format(token)
     traefik_port = get_traefik_port()
@@ -435,8 +432,7 @@ def update_cert_auth_kubeproxy(token, ca, master_ip, master_port, hostname_overr
         cert["certificate_key_location"],
     )
     set_arg("--master", None, "kube-proxy")
-    if hostname_override:
-        set_arg("--hostname-override", hostname_override, "kube-proxy")
+    set_arg("--hostname-override", None, "kube-proxy")
 
 
 def update_kubeproxy_cidr(cidr):
@@ -847,7 +843,7 @@ def join_dqlite_worker_node(info, master_ip, master_port, token):
     store_base_kubelet_args(info["kubelet_args"])
     update_kubelet_node_ip(info["kubelet_args"], hostname_override)
     update_kubelet_hostname_override(info["kubelet_args"])
-    update_cert_auth_kubeproxy(token, info["ca"], master_ip, master_port, hostname_override)
+    update_cert_auth_kubeproxy(token, info["ca"], master_ip, master_port)
     update_cert_auth_kubelet(token, info["ca"], master_ip, master_port)
 
     store_callback_token(info["callback_token"])
@@ -937,7 +933,7 @@ def join_etcd(connection_parts, verify=True):
 
     store_remote_ca(info["ca"])
     update_flannel(info["etcd"], master_ip, master_port, token)
-    update_kubeproxy(info["kubeproxy"], info["ca"], master_ip, info["apiport"], hostname_override)
+    update_kubeproxy(info["kubeproxy"], info["ca"], master_ip, info["apiport"])
     update_kubelet(info["kubelet"], info["ca"], master_ip, info["apiport"])
     mark_worker_node()
     mark_no_cert_reissue()


### PR DESCRIPTION
Backport #4360 to 1.27 branch