### PR TITLE
fix: ensure nf_conntrack module loaded for kubelite.

### DIFF
--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -204,6 +204,19 @@ then
   fi
 fi
 
+# kube-proxy reads some values related to the 'nf_conntrack' kernel
+# module from procfs on startup, so we must ensure it is loaded:
+if ! [ -f /proc/sys/net/netfilter/nf_conntrack_max ]
+then
+  if /sbin/modprobe nf_conntrack || modprobe nf_conntrack
+  then
+    echo "Successfully loaded nf_conntrack module."
+  else
+    echo -n "Failed to load nf_conntrack kernel module. "
+    echo "ProxyServer will fail to start until it's loaded."
+  fi
+fi
+
 # on lxc containers do not try to change the conntrack configuration
 # see https://github.com/canonical/microk8s/issues/1438
 if grep -E lxc /proc/1/environ &&


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

This patch ensures that the `nf_conntrack` kernel module is loaded before `kubelite` is started as the ProxyServer needs to read some conntrack module-related params from procfs.

Closes #4462 

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

By explicitly loading `nf_conntrack` before starting `kubelite`, it should ensure the procfs values that the ProxyServer reads are always present on startup.

Previously, although the it would always crashed if the module wasn't loaded, this wasn't that common of an occurrence in practice as there are quite a few ways `nf_conntrack` gets loaded transparently:
* Cilium [automatically loads `iptable_nat`](https://github.com/cilium/cilium/blob/63cd391f93b4e2c865268241d384504348672042/pkg/datapath/iptables/iptables.go#L367-L368) after a small startup delay, whose dependency tree includes `nf_conntrack`
* starting firewalld/ufw/most other firewall services
* setting iptables/nftables rules which imply session tracking

#### Testing
<!-- Please explain how you tested your changes. -->

I've written a [trivial eBPF probe](https://gist.github.com/aznashwan/32b8b00f0378e341ea29f80d0a4eca44) to monitor whenever a process loads a kernel module, and validated that:
1) after freshly booting the system (22.04 and 24.04 VMs on Proxmox KVM FWIW), nothing had/was automatically loading the `nf_conntrack` module
2) after installing the updated microk8s snap, the `run-kubelite-with-args` script would load it itself
3) there were no errors/warnings related to values exposed by the conntack module in the kubelite logs
4) ensured a simple test `Deployment` worked as expected

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

Only the minute risk that the `nf_conntrack` module (which is *very* widely distributed and used) might not be installed on the host system.

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [X] The introduced changes are covered by unit and/or integration tests. ***

*** it's technically implicitly covered since the LXD profile used for integration tests includes `nf_nat`, which depends on `nf_conntrack` and thus cause it to be loaded, but there is no "negative test" where we intentionally deny its loading.