### PR TITLE
scripts: Fix kill-host-pods script (#4835)

### DIFF
--- a/scripts/kill-host-pods.py
+++ b/scripts/kill-host-pods.py
@@ -41,7 +41,7 @@ def post_filter_has_snap_data_mounts(pod) -> bool:
         hostpath_volume = volume.get("hostPath", {})
         host_path = hostpath_volume.get("path", "")
         if not host_path:
-            return False
+            continue
         if host_path.startswith(SNAP_DATA_CURRENT):
             return True
 

--- a/scripts/kill-host-pods.py
+++ b/scripts/kill-host-pods.py
@@ -41,7 +41,7 @@ def post_filter_has_snap_data_mounts(pod) -> bool:
         hostpath_volume = volume.get("hostPath", {})
         host_path = hostpath_volume.get("path", "")
         if not host_path:
-            continue
+            return False
         if host_path.startswith(SNAP_DATA_CURRENT):
             return True
 


### PR DESCRIPTION
### Overview
This PR fixes the `kill-host-pods.py` script. Currently the `--with-snap-data-mounts` filter does not work correctly as it returns `False` too early.