### PR TITLE
replace kill_all_container_shims with remove_all_containers even in classic

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -996,11 +996,6 @@ get_container_shim_pids() {
     $SNAP/bin/ps -e -o pid= -o args= | $SNAP/bin/grep -v 'grep' | $SNAP/bin/sed -e 's/^ *//; s/\s\s*/\t/;' | $SNAP/bin/grep -w '/snap/microk8s/.*/bin/containerd-shim' | $SNAP/usr/bin/cut -f1
 }
 
-kill_all_container_shims() {
-  run_with_sudo systemctl kill snap.microk8s.daemon-kubelite.service --signal=SIGKILL &>/dev/null || true
-  run_with_sudo systemctl kill snap.microk8s.daemon-containerd.service --signal=SIGKILL &>/dev/null || true
-}
-
 is_first_boot() {
   # Return 0 if this is the first start after the host booted.
   # The argument $1 is a directory that may contain a last-start-date file

--- a/microk8s-resources/default-hooks/remove.d/90-containers
+++ b/microk8s-resources/default-hooks/remove.d/90-containers
@@ -2,9 +2,4 @@
 
 . "${SNAP}/actions/common/utils.sh"
 
-if is_strict
-then
-  remove_all_containers
-else
-  kill_all_container_shims
-fi
+remove_all_containers

--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -65,15 +65,8 @@ do
         echo "cert change detected. Reconfiguring the kube-apiserver"
         rm -rf .srl
         snapctl stop microk8s.daemon-kubelite
-        if is_strict
-        then
-          remove_all_containers
-          snapctl restart microk8s.daemon-containerd
-        else
-          snapctl stop microk8s.daemon-containerd
-          kill_all_container_shims
-          snapctl start microk8s.daemon-containerd
-        fi
+        remove_all_containers
+        snapctl restart microk8s.daemon-containerd
         snapctl start microk8s.daemon-kubelite
         start_all_containers
         restart_attempt=$[$restart_attempt+1]

--- a/microk8s-resources/wrappers/microk8s-stop.wrapper
+++ b/microk8s-resources/wrappers/microk8s-stop.wrapper
@@ -40,13 +40,13 @@ while true; do
     esac
 done
 
-stopcmd="run_with_sudo snap stop ${SNAP_NAME} --disable"
+prefix_cmd="run_with_sudo snap"
 if is_strict
 then
-  stopcmd="snapctl stop microk8s.daemon-kubelite --disable"
+  prefix_cmd="snapctl"
 fi
 
-$stopcmd
+$prefix_cmd stop microk8s.daemon-kubelite --disable
 stop_status=$?
 
 if ! [ $stop_status -eq 0 ]
@@ -54,12 +54,7 @@ then
     echo 'Failed to stop microk8s services. Check snapd logs with "journalctl -u snapd.service"'
     exit 1
 else
-    if is_strict
-    then
-      remove_all_containers
-      snapctl stop microk8s --disable
-    else
-      kill_all_container_shims
-    fi
+    remove_all_containers
+    $prefix_cmd stop microk8s --disable
     run_with_sudo touch ${SNAP_DATA}/var/lock/stopped.lock
 fi


### PR DESCRIPTION
#### Summary

1. We've seen issues with containers not being stopped on microk8s stop commands. See https://github.com/canonical/microk8s/issues/3969
2. We've mostly discovered this issue with snap refresh of microk8s, the problem is also probably causing https://github.com/canonical/microk8s/issues/4691

Current behaviour is very dangerous : we've seen data corruption and file locks issues after microk8s upgrades because containers processes become duplicated. (Processes before upgrade are still present, and upgraded microk8s starts new containers writing on the same resources).

#### Changes
- We replace `kill_all_container_shims` with `remove_all_containers`, regardless of `classic` or `strict` confinement

#### Testing
- I ran the `microk8s stop` command patched and asserted that no containers were present anymore.

Before : 

```
microk8s stop
sleep 60s
# list orphaned processes
for cgroup_tasks in `find /sys/fs/cgroup/pids/kubepods/ -name tasks`; do head -n 1 "$cgroup_tasks"; done | xargs ps
    PID TTY      STAT   TIME COMMAND
  42522 ?        Ss     0:00 /pause
  44183 ?        Ss     0:00 /pause
  44307 ?        Ss     0:00 /pause
  44868 ?        Ss     0:00 /pause
  44870 ?        Ss     0:00 /usr/local/bin/runsvdir -P /etc/service/enabled
  44913 ?        Ss     0:00 /opt/bitnami/postgresql/bin/postgres -D /bitnami/postgresql/data --config-file=/opt/bitnami/postgresql/conf/postgresql.conf --external_pid_file=/opt/bitnami/postgresql/tmp/postgresql.pid --hba_file=/opt
  45138 ?        Ss     0:00 /pause
  45317 ?        Ss     0:00 /pause
...
```

After : 

```
microk8s stop
Stopped.
Stopped.
for cgroup_tasks in `find /sys/fs/cgroup/pids/kubepods/ -name tasks`; do head -n 1 "$cgroup_tasks"; done | xargs ps
    PID TTY          TIME CMD
   1048 pts/0    00:00:00 bash
  23334 pts/0    00:00:00 xargs
  23373 pts/0    00:00:00 ps
```
#### Possible Regressions


#### Checklist
* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
- It is expected that stopping containerd does not stop containers, see https://github.com/containerd/containerd/issues/7076
