### PR TITLE
the "--mem" long option is deprecated in favour of "--memory". Please…

### DIFF
--- a/installer/cli/microk8s.py
+++ b/installer/cli/microk8s.py
@@ -109,7 +109,7 @@ def _show_install_help():
     Options:
       --help     Show this message and exit.
       --cpu      Cores used by MicroK8s (default={definitions.DEFAULT_CORES}, min={definitions.MIN_CORES})
-      --mem      RAM in GB used by MicroK8s (default={definitions.DEFAULT_MEMORY_GB}, min={definitions.MIN_MEMORY_GB})
+      --memory   RAM in GB used by MicroK8s (default={definitions.DEFAULT_MEMORY_GB}, min={definitions.MIN_MEMORY_GB})
       --disk     Max volume in GB of the dynamically expandable hard disk to be used (default={definitions.DEFAULT_DISK_GB}, min={definitions.MIN_DISK_GB})
       --channel  Kubernetes version to install (default={definitions.DEFAULT_CHANNEL})
       --image    Ubuntu version to install (default={definitions.DEFAULT_IMAGE})


### PR DESCRIPTION
the "--mem" long option is deprecated in favour of "--memory". Please… update any scripts, etc.

<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
the "--mem" long option is deprecated in favour of "--memory". Please… update any scripts, etc.

#### Changes
change from --mem to --memory

#### Testing
N/A

#### Possible Regressions
No

#### Checklist


* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

#### Notes
N/A
