### PR TITLE
fix: don't error if pod has no containerStatuses (#4471)

### DIFF
--- a/scripts/kill-host-pods.py
+++ b/scripts/kill-host-pods.py
@@ -21,7 +21,7 @@ def post_filter_has_known_containers(pod, containers: list) -> bool:
     Return true if any of the container IDs on the pod match the list of
     containers passed on the second argument.
     """
-    for container in pod["status"]["containerStatuses"] or []:
+    for container in pod["status"].get("containerStatuses") or []:
         try:
             _, container_id = container["containerID"].split("containerd://", 2)
             if container_id in containers:


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

`kill-host-pods.py` iterates over all pods in all namespaces looking for pods that are running on the current node.  But if any pods in the iteration do not have `containerStatuses` in their pod status structure (e.g. if they're Pending waiting for a valid node to schedule to) then this currently causes the script to crash with a `KeyError`.  This PR changes the code to treat a missing `containerStatuses` the same as an empty one, so the pod is correctly skipped rather than the whole script crashing.

Closes #4471

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

- changed `pod["status"]["containerStatuses"]` (which raises an error if `containerStatuses` is missing) to `pod["status"].get("containerStatuses")` (which simply returns `None`).

#### Testing
<!-- Please explain how you tested your changes. -->

Tested locally with a copy of the script, I believe the change is trivial enough not to require automated tests beyond this.

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
