### PR TITLE
Disable testing on debian and centos. Images missing.

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -198,33 +198,6 @@ jobs:
         run: |
           sudo -E bash -x -c "./tests/libs/airgap.sh --distro ubuntu:20.04 --channel $PWD/build/microk8s.snap"
 
-  test-spread:
-    name: Test microk8s on multi distros
-    runs-on: ubuntu-20.04
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        distro: ["images:centos/7", "images:debian/12"]
-    steps:
-      - name: Checking out repo
-        uses: actions/checkout@v4
-      - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
-        with:
-          name: microk8s.snap
-          path: build
-      - name: Initialize LXD
-        run: |
-          sudo apt install apparmor apparmor-utils -y
-          sudo lxd init --auto
-          sudo lxc network set lxdbr0 ipv6.address=none
-          sudo usermod --append --groups lxd $USER
-          sg lxd -c 'lxc version'
-      - name: Run spread tests
-        run: |
-          sudo -E bash -x -c "./tests/libs/spread.sh --distro ${{ matrix.distro }} --channel $PWD/build/microk8s.snap"
-
   security-scan:
     name: Security scan
     runs-on: ubuntu-20.04


### PR DESCRIPTION
The lxc images are missing for the spread tests.