### PR TITLE
Use build-snaps instead of manually installing the go snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,9 +21,8 @@ environment:
 parts:
   build-deps:
     plugin: nil
-    override-build: |
-      snap install go --classic --channel 1.21/stable
-      snap refresh go --channel 1.21/stable
+    build-snaps:
+      - go/1.21/stable
     build-packages:
       - autoconf
       - automake


### PR DESCRIPTION
#### Summary
This improves the snapcraft.yaml file by making use of the built-in syntax for installing snap build dependencies, rather than manually installing and refreshing the snaps in `override-build`.

#### Changes
Replaces `snap install` and `snap refresh` with `build-snaps: [ go/1.21/stable ]`, allowing snapcraft to manage the lifecycle of the snap dependencies. 

#### Testing
Built the snap using snapcraft and installed it. The snap builds and runs correctly.

#### Checklist

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

#### Notes
N/A
