### PR TITLE
[Backport 1.26-strict] Bump runc containerd

### DIFF
--- a/build-scripts/components/containerd/version.sh
+++ b/build-scripts/components/containerd/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.6.15"
+echo "v1.6.28"

--- a/build-scripts/components/runc/strict-patches/0001-apparmor-change-profile-immediately-not-on-exec.patch
+++ b/build-scripts/components/runc/strict-patches/0001-apparmor-change-profile-immediately-not-on-exec.patch
@@ -1,14 +1,14 @@
-From cc499086e2bbde59a349b52bdf7ce414b6fb3f0a Mon Sep 17 00:00:00 2001
+From a367e391600dfab0d9eb3deaec4db300a2fb1fa1 Mon Sep 17 00:00:00 2001
 From: Alberto Mardegan <mardy@users.sourceforge.net>
 Date: Wed, 16 Jun 2021 15:04:16 +0300
-Subject: [PATCH] apparmor: change profile immediately, not on exec
+Subject: [PATCH 1/3] apparmor: change profile immediately, not on exec
 
 ---
  libcontainer/apparmor/apparmor_linux.go | 8 ++++----
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/libcontainer/apparmor/apparmor_linux.go b/libcontainer/apparmor/apparmor_linux.go
-index 8b1483c7..292cfa6d 100644
+index 8b1483c..292cfa6 100644
 --- a/libcontainer/apparmor/apparmor_linux.go
 +++ b/libcontainer/apparmor/apparmor_linux.go
 @@ -48,9 +48,9 @@ func setProcAttr(attr, value string) error {
@@ -32,5 +32,6 @@ index 8b1483c7..292cfa6d 100644
 +	return changeProfile(name)
  }
 -- 
-2.25.1
+2.34.1
+
 

--- a/build-scripts/components/runc/strict-patches/0002-setns_init_linux-set-the-NNP-flag-after-changing-the.patch
+++ b/build-scripts/components/runc/strict-patches/0002-setns_init_linux-set-the-NNP-flag-after-changing-the.patch
@@ -1,21 +1,25 @@
-From 66fd3c5129599834de8262ee90a1ab2bf6b68ff0 Mon Sep 17 00:00:00 2001
-From: Alberto Mardegan <mardy@users.sourceforge.net>
-Date: Wed, 16 Jun 2021 15:04:40 +0300
+From 5351ef6f5b592472e077512714b2516cdbae1b51 Mon Sep 17 00:00:00 2001
+From: Angelos Kolaitis <angelos.kolaitis@canonical.com>
+Date: Thu, 1 Feb 2024 11:23:08 +0200
 Subject: [PATCH 2/3] setns_init_linux: set the NNP flag after changing the
  apparmor profile
 
 With the current version of the AppArmor kernel module, it's not
 possible to switch the AppArmor profile if the NoNewPrivileges flag is
 set. So, we invert the order of the two operations.
+
+Adjusts the previous patch for runc version v1.1.12
+
+Co-Authored-By: Alberto Mardegan <mardy@users.sourceforge.net>
 ---
  libcontainer/setns_init_linux.go | 10 +++++-----
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/libcontainer/setns_init_linux.go b/libcontainer/setns_init_linux.go
-index 97987f1d..eec427a0 100644
+index d1bb122..00407ce 100644
 --- a/libcontainer/setns_init_linux.go
 +++ b/libcontainer/setns_init_linux.go
-@@ -57,11 +57,6 @@ func (l *linuxSetnsInit) Init() error {
+@@ -56,11 +56,6 @@ func (l *linuxSetnsInit) Init() error {
  			return err
  		}
  	}
@@ -27,7 +31,7 @@ index 97987f1d..eec427a0 100644
  	if err := selinux.SetExecLabel(l.config.ProcessLabel); err != nil {
  		return err
  	}
-@@ -80,6 +75,11 @@ func (l *linuxSetnsInit) Init() error {
+@@ -84,6 +79,11 @@ func (l *linuxSetnsInit) Init() error {
  	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
  		return err
  	}
@@ -36,9 +40,8 @@ index 97987f1d..eec427a0 100644
 +			return err
 +		}
 +	}
- 	// Set seccomp as close to execve as possible, so as few syscalls take
- 	// place afterward (reducing the amount of syscalls that users need to
- 	// enable in their seccomp profiles).
--- 
-2.25.1
 
+ 	// Check for the arg before waiting to make sure it exists and it is
+ 	// returned as a create time error.
+--
+2.34.1

--- a/build-scripts/components/runc/strict-patches/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
+++ b/build-scripts/components/runc/strict-patches/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
@@ -1,7 +1,7 @@
-From 20906ff89553a0fb078d6c955ef5125c58361223 Mon Sep 17 00:00:00 2001
+From 103a94a51ea334d25bf573f2f20cd4d9a099d827 Mon Sep 17 00:00:00 2001
 From: Alberto Mardegan <mardy@users.sourceforge.net>
 Date: Thu, 17 Jun 2021 14:31:35 +0300
-Subject: [PATCH] standard_init_linux: change AppArmor profile as late as
+Subject: [PATCH 3/3] standard_init_linux: change AppArmor profile as late as
  possible
 
 ---
@@ -9,10 +9,10 @@ Subject: [PATCH] standard_init_linux: change AppArmor profile as late as
  1 file changed, 9 insertions(+), 9 deletions(-)
 
 diff --git a/libcontainer/standard_init_linux.go b/libcontainer/standard_init_linux.go
-index 585a04fa..c1b48d09 100644
+index d1d9435..7097571 100644
 --- a/libcontainer/standard_init_linux.go
 +++ b/libcontainer/standard_init_linux.go
-@@ -126,10 +126,6 @@ func (l *linuxStandardInit) Init() error {
+@@ -127,10 +127,6 @@ func (l *linuxStandardInit) Init() error {
  			return &os.SyscallError{Syscall: "sethostname", Err: err}
  		}
  	}
@@ -23,7 +23,7 @@ index 585a04fa..c1b48d09 100644
  	for key, value := range l.config.Config.Sysctl {
  		if err := writeSystemProperty(key, value); err != nil {
  			return err
-@@ -149,17 +145,21 @@ func (l *linuxStandardInit) Init() error {
+@@ -150,17 +146,21 @@ func (l *linuxStandardInit) Init() error {
  	if err != nil {
  		return fmt.Errorf("can't get pdeath signal: %w", err)
  	}
@@ -50,6 +50,5 @@ index 585a04fa..c1b48d09 100644
  	if err := selinux.SetExecLabel(l.config.ProcessLabel); err != nil {
  		return fmt.Errorf("can't set process label: %w", err)
  	}
--- 
-2.25.1
-
+--
+2.34.1

--- a/build-scripts/components/runc/version.sh
+++ b/build-scripts/components/runc/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.1.4"
+echo "v1.1.12"


### PR DESCRIPTION
### Summary

Backport https://github.com/canonical/microk8s/pull/4398 to 1.26-strict branch