### PR TITLE
k8s-dqlite v1.4.0

### DIFF
--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.3.0"
+echo "v1.4.0"


### PR DESCRIPTION
## K8s-dqlite v1.4.0
This PR bumps the k8s-dqlite version. See the [release notes](https://github.com/canonical/k8s-dqlite/releases/tag/v1.4.0) for further details on the changes.