### PR TITLE
[Backport 1.30-strict] fix: ensure nf_conntrack module loaded for kubelite.

### DIFF
--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -204,6 +204,19 @@ then
   fi
 fi
 
+# kube-proxy reads some values related to the 'nf_conntrack' kernel
+# module from procfs on startup, so we must ensure it is loaded:
+if ! [ -f /proc/sys/net/netfilter/nf_conntrack_max ]
+then
+  if /sbin/modprobe nf_conntrack || modprobe nf_conntrack
+  then
+    echo "Successfully loaded nf_conntrack module."
+  else
+    echo -n "Failed to load nf_conntrack kernel module. "
+    echo "ProxyServer will fail to start until it's loaded."
+  fi
+fi
+
 # on lxc containers do not try to change the conntrack configuration
 # see https://github.com/canonical/microk8s/issues/1438
 if grep -E lxc /proc/1/environ &&


### PR DESCRIPTION
This patch ensures that the `nf_conntrack` kernel module is loaded before `kubelite` is started as the ProxyServer needs to read some conntrack module-related params from procfs.

Previously, although the it would always crashed if the module wasn't loaded, this wasn't that common of an occurrence in practice as there are quite a few ways `nf_conntrack` gets loaded transparently:
* Cilium [automatically loads `iptable_nat`](https://github.com/cilium/cilium/blob/63cd391f93b4e2c865268241d384504348672042/pkg/datapath/iptables/iptables.go#L367-L368) after a small startup delay, whose dependency tree includes `nf_conntrack`
* starting firewalld/ufw/most other firewall services
* setting iptables/nftables rules which imply session tracking

By explicitly loading `nf_conntrack` before starting `kubelite`, it should ensure the procfs values ther ProxyServer reads are always present on startup.

<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

#### Testing
<!-- Please explain how you tested your changes. -->

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [ ] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
