### PR TITLE
Stop running tests on the host -  1.30 strict

### DIFF
--- a/tests/libs/addons.sh
+++ b/tests/libs/addons.sh
@@ -6,15 +6,6 @@ function setup_addons_tests() {
   local PROXY=$3
   local TO_CHANNEL=$4
 
-  if [[ ${TO_CHANNEL} =~ /.*/microk8s.*snap ]]
-  then
-    snap install "${TO_CHANNEL}" --dangerous --classic
-  else
-    snap install microk8s --channel="${TO_CHANNEL}" --classic
-  fi
-
-  microk8s status --wait-ready
-
   create_machine "$NAME" "$DISTRO" "$PROXY"
   if [[ ${TO_CHANNEL} =~ /.*/microk8s.*snap ]]
   then
@@ -125,8 +116,5 @@ then
   if [ "x${DISABLE_COMMUNITY_TESTS}" != "x1" ]; then
     run_community_addons_tests "$NAME"
   fi
-  run_eksd_addons_tests
-  run_gpu_addon_test
-  run_microceph_addon_test
   post_addons_tests "$NAME"
 fi

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -43,10 +43,10 @@ set -uex
 
 setup_tests "$@"
 
-#DISABLE_AIRGAP_TESTS="${DISABLE_AIRGAP_TESTS:-0}"
-#if [ "x${DISABLE_AIRGAP_TESTS}" != "x1" ]; then
-#  . tests/libs/airgap.sh
-#fi
+DISABLE_AIRGAP_TESTS="${DISABLE_AIRGAP_TESTS:-0}"
+if [ "x${DISABLE_AIRGAP_TESTS}" != "x1" ]; then
+  . tests/libs/airgap.sh
+fi
 
 #. tests/libs/clustering.sh
 

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -43,12 +43,12 @@ set -uex
 
 setup_tests "$@"
 
-DISABLE_AIRGAP_TESTS="${DISABLE_AIRGAP_TESTS:-0}"
-if [ "x${DISABLE_AIRGAP_TESTS}" != "x1" ]; then
-  . tests/libs/airgap.sh
-fi
+#DISABLE_AIRGAP_TESTS="${DISABLE_AIRGAP_TESTS:-0}"
+#if [ "x${DISABLE_AIRGAP_TESTS}" != "x1" ]; then
+#  . tests/libs/airgap.sh
+#fi
 
-#. tests/libs/clustering.sh
+. tests/libs/clustering.sh
 
 #. tests/libs/addons-upgrade.sh
 

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -43,17 +43,15 @@ set -uex
 
 setup_tests "$@"
 
-#DISABLE_AIRGAP_TESTS="${DISABLE_AIRGAP_TESTS:-0}"
-#if [ "x${DISABLE_AIRGAP_TESTS}" != "x1" ]; then
-#  . tests/libs/airgap.sh
-#fi
+DISABLE_AIRGAP_TESTS="${DISABLE_AIRGAP_TESTS:-0}"
+if [ "x${DISABLE_AIRGAP_TESTS}" != "x1" ]; then
+  . tests/libs/airgap.sh
+fi
 
 . tests/libs/clustering.sh
 
-#. tests/libs/addons-upgrade.sh
+. tests/libs/addons-upgrade.sh
 
-#. tests/libs/upgrade-path.sh
+. tests/libs/upgrade-path.sh
 
-sudo lxc list
-snap list
 . tests/libs/addons.sh

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -54,4 +54,6 @@ fi
 
 #. tests/libs/upgrade-path.sh
 
+sudo lxc list
+snap list
 . tests/libs/addons.sh

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -43,15 +43,15 @@ set -uex
 
 setup_tests "$@"
 
-DISABLE_AIRGAP_TESTS="${DISABLE_AIRGAP_TESTS:-0}"
-if [ "x${DISABLE_AIRGAP_TESTS}" != "x1" ]; then
-  . tests/libs/airgap.sh
-fi
+#DISABLE_AIRGAP_TESTS="${DISABLE_AIRGAP_TESTS:-0}"
+#if [ "x${DISABLE_AIRGAP_TESTS}" != "x1" ]; then
+#  . tests/libs/airgap.sh
+#fi
 
-. tests/libs/clustering.sh
+#. tests/libs/clustering.sh
 
-. tests/libs/addons-upgrade.sh
+#. tests/libs/addons-upgrade.sh
 
-. tests/libs/upgrade-path.sh
+#. tests/libs/upgrade-path.sh
 
 . tests/libs/addons.sh


### PR DESCRIPTION
#### Summary
Do not test workloads on the host.

#### Changes
Remove the addon tests that run on the host on strict confinement.

#### Testing
Locally and in our CI

#### Possible Regressions
The most notable change is the test of micro-ceph

