### PR TITLE
[1.28-strict] do not produce static PIE runc executables on arm64

### DIFF
--- a/build-scripts/components/runc/build.sh
+++ b/build-scripts/components/runc/build.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+VERSION="${2}"
+
 export INSTALL="${1}/bin"
 mkdir -p "${INSTALL}"
+
+export COMMIT="$(git describe --always --long "${VERSION}")"
 
 make BUILDTAGS="seccomp apparmor" EXTRA_LDFLAGS="-s -w" static
 cp runc "${INSTALL}/runc"

--- a/build-scripts/components/runc/patches/0001-Disable-static-PIE-on-arm64.patch
+++ b/build-scripts/components/runc/patches/0001-Disable-static-PIE-on-arm64.patch
@@ -1,0 +1,25 @@
+From bcf130f097781d162c0461105a12f4c9f412d3e8 Mon Sep 17 00:00:00 2001
+From: Angelos Kolaitis <angelos.kolaitis@canonical.com>
+Date: Tue, 20 Feb 2024 12:32:27 +0200
+Subject: [PATCH] Disable static PIE on arm64
+
+Ubuntu does not currently have the rcrt1.o file on arm64
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index e3af9bc1..b2b07720 100644
+--- a/Makefile
++++ b/Makefile
+@@ -33,7 +33,7 @@ LDFLAGS_STATIC := -extldflags -static
+ # Enable static PIE executables on supported platforms.
+ # This (among the other things) requires libc support (rcrt1.o), which seems
+ # to be available only for arm64 and amd64 (Debian Bullseye).
+-ifneq (,$(filter $(GOARCH),arm64 amd64))
++ifneq (,$(filter $(GOARCH),amd64))
+ 	ifeq (,$(findstring -race,$(EXTRA_FLAGS)))
+ 		GO_BUILDMODE_STATIC := -buildmode=pie
+ 		LDFLAGS_STATIC := -linkmode external -extldflags --static-pie
+--
+2.34.1


### PR DESCRIPTION
Backport #4426 to 1.28-strict branch