### PR TITLE
Do not run addons tests on the host. Only on lxc containers.

### DIFF
--- a/tests/libs/addons.sh
+++ b/tests/libs/addons.sh
@@ -6,15 +6,6 @@ function setup_addons_tests() {
   local PROXY=$3
   local TO_CHANNEL=$4
 
-  if [[ ${TO_CHANNEL} =~ /.*/microk8s.*snap ]]
-  then
-    snap install "${TO_CHANNEL}" --dangerous --classic
-  else
-    snap install microk8s --channel="${TO_CHANNEL}" --classic
-  fi
-
-  microk8s status --wait-ready
-
   create_machine "$NAME" "$DISTRO" "$PROXY"
   if [[ ${TO_CHANNEL} =~ /.*/microk8s.*snap ]]
   then
@@ -125,8 +116,5 @@ then
   if [ "x${DISABLE_COMMUNITY_TESTS}" != "x1" ]; then
     run_community_addons_tests "$NAME"
   fi
-  run_eksd_addons_tests
-  run_gpu_addon_test
-  run_microceph_addon_test
   post_addons_tests "$NAME"
 fi


### PR DESCRIPTION
#### Summary
Running tests on the host and on lxc containers seems to have unforeseen side-effects. For now we disable testing on the host.

#### Changes
Remove the addon tests that run on the host on strict confinement.

#### Testing
Locally and in our CI

#### Possible Regressions
The most notable change is the test of micro-ceph

