### PR TITLE
Stop testing on the host as this causes problems on our CI

### DIFF
--- a/tests/libs/addons.sh
+++ b/tests/libs/addons.sh
@@ -6,15 +6,6 @@ function setup_addons_tests() {
   local PROXY=$3
   local TO_CHANNEL=$4
 
-  if [[ ${TO_CHANNEL} =~ /.*/microk8s.*snap ]]
-  then
-    snap install "${TO_CHANNEL}" --dangerous --classic
-  else
-    snap install microk8s --channel="${TO_CHANNEL}" --classic
-  fi
-
-  microk8s status --wait-ready
-
   create_machine "$NAME" "$DISTRO" "$PROXY"
   if [[ ${TO_CHANNEL} =~ /.*/microk8s.*snap ]]
   then
@@ -124,8 +115,5 @@ then
   if [ "x${DISABLE_COMMUNITY_TESTS}" != "x1" ]; then
     run_community_addons_tests "$NAME"
   fi
-  run_eksd_addons_tests
-  run_gpu_addon_test
-  run_microceph_addon_test
   post_addons_tests "$NAME"
 fi


### PR DESCRIPTION
#### Summary
This comes up on our AWS instances on ARM64. We also see this on strict deployments:
```
Setup snap "microceph" aliases                                             
error: cannot perform the following tasks:
[release-microk8s-arm64] - Run install hook of "microceph" snap if present (run hook "install": cannot create symbolic link "/tmp/snap.rootfs_YEesS5/bin": Permission denied)
```

Disabling the testing on the host.

