### PR TITLE
[1.26] Use snapcraft 7.x/edge for builds

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -19,7 +19,7 @@ jobs:
           sg lxd -c 'lxc version'
       - name: Install snapcraft
         run: |
-          sudo snap install snapcraft --classic
+          sudo snap install snapcraft --classic --channel 7.x/edge
       - name: Install snapd from candidate
         run: |
           # TODO(neoaggelos): revert this after latest/beta is working again


### PR DESCRIPTION
### Summary

Pin snapcraft to 7.x for building MicroK8s, required for core18 snaps.