### PR TITLE
[Backport 1.30] Watch query timeout k8s-dqlite backport

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -197,13 +197,11 @@ jobs:
           sudo -E bash -x -c "./tests/libs/airgap.sh --distro ubuntu:20.04 --channel $PWD/build/microk8s.snap"
 
   test-spread:
-    name: Test microk8s on multi distros
+    name: Test microk8s on debian
     runs-on: ubuntu-20.04
     needs: build
     strategy:
       fail-fast: false
-      matrix:
-        distro: ["images:centos/7", "images:debian/12"]
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4
@@ -221,7 +219,7 @@ jobs:
           sg lxd -c 'lxc version'
       - name: Run spread tests
         run: |
-          sudo -E bash -x -c "./tests/libs/spread.sh --distro ${{ matrix.distro }} --channel $PWD/build/microk8s.snap"
+          sudo -E bash -x -c "./tests/libs/spread.sh --distro images:debian/12 --channel $PWD/build/microk8s.snap"
 
   security-scan:
     name: Security scan

--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.1.9"
+echo "v1.1.12"

--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.1.12"
+echo "v1.1.11"


### PR DESCRIPTION
## Description
Backports watcher query timeout in k8s-dqlite: https://github.com/canonical/k8s-dqlite/pull/161

The PR adds a timeout on long running after queries in k8s-dqlite which are part of the watcher's poll loop. 
The timeout is configurable using the `watch-query-timeout` flag.

## Context
This PR addresses issues raised in microk8s where after the leader node is removed from the cluster the remaining nodes also go into `NotReady` state for ~20 minutes. This timeout helps the responsiveness of the cluster after loosing its leader.
