### PR TITLE
Add systemd delegate config if cpuset is missing

### DIFF
--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -125,6 +125,17 @@ then
   fi
 fi
 
+if ! is_strict && (systemctl show snap.microk8s.daemon-kubelite.service -p NRestarts | grep -qv "NRestarts=0") && (grep -qv cpuset /sys/fs/cgroup/cgroup.subtree_control)
+then
+  mkdir -p /etc/systemd/system/snap.microk8s.daemon-kubelite.service.d
+  tee /etc/systemd/system/snap.microk8s.daemon-kubelite.service.d/delegate.conf > /dev/null <<EOF
+[Service]
+Delegate=yes
+EOF
+  systemctl daemon-reload
+  snap restart microk8s
+fi
+
 # wait for containerd socket
 if grep -e "--address " $SNAP_DATA/args/containerd &> /dev/null
 then

--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -135,8 +135,8 @@ then
 [Service]
 Delegate=yes
 EOF
-  systemctl daemon-reload
-  snap restart microk8s
+  systemctl daemon-reload || true
+  snap restart microk8s || true
 fi
 
 # wait for containerd socket

--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -125,7 +125,10 @@ then
   fi
 fi
 
-if ! is_strict && (systemctl show snap.microk8s.daemon-kubelite.service -p NRestarts | grep -qv "NRestarts=0") && (grep -qv cpuset /sys/fs/cgroup/cgroup.subtree_control)
+if ! is_strict &&
+   (systemctl show snap.microk8s.daemon-kubelite.service -p NRestarts | grep -qv "NRestarts=0") &&
+   (grep -qv cpuset /sys/fs/cgroup/cgroup.subtree_control) &&
+   [ ! -e /etc/systemd/system/snap.microk8s.daemon-kubelite.service.d/delegate.conf ]
 then
   mkdir -p /etc/systemd/system/snap.microk8s.daemon-kubelite.service.d
   tee /etc/systemd/system/snap.microk8s.daemon-kubelite.service.d/delegate.conf > /dev/null <<EOF

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -55,7 +55,6 @@ then
   sysctl --system
 
   rm -rf /etc/systemd/system/snap.microk8s.daemon-kubelite.service.d || true
-  systemctl daemon-reload
 fi
 
 # Clean the container location so we do not snapshot it.

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -53,6 +53,9 @@ then
   # remove custom sysctl parameters
   rm -f /etc/sysctl.d/10-microk8s.conf
   sysctl --system
+
+  rm -rf /etc/systemd/system/snap.microk8s.daemon-kubelite.service.d || true
+  systemctl daemon-reload
 fi
 
 # Clean the container location so we do not snapshot it.


### PR DESCRIPTION
Add delegate config if cpuset is missing, possible workaround for #4361
The issue is likely to be upstream dependency update on runc/libcontainers as 1.28 does not suffer from this.
An updated kernel(6.1+, tested with 6.5) also does not seem to suffer from this condition.