### PR TITLE
Prioritize SNAP_CURRENT in containerd paths

### DIFF
--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -26,7 +26,7 @@ fi
 # containerd-shims need to look for runc in  /snap/microk8s/current/usr/bin/runc
 SNAP_CURRENT=`echo "${SNAP}" | sed -e "s,${SNAP_REVISION},current,"`
 CURRENT_PATH="$SNAP_CURRENT/usr/sbin:$SNAP_CURRENT/usr/bin:$SNAP_CURRENT/sbin:$SNAP_CURRENT/bin"
-export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$CURRENT_PATH:$PATH"
+export PATH="$CURRENT_PATH:$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 
 if is_strict
 then


### PR DESCRIPTION
The wrong priority in path leads to issues with containerd-shim binary trying to be called from a previous revision that is not installed anymore. Prioritizing $SNAP_CURRENT paths makes sure this path always exists and points to the latest binary.

Fixes #4691 