### PR TITLE
Backport: [1.31-strict] memory leak fix k8s-dqlite v1.2.1 (#4866)

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Create installer
         run: makensis.exe ${{ github.workspace }}/installer/windows/microk8s.nsi
       - name: Upload installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Windows installer
           path: ${{ github.workspace }}/installer/windows/microk8s-installer.exe

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -28,7 +28,7 @@ jobs:
           sg lxd -c 'snapcraft --use-lxd'
           sudo mv microk8s*.snap microk8s.snap
       - name: Uploading snap
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: microk8s.snap
           path: microk8s.snap
@@ -50,7 +50,7 @@ jobs:
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -75,7 +75,7 @@ jobs:
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -107,12 +107,12 @@ jobs:
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
       # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
+      #   uses: mxschmitt/action-tmate@v4
       - name: Running addons tests
         run: |
           set -x
@@ -133,7 +133,7 @@ jobs:
       - name: Checking out repo
         uses: actions/checkout@v4
       # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
+      #   uses: mxschmitt/action-tmate@v4
       - name: Install test dependencies
         run: |
           set -x
@@ -143,7 +143,7 @@ jobs:
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -169,7 +169,7 @@ jobs:
           sudo pip3 install --upgrade pip
           sudo pip3 install -U pytest sh requests
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -189,7 +189,7 @@ jobs:
       - name: Checking out repo
         uses: actions/checkout@v4
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -211,39 +211,30 @@ jobs:
       - name: Checking out repo
         uses: actions/checkout@v4
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
-      - name: Setup Trivy vulnerability scanner
+      - name: Create sarifs directory
         run: |
           mkdir -p sarifs
-          VER=$(curl --silent -qI https://github.com/aquasecurity/trivy/releases/latest | awk -F '/' '/^location/ {print  substr($NF, 1, length($NF)-1)}');
-          wget https://github.com/aquasecurity/trivy/releases/download/${VER}/trivy_${VER#v}_Linux-64bit.tar.gz
-          tar -zxvf ./trivy_${VER#v}_Linux-64bit.tar.gz
-      - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: "fs"
-          ignore-unfixed: true
-          format: "sarif"
-          output: "trivy-microk8s-repo-scan--results.sarif"
-          severity: "CRITICAL"
-      - name: Gather Trivy repo scan results
+      - name: Install Trivy vulnerability scanner
+        uses: aquasecurity/setup-trivy@v0.2.2
+      - name: Run Trivy vulnerability scanner on codebase
         run: |
-          cp trivy-microk8s-repo-scan--results.sarif ./sarifs/
+          trivy fs . --format sarif --severity CRITICAL > sarifs/trivy-microk8s-repo-scan--results.sarif
       - name: Run Trivy vulnerability scanner on images
         run: |
           for i in $(cat ./build-scripts/images.txt) ; do
             name=$(echo  $i | awk -F ':|/' '{print $(NF-1)}')
-            ./trivy image $i --format sarif > sarifs/$name.sarif
+            trivy image $i --format sarif > sarifs/$name.sarif
           done
       - name: Run Trivy vulnerability scanner on the snap
         run: |
           cp build/microk8s.snap .
           unsquashfs microk8s.snap
-          ./trivy rootfs ./squashfs-root/ --format sarif > sarifs/snap.sarif
+          trivy rootfs ./squashfs-root/ --format sarif > sarifs/snap.sarif
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "sarifs"

--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.2.0"
+echo "v1.2.1"


### PR DESCRIPTION
## Description 
* bug: [backport v1.2] memory leak fix k8s-dqlite PR: https://github.com/canonical/k8s-dqlite/pull/240
* CI: bump artifact in gh actions
* CI: Trivy job fix
