### PR TITLE
kill-host-pods.py: filter pods by node

### DIFF
--- a/microk8s-resources/default-hooks/reconcile.d/10-pods-restart
+++ b/microk8s-resources/default-hooks/reconcile.d/10-pods-restart
@@ -4,7 +4,9 @@
 
 if ! [ -e "${SNAP_DATA}/var/lock/no-cni-reload" ] &&
   [ -e "${SNAP_DATA}/var/lock/snapdata-mounts-need-reload" ]; then
-  if (is_apiserver_ready) && "${SNAP}/scripts/kill-host-pods.py" --with-snap-data-mounts --with-owner -- -A; then
+  if (is_apiserver_ready) && "${SNAP}/scripts/kill-host-pods.py" \
+      --with-snap-data-mounts --with-owner \
+      -- -A --field-selector spec.nodeName=$(hostname) ; then
     rm "${SNAP_DATA}/var/lock/snapdata-mounts-need-reload"
   fi
 fi


### PR DESCRIPTION
Starting with k8s 1.32, AuthorizeNodeWithSelectors is enabled by default: https://kubernetes.io/docs/reference/access-authn-authz/node/

If the rbac microk8s addon is enabled, the kube-apiserver will run with "--authorization-mode=RBAC,Node". This means that kublets (system:node:$node) will no longer be allowed to access pods that reside on other nodes.

For this reason, the "kill-host-pods.py" script is now getting access denied errors:

```
  Error from server (Forbidden): pods is forbidden:
  User "system:node:myhostname" cannot list resource "pods" in API group ""
  at the cluster scope: can only list/watch pods with spec.nodeName field selector
```

As suggested by the error message, we'll solve it by filtering pods by the node name.

Fixes: https://github.com/canonical/microk8s/issues/4802

<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

#### Testing
<!-- Please explain how you tested your changes. -->

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [ ] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
