### PR TITLE
[Backport 1.28-strict] Prioritize SNAP_CURRENT in containerd paths (#4710)

### DIFF
--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -23,7 +23,7 @@ fi
 # containerd-shims need to look for runc in  /snap/microk8s/current/usr/bin/runc
 SNAP_CURRENT=`echo "${SNAP}" | sed -e "s,${SNAP_REVISION},current,"`
 CURRENT_PATH="$SNAP_CURRENT/usr/sbin:$SNAP_CURRENT/usr/bin:$SNAP_CURRENT/sbin:$SNAP_CURRENT/bin"
-export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$CURRENT_PATH:$PATH"
+export PATH="$CURRENT_PATH:$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 ARCH="$($SNAP/bin/uname -m)"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH


### PR DESCRIPTION
Backports #4710