### PR TITLE
Inspect ip route fix

### DIFF
--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -77,7 +77,7 @@ function store_network {
   printf -- '  Copy network configuration to the final report tarball\n'
   mkdir -p $INSPECT_DUMP/network
   ip addr &> $INSPECT_DUMP/network/ip-addr
-  ip route &> $INSPECT_DUMP/network/ip-addr
+  ip route &> $INSPECT_DUMP/network/ip-route
   iptables -t nat -L -n -v &> $INSPECT_DUMP/network/iptables
   iptables -S &> $INSPECT_DUMP/network/iptables-S
   iptables -L &> $INSPECT_DUMP/network/iptables-L


### PR DESCRIPTION

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.
-->
Fixes typo in the output of the `ip route` command when running `microk8s inspect`
Inspired by canonical/microk8s/pull/4694

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
fix in `scripts/inspect.sh`
#### Testing
<!-- Please explain how you tested your changes. -->
manual test
#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->
no
#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
