### PR TITLE
Bump go version to 1.23

### DIFF
--- a/build-scripts/components/etcd/version.sh
+++ b/build-scripts/components/etcd/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v3.5.5"
+echo "v3.5.17"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,7 @@ parts:
   build-deps:
     plugin: nil
     build-snaps:
-      - go/1.21/stable
+      - go/1.23/stable
     build-packages:
       - autoconf
       - automake


### PR DESCRIPTION
Bumps go version to 1.23 to accommodate 1.32 release
Bumps etcd patch version to `3.5.17` to build with 1.23