### PR TITLE
install snapd in setup for test-distro

### DIFF
--- a/tests/libs/utils.sh
+++ b/tests/libs/utils.sh
@@ -40,6 +40,7 @@ function setup_tests() {
   PROXY="${4-$PROXY}"
 
   export DEBIAN_FRONTEND=noninteractive
+  snap install snapd
   apt-get install python3-pip -y
   pip3 install -U pytest requests pyyaml sh psutil
   apt-get install jq -y


### PR DESCRIPTION
## Description

Jammy seems to have an issue installing core20:
```
Ensure prerequisites for "microk8s" are available                              -
error: cannot perform the following tasks:
[release-microk8s-arm64] - Ensure prerequisites for "microk8s" are available (cannot install snap base "core20": snap "core20" assumes unsupported features: snapd2.61 (try to refresh snapd))
```
Install snapd during set-up as a fix.