### PR TITLE
microk8s inspect incorrectly logs the 'ip addr' and 'ip route' system commands.

### DIFF
--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -77,7 +77,7 @@ function store_network {
   printf -- '  Copy network configuration to the final report tarball\n'
   mkdir -p $INSPECT_DUMP/network
   ip addr &> $INSPECT_DUMP/network/ip-addr
-  ip route &> $INSPECT_DUMP/network/ip-addr
+  ip route &> $INSPECT_DUMP/network/ip-route
   iptables -t nat -L -n -v &> $INSPECT_DUMP/network/iptables
   iptables -S &> $INSPECT_DUMP/network/iptables-S
   iptables -L &> $INSPECT_DUMP/network/iptables-L


### PR DESCRIPTION
In the inspect report, the commands 'ip addr' and 'ip route' were both being written to the file 'ip-addr' file. 

The 'ip route' command was run second so the result was 
* misleading output in the ip-addr file actually being from 'ip-route'
* missing the output from 'ip-addr'."

#### Summary
'ip addr' command will generate the 'ip-addr' file for output **Corrected**
'ip route' command will generate the 'ip-route' file **New**

#### Changes
One liner, redirect the output of 'ip route' to 'ip-route' file.

#### Testing
no testing, seemed very straight forward.

#### Possible Regressions
Anyone programmatically running a microk8s inspect report on failure and parsing the output of this file would need to change their system to use the "ip-route" file.

#### Checklist

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
n/a