### PR TITLE
bug: fix memory leak k8s-dqlite

### DIFF
--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.4.0"
+echo "fix-mem-leak"


### PR DESCRIPTION
## Description
We've detected a leak in the watch poll loop.
See https://github.com/canonical/k8s-dqlite/pull/240

TODO: update k8s-dqlite branch to tag.