### PR TITLE
[Backport 1.28-strict] Watcher query timeout

### DIFF
--- a/build-scripts/components/k8s-dqlite/build.sh
+++ b/build-scripts/components/k8s-dqlite/build.sh
@@ -3,10 +3,8 @@
 INSTALL="${1}/bin"
 mkdir -p "${INSTALL}"
 
-export CGO_LDFLAGS_ALLOW="-Wl,-z,now"
-export CGO_CFLAGS="-I${SNAPCRAFT_STAGE}/usr/include/"
-export CGO_LDFLAGS="-L${SNAPCRAFT_STAGE}/lib"
+make static -j
 
-go build -ldflags "-s -w" -tags libsqlite3,dqlite .
+cp bin/static/dqlite "${INSTALL}/dqlite"
+cp bin/static/k8s-dqlite "${INSTALL}/k8s-dqlite"
 
-cp k8s-dqlite "${INSTALL}/k8s-dqlite"

--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "watchers"
+echo "v1.1.11"

--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.1.7"
+echo "watchers"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,8 +21,8 @@ parts:
   build-deps:
     plugin: nil
     override-build: |
-      snap install go --classic --channel 1.20/stable
-      snap refresh go --channel 1.20/stable
+      snap install go --classic --channel 1.21/stable
+      snap refresh go --channel 1.21/stable
     build-packages:
       - autoconf
       - automake
@@ -47,40 +47,8 @@ parts:
       - rsync
       - tcl
 
-  raft:
-    after: [build-deps]
-    source: build-scripts/components/raft
-    build-attributes: [no-patchelf]
-    plugin: nil
-    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh raft
-    stage-packages:
-      - libuv1
-    stage:
-      - -usr/share/doc
-      - -usr/share/man
-
-  sqlite:
-    after: [build-deps]
-    source: build-scripts/components/sqlite
-    build-attributes: [no-patchelf]
-    plugin: nil
-    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh sqlite
-
-  dqlite:
-    after: [sqlite, raft]
-    source: build-scripts/components/dqlite
-    build-attributes: [no-patchelf]
-    plugin: nil
-    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh dqlite
-
-  dqlite-client:
-    after: [dqlite]
-    plugin: nil
-    source: build-scripts/components/dqlite-client
-    override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh dqlite-client
-
   k8s-dqlite:
-    after: [dqlite]
+    after: [build-deps]
     source: build-scripts/components/k8s-dqlite
     plugin: nil
     override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh k8s-dqlite
@@ -337,8 +305,6 @@ parts:
       - cluster-agent
       - cni
       - containerd
-      - dqlite
-      - dqlite-client
       - etcd
       - flannel-cni-plugin
       - flanneld
@@ -348,9 +314,7 @@ parts:
       - microk8s-addons
       - migrator
       - python-runtime
-      - raft
       - runc
-      - sqlite
     plugin: nil
     source: .
     build-packages:


### PR DESCRIPTION
## Description
Backports watcher query timeout in k8s-dqlite: https://github.com/canonical/k8s-dqlite/pull/161

The PR adds a timeout on long running after queries in k8s-dqlite which are part of the watcher's poll loop. 
The timeout is configurable using the `watch-query-timeout` flag.

## Context
This PR addresses issues raised in microk8s where after the leader node is removed from the cluster the remaining nodes also go into `NotReady` state for ~20 minutes. This timeout helps the responsiveness of the cluster after loosing its leader.
