### PR TITLE
Fix the KUBE_TRACK version

### DIFF
--- a/build-scripts/components/kubernetes/version.sh
+++ b/build-scripts/components/kubernetes/version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-KUBE_TRACK="${KUBE_TRACK:1.30}"            # example: "1.24"
+KUBE_TRACK="${KUBE_TRACK:-1.30}"            # example: "1.24"
 KUBE_VERSION="${KUBE_VERSION:-}"        # example: "v1.24.2"
 
 if [ -z "${KUBE_VERSION}" ]; then


### PR DESCRIPTION
Typo fix in pinning the k8s version in the 1.30 track