### PR TITLE
Changed add_token.py for issue #4526 

### DIFF
--- a/scripts/wrappers/add_token.py
+++ b/scripts/wrappers/add_token.py
@@ -120,10 +120,10 @@ def print_yaml(token, check):
 
 def print_short(token, check):
     default_ip, all_ips, port = get_network_info()
-
     print(f"microk8s join {default_ip}:{port}/{token}/{check}")
     for ip in all_ips:
-        print(f"microk8s join {ip}:{port}/{token}/{check}")
+        if ip != default_ip:
+            print(f"microk8s join {ip}:{port}/{token}/{check}")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_addtoken.py
+++ b/tests/unit/test_addtoken.py
@@ -1,0 +1,26 @@
+from unittest import mock
+from add_token import print_short
+
+
+def test_single(capsys):
+    with mock.patch(
+        "add_token.get_network_info", return_value=["10.23.53.54", ["10.23.53.54"], "32"]
+    ):
+        print_short("t", "c")
+        captured = capsys.readouterr()
+        output = captured.out.strip()
+        assert output == "microk8s join 10.23.53.54:32/t/c"
+
+
+def test_multiple(capsys):
+    with mock.patch(
+        "add_token.get_network_info", return_value=["d_ip", ["ip1", "ip2", "d_ip"], "4"]
+    ):
+        print_short("t", "c")
+        captured = capsys.readouterr()
+        all_outputs = captured.out.strip().split("\n")
+        assert all_outputs == [
+            "microk8s join d_ip:4/t/c",
+            "microk8s join ip1:4/t/c",
+            "microk8s join ip2:4/t/c",
+        ]


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   In scripts/wrappers/add.token.py, the function print_short was changed. instead of iterating through all_ips list, a set was created to store all the unique addresses, so that the information is not printed twice while iterating.

   The link to the issue - https://github.com/canonical/microk8s/issues/4526

   Closes #4526 
   References #4526 
-->

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
/microk8s/scripts/wrappers/add_token.py

#### Testing
<!-- Please explain how you tested your changes. -->
The change was tested with a unittest in tests/unit/test_addtoken.py
Tested using mock print assertion with builtins.print

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [Yes] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [Yes] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [Yes] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
