### PR TITLE
snapcraft.yaml: upgrade to libmnl-1.0.5

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -97,7 +97,7 @@ parts:
   libmnl:
     after: [build-deps]
     plugin: autotools
-    source: https://www.netfilter.org/pub/libmnl/libmnl-1.0.4.tar.bz2
+    source: https://www.netfilter.org/pub/libmnl/libmnl-1.0.5.tar.bz2
     prime:
       - -usr/local/include
 


### PR DESCRIPTION
The config.guess script in libmnl-1.0.4 is too old to recognize the riscv64 architecture.

Besides the build system the differences between both version are mostly cosmetic, like adding a const qualifier to a  function parameter.