### PR TITLE
K8s-dqlite v1.3.0 (Dqlite LTS)

### DIFF
--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.2.0"
+echo "v1.3.0"


### PR DESCRIPTION
## K8s-dqlite v1.3.0 (Dqlite LTS)
This PR updates the k8s-dqlite version from `v1.2.0` to `v1.3.0`.
Release notes: https://github.com/canonical/k8s-dqlite/releases/tag/v1.3.0