### PR TITLE
Auto-update images branch 1.32

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Create installer
         run: makensis.exe ${{ github.workspace }}/installer/windows/microk8s.nsi
       - name: Upload installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Windows installer
           path: ${{ github.workspace }}/installer/windows/microk8s-installer.exe

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -30,7 +30,7 @@ jobs:
           sg lxd -c 'snapcraft --use-lxd'
           sudo mv microk8s*.snap microk8s.snap
       - name: Uploading snap
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: microk8s.snap
           path: microk8s.snap
@@ -52,7 +52,7 @@ jobs:
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -77,7 +77,7 @@ jobs:
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -107,7 +107,7 @@ jobs:
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -140,7 +140,7 @@ jobs:
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -165,7 +165,7 @@ jobs:
           sudo pip3 install --upgrade pip
           sudo pip3 install -U pytest sh requests
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -184,7 +184,7 @@ jobs:
       - name: Checking out repo
         uses: actions/checkout@v4
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -206,7 +206,7 @@ jobs:
       - name: Checking out repo
         uses: actions/checkout@v4
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build

--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -18,12 +18,14 @@ jobs:
           # Latest branches
           - { branch: master, channel: latest/edge }
           # Stable branches
+          - { branch: "1.32", channel: "1.32" }
           - { branch: "1.31", channel: "1.31" }
           - { branch: "1.30", channel: "1.30" }
           - { branch: "1.29", channel: "1.29" }
           - { branch: "1.28", channel: "1.28" }
           - { branch: "1.27", channel: "1.27" }
           # Stable strict branches
+          - { branch: 1.32-strict, channel: 1.32-strict }
           - { branch: 1.31-strict, channel: 1.31-strict }
           - { branch: 1.30-strict, channel: 1.30-strict }
           - { branch: 1.29-strict, channel: 1.29-strict }


### PR DESCRIPTION
## Auto-update images branch 1.32

This PR adds 1.32 to the list of branches who's images are checked for updates by CI.