### PR TITLE
[Backport 1.29-strict] Watch query timeout backport k8s-dqlite

### DIFF
--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.1.9"
+echo "v1.1.12"

--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.1.12"
+echo "v1.1.11"


### PR DESCRIPTION
## Description
Backports watcher query timeout in k8s-dqlite: https://github.com/canonical/k8s-dqlite/pull/161

The PR adds a timeout on long running after queries in k8s-dqlite which are part of the watcher's poll loop. 
The timeout is configurable using the `watch-query-timeout` flag.

## Context
This PR addresses issues raised in microk8s where after the leader node is removed from the cluster the remaining nodes also go into `NotReady` state for ~20 minutes. This timeout helps the responsiveness of the cluster after loosing its leader.
