### PR TITLE
Add psutil to pip install directives

### DIFF
--- a/tests/libs/utils.sh
+++ b/tests/libs/utils.sh
@@ -41,7 +41,7 @@ function setup_tests() {
 
   export DEBIAN_FRONTEND=noninteractive
   apt-get install python3-pip -y
-  pip3 install -U pytest requests pyyaml sh
+  pip3 install -U pytest requests pyyaml sh psutil
   apt-get install jq -y
   snap install kubectl --classic
   export ARCH=$(uname -m)

--- a/tests/lxc/install-deps/images_almalinux-8
+++ b/tests/lxc/install-deps/images_almalinux-8
@@ -9,7 +9,7 @@ systemctl enable --now snapd.socket
 ln -s /var/lib/snapd/snap /snap
 yum install python3-pip  -y
 yum install docker -y
-pip3 install pytest requests pyyaml sh
+pip3 install pytest requests pyyaml sh psutil
 
 # wait for the snapd seeding to take place!
 n=0

--- a/tests/lxc/install-deps/images_centos-7
+++ b/tests/lxc/install-deps/images_centos-7
@@ -7,7 +7,7 @@ systemctl enable --now snapd.socket
 ln -s /var/lib/snapd/snap /snap
 yum install python3-pip  -y
 yum install docker -y
-pip3 install pytest requests pyyaml sh
+pip3 install pytest requests pyyaml sh psutil
 
 # wait for the snapd seeding to take place!
 n=0

--- a/tests/lxc/install-deps/images_centos-8-Stream
+++ b/tests/lxc/install-deps/images_centos-8-Stream
@@ -9,7 +9,7 @@ systemctl enable --now snapd.socket
 ln -s /var/lib/snapd/snap /snap
 yum install python3-pip  -y
 yum install docker -y
-pip3 install pytest requests pyyaml sh
+pip3 install pytest requests pyyaml sh psutil
 
 # wait for the snapd seeding to take place!
 n=0

--- a/tests/lxc/install-deps/images_debian-10
+++ b/tests/lxc/install-deps/images_debian-10
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io libsquashfuse0 squashfuse fuse snapd -y
-pip3 install pytest requests pyyaml sh
+pip3 install pytest requests pyyaml sh psutil
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
 

--- a/tests/lxc/install-deps/images_debian-11
+++ b/tests/lxc/install-deps/images_debian-11
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io libsquashfuse0 squashfuse fuse snapd -y
-pip3 install pytest requests pyyaml sh
+pip3 install pytest requests pyyaml sh psutil
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
 

--- a/tests/lxc/install-deps/images_debian-12
+++ b/tests/lxc/install-deps/images_debian-12
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io libsquashfuse0 squashfuse fuse snapd -y
-pip3 install pytest requests pyyaml sh --break-system-packages
+pip3 install pytest requests pyyaml sh psutil --break-system-packages
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
 

--- a/tests/lxc/install-deps/images_fedora-37
+++ b/tests/lxc/install-deps/images_fedora-37
@@ -8,7 +8,7 @@ systemctl enable --now snapd.socket
 ln -s /var/lib/snapd/snap /snap
 yum install python3-pip  -y
 yum install docker -y
-pip3 install pytest requests pyyaml sh
+pip3 install pytest requests pyyaml sh psutil
 
 # wait for the snapd seeding to take place!
 n=0

--- a/tests/lxc/install-deps/images_fedora-38
+++ b/tests/lxc/install-deps/images_fedora-38
@@ -8,7 +8,7 @@ systemctl enable --now snapd.socket
 ln -s /var/lib/snapd/snap /snap
 yum install python3-pip  -y
 yum install docker -y
-pip3 install pytest requests pyyaml sh
+pip3 install pytest requests pyyaml sh psutil
 
 # wait for the snapd seeding to take place!
 n=0

--- a/tests/lxc/install-deps/images_rockylinux-8
+++ b/tests/lxc/install-deps/images_rockylinux-8
@@ -9,7 +9,7 @@ systemctl enable --now snapd.socket
 ln -s /var/lib/snapd/snap /snap
 yum install python3-pip  -y
 yum install docker -y
-pip3 install pytest requests pyyaml sh
+pip3 install pytest requests pyyaml sh psutil
 
 # wait for the snapd seeding to take place!
 n=0

--- a/tests/lxc/install-deps/ubuntu_18.04
+++ b/tests/lxc/install-deps/ubuntu_18.04
@@ -6,7 +6,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install python3-pip docker.io -y
 # In Ubuntu 18.04 for arm64 on LXC, "pip3 install -U pyyaml" breaks netplan
-pip3 install pytest requests pyyaml sh
+pip3 install pytest requests pyyaml sh psutil
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
 snap install core20 | true

--- a/tests/lxc/install-deps/ubuntu_20.04
+++ b/tests/lxc/install-deps/ubuntu_20.04
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y
-pip3 install pytest requests pyyaml sh
+pip3 install pytest requests pyyaml sh psutil
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
 snap install core20 | true

--- a/tests/lxc/install-deps/ubuntu_22.04
+++ b/tests/lxc/install-deps/ubuntu_22.04
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y
-pip3 install pytest requests pyyaml sh
+pip3 install pytest requests pyyaml sh psutil
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
 snap install core20 | true


### PR DESCRIPTION
Follow up on #4755 to add psutil to testing scripts as well

We've received errors on psutil not being available by default