### PR TITLE
[Backport 1.32] CI: Pins pytest to 8.3.4 for Test core addons (#4923)

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -73,7 +73,7 @@ jobs:
           set -x
           sudo apt-get install python3-setuptools
           sudo pip3 install --upgrade pip
-          sudo pip3 install -U pytest sh psutil
+          sudo pip3 install -U pytest==8.3.4 sh psutil
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
       - name: Fetch snap

--- a/tests/lxc/install-deps/images_almalinux-8
+++ b/tests/lxc/install-deps/images_almalinux-8
@@ -7,9 +7,9 @@ yum install fuse squashfuse -y
 yum install snapd -y
 systemctl enable --now snapd.socket
 ln -s /var/lib/snapd/snap /snap
-yum install python3-pip  -y
+yum install python3-pip -y
 yum install docker -y
-pip3 install pytest requests pyyaml sh psutil
+pip3 install pytest==8.3.4 requests pyyaml sh psutil
 
 # wait for the snapd seeding to take place!
 n=0

--- a/tests/lxc/install-deps/images_archlinux
+++ b/tests/lxc/install-deps/images_archlinux
@@ -20,7 +20,7 @@ pacman -S --noconfirm python
 pacman -S --noconfirm docker
 sudo systemctl enable --now docker.service
 echo "127.0.0.1       localhost" | sudo tee -a /etc/hosts
-pip3 install pytest requests pyyaml
+pip3 install pytest==8.3.4 requests pyyaml
 
 # wait for the snapd seeding to take place!
 n=0

--- a/tests/lxc/install-deps/images_centos-7
+++ b/tests/lxc/install-deps/images_centos-7
@@ -5,9 +5,9 @@ yum install sudo -y
 yum install snapd -y
 systemctl enable --now snapd.socket
 ln -s /var/lib/snapd/snap /snap
-yum install python3-pip  -y
+yum install python3-pip -y
 yum install docker -y
-pip3 install pytest requests pyyaml sh psutil
+pip3 install pytest==8.3.4 requests pyyaml sh psutil
 
 # wait for the snapd seeding to take place!
 n=0

--- a/tests/lxc/install-deps/images_centos-8-Stream
+++ b/tests/lxc/install-deps/images_centos-8-Stream
@@ -7,9 +7,9 @@ yum install fuse squashfuse -y
 yum install snapd -y
 systemctl enable --now snapd.socket
 ln -s /var/lib/snapd/snap /snap
-yum install python3-pip  -y
+yum install python3-pip -y
 yum install docker -y
-pip3 install pytest requests pyyaml sh psutil
+pip3 install pytest==8.3.4 requests pyyaml sh psutil
 
 # wait for the snapd seeding to take place!
 n=0

--- a/tests/lxc/install-deps/images_debian-10
+++ b/tests/lxc/install-deps/images_debian-10
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io libsquashfuse0 squashfuse fuse snapd -y
-pip3 install pytest requests pyyaml sh psutil
+pip3 install pytest==8.3.4 requests pyyaml sh psutil
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
 

--- a/tests/lxc/install-deps/images_debian-11
+++ b/tests/lxc/install-deps/images_debian-11
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io libsquashfuse0 squashfuse fuse snapd -y
-pip3 install pytest requests pyyaml sh psutil
+pip3 install pytest==8.3.4 requests pyyaml sh psutil
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
 

--- a/tests/lxc/install-deps/images_debian-12
+++ b/tests/lxc/install-deps/images_debian-12
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io libsquashfuse0 squashfuse fuse snapd -y
-pip3 install pytest requests pyyaml sh psutil --break-system-packages
+pip3 install pytest==8.3.4 requests pyyaml sh psutil --break-system-packages
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
 

--- a/tests/lxc/install-deps/images_fedora-37
+++ b/tests/lxc/install-deps/images_fedora-37
@@ -6,9 +6,9 @@ yum install fuse squashfuse -y
 yum install snapd -y
 systemctl enable --now snapd.socket
 ln -s /var/lib/snapd/snap /snap
-yum install python3-pip  -y
+yum install python3-pip -y
 yum install docker -y
-pip3 install pytest requests pyyaml sh psutil
+pip3 install pytest==8.3.4 requests pyyaml sh psutil
 
 # wait for the snapd seeding to take place!
 n=0

--- a/tests/lxc/install-deps/images_fedora-38
+++ b/tests/lxc/install-deps/images_fedora-38
@@ -6,9 +6,9 @@ yum install fuse squashfuse -y
 yum install snapd -y
 systemctl enable --now snapd.socket
 ln -s /var/lib/snapd/snap /snap
-yum install python3-pip  -y
+yum install python3-pip -y
 yum install docker -y
-pip3 install pytest requests pyyaml sh psutil
+pip3 install pytest==8.3.4 requests pyyaml sh psutil
 
 # wait for the snapd seeding to take place!
 n=0

--- a/tests/lxc/install-deps/images_rockylinux-8
+++ b/tests/lxc/install-deps/images_rockylinux-8
@@ -7,9 +7,9 @@ yum install fuse squashfuse -y
 yum install snapd -y
 systemctl enable --now snapd.socket
 ln -s /var/lib/snapd/snap /snap
-yum install python3-pip  -y
+yum install python3-pip -y
 yum install docker -y
-pip3 install pytest requests pyyaml sh psutil
+pip3 install pytest==8.3.4 requests pyyaml sh psutil
 
 # wait for the snapd seeding to take place!
 n=0

--- a/tests/lxc/install-deps/ubuntu_18.04
+++ b/tests/lxc/install-deps/ubuntu_18.04
@@ -6,7 +6,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install python3-pip docker.io -y
 # In Ubuntu 18.04 for arm64 on LXC, "pip3 install -U pyyaml" breaks netplan
-pip3 install pytest requests pyyaml sh psutil
+pip3 install pytest==8.3.4 requests pyyaml sh psutil
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
 snap install core20 | true

--- a/tests/lxc/install-deps/ubuntu_20.04
+++ b/tests/lxc/install-deps/ubuntu_20.04
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y
-pip3 install pytest requests pyyaml sh psutil
+pip3 install pytest==8.3.4 requests pyyaml sh psutil
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
 snap install core20 | true

--- a/tests/lxc/install-deps/ubuntu_22.04
+++ b/tests/lxc/install-deps/ubuntu_22.04
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y
-pip3 install pytest requests pyyaml sh psutil
+pip3 install pytest==8.3.4 requests pyyaml sh psutil
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
 snap install core20 | true


### PR DESCRIPTION
## Description

Passed Jenkins release CI: https://jenkins.canonical.com/k8s-ps5/job/release-microk8s-arch-amd64/node=runner-cloud/553/console
Currently, the "Test core addons" job fails because the test_cis test fails, having 2 more warnings than expected.

Those warnings are from ``microk8s kube-burner``, which has the following new warnings (the checks were passing before):

```
[WARN] 2.3 Ensure that the --auto-tls argument is not set to true (Automated)
[WARN] 2.6 Ensure that the --peer-auto-tls argument is not set to true (Automated)
``

Those warnings appear because the commands used for checking them fail:

```
2.3 audit test did not run: failed to run: "/bin/ps -ef | /bin/grep k8s-dqlite | /bin/grep -v grep", output: "", error: exit status 1 2.6 audit test did not run: failed to run: "/bin/ps -ef | /bin/grep k8s-dqlite | /bin/grep -v grep", output: "", error: exit status 1
```

Those errors would suggest that there is no ``k8s-dqlite`` process running
on the node... but it should. In ``test_cis``, after enabling
``cis-hardening`` (``microk8s enable cis-hardening``) and before running
``microk8s kube-burner``, in the test we're waiting for Kubernetes to be
available, accesible, and ready (``wait_for_installation``), which would only
be possible if ``k8s-dqlite`` would be running. What's more, this issue
does not occur when manually running the exact same commands as in the
GitHub action, even on the same GitHub Runners.

Pinning pytest to 8.3.4 seems to be solving the issue above (8.3.5 was released
a few days ago).

<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->
