### PR TITLE
ignore missing info.yaml file when joining dqlite control plane node

### DIFF
--- a/scripts/wrappers/join.py
+++ b/scripts/wrappers/join.py
@@ -594,10 +594,13 @@ def update_dqlite(cluster_cert, cluster_key, voters, host):
 
     # We get the dqlite port from the already existing deployment
     port = 19001
-    with open("{}/info.yaml".format(cluster_backup_dir)) as f:
-        data = yaml.safe_load(f)
-    if "Address" in data:
-        port = data["Address"].rsplit(":")[-1]
+    try:
+        with open("{}/info.yaml".format(cluster_backup_dir)) as f:
+            data = yaml.safe_load(f)
+        if "Address" in data:
+            port = data["Address"].rsplit(":")[-1]
+    except OSError:
+        pass
 
     # If host is an IPv6 address, wrap it in square brackets
     try:


### PR DESCRIPTION
### Summary

When joining control plane nodes, do not fail if the `info.yaml` file of the existing dqlite cluster does not exist

Addresses the following error:

```
Traceback (most recent call last):
  File "/snap/microk8s/6738/scripts/wrappers/join.py", line 1015, in <module>
    join(prog_name="microk8s join")
  File "/snap/microk8s/6738/usr/lib/python3/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/snap/microk8s/6738/usr/lib/python3/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/snap/microk8s/6738/usr/lib/python3/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/snap/microk8s/6738/usr/lib/python3/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/snap/microk8s/6738/scripts/wrappers/join.py", line 1005, in join
    join_dqlite(connection_parts, verify, worker)
  File "/snap/microk8s/6738/scripts/wrappers/join.py", line 689, in join_dqlite
    join_dqlite_master_node(info, master_ip)
  File "/snap/microk8s/6738/scripts/wrappers/join.py", line 839, in join_dqlite_master_node
    update_dqlite(info["cluster_cert"], info["cluster_key"], info["voters"], hostname_override)
  File "/snap/microk8s/6738/scripts/wrappers/join.py", line 597, in update_dqlite
    with open("{}/info.yaml".format(cluster_backup_dir)) as f:
FileNotFoundError: [Errno 2] No such file or directory: '/var/snap/microk8s/6738/var/kubernetes/backend.backup/info.yaml'
```