### PR TITLE
Fix erroneous microk8s join invocations by adding validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ tests/__pycache__
 /installer/**/__pycache__
 /installer/dist/
 /installer/build/
+.tox/
 .tox_env/
 __pycache__/
 microk8s_*.txt #Remote build log

--- a/scripts/wrappers/add_token.py
+++ b/scripts/wrappers/add_token.py
@@ -6,7 +6,7 @@ import time
 import argparse
 import subprocess
 
-from common.cluster.utils import is_node_running_dqlite
+from common.cluster.utils import is_node_running_dqlite, TOKEN_ΜΙΝ_LEN
 
 try:
     from secrets import token_hex
@@ -165,7 +165,7 @@ if __name__ == "__main__":
     else:
         token = token_hex(16)
 
-    if len(token) < 32:
+    if len(token) < TOKEN_ΜΙΝ_LEN:
         print("Invalid token size.  It must be 32 characters long.")
         exit(1)
 


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

Add validation to microk8s join connection string to avoid wrong usage that may lead to propagating errors to microk8s state.

Closes #4396

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

The validation of the connection string checks:

- The format of the string
- The validity of master IP
- The validity of master PORT
- The lengths of token and fingerprint

#### Testing
<!-- Please explain how you tested your changes. -->

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
