### PR TITLE
[Backport 1.28-strict] CI: Fix addons CI (#4913)(#4923)

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -71,7 +71,7 @@ jobs:
           set -x
           sudo apt-get install python3-setuptools
           sudo pip3 install --upgrade pip
-          sudo pip3 install -U pytest sh
+          sudo pip3 install -U pytest==8.3.4 sh
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
       - name: Fetch snap

--- a/tests/lxc/install-deps/images_archlinux
+++ b/tests/lxc/install-deps/images_archlinux
@@ -3,7 +3,7 @@
 pacman -S --noconfirm --needed base-devel
 pacman -S --noconfirm --needed git
 useradd user
-echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+echo "user ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers
 mkdir /home/user
 chown user:user /home/user
 cd /tmp
@@ -14,19 +14,18 @@ sudo ln -s /var/lib/snapd/snap /snap
 su user -c "git clone https://aur.archlinux.org/squashfuse-git.git"
 su user -c "cd squashfuse-git; makepkg -si --noconfirm"
 pacman -S --noconfirm --needed fuse3
-echo "PATH=$PATH:/snap/bin" >> /etc/profile
+echo "PATH=$PATH:/snap/bin" >>/etc/profile
 pacman -S --noconfirm python-pip
 pacman -S --noconfirm python
 pacman -S --noconfirm docker
 sudo systemctl enable --now docker.service
 echo "127.0.0.1       localhost" | sudo tee -a /etc/hosts
-pip3 install pytest requests pyyaml
+pip3 install pytest==8.3.4 requests pyyaml
 
 # wait for the snapd seeding to take place!
 n=0
-until [ $n -ge 7 ]
-do
-  sudo snap install core18 && break  # substitute your command here
-  n=$[$n+1]
+until [ $n -ge 7 ]; do
+  sudo snap install core18 && break # substitute your command here
+  n=$(($n + 1))
   sleep 10
 done

--- a/tests/lxc/install-deps/images_centos-7
+++ b/tests/lxc/install-deps/images_centos-7
@@ -5,15 +5,14 @@ yum install sudo -y
 yum install snapd -y
 systemctl enable --now snapd.socket
 ln -s /var/lib/snapd/snap /snap
-yum install python3-pip  -y
+yum install python3-pip -y
 yum install docker -y
-pip3 install pytest requests pyyaml sh
+pip3 install pytest==8.3.4 requests pyyaml sh
 
 # wait for the snapd seeding to take place!
 n=0
-until [ $n -ge 7 ]
-do
-  sudo snap install core20 && break  # substitute your command here
-  n=$[$n+1]
+until [ $n -ge 7 ]; do
+  sudo snap install core20 && break # substitute your command here
+  n=$(($n + 1))
   sleep 10
 done

--- a/tests/lxc/install-deps/ubuntu_18.04
+++ b/tests/lxc/install-deps/ubuntu_18.04
@@ -6,7 +6,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install python3-pip docker.io -y
 # In Ubuntu 18.04 for arm64 on LXC, "pip3 install -U pyyaml" breaks netplan
-pip3 install pytest requests pyyaml sh
+pip3 install pytest==8.3.4 requests pyyaml sh
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
 snap install core20 | true

--- a/tests/lxc/install-deps/ubuntu_20.04
+++ b/tests/lxc/install-deps/ubuntu_20.04
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y
-pip3 install pytest requests pyyaml sh
+pip3 install pytest==8.3.4 requests pyyaml sh
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
 snap install core18 | true

--- a/tests/lxc/install-deps/ubuntu_22.04
+++ b/tests/lxc/install-deps/ubuntu_22.04
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install python3-pip docker.io -y
-pip3 install pytest requests pyyaml sh
+pip3 install pytest==8.3.4 requests pyyaml sh
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
 snap install core20 | true

--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -26,6 +26,7 @@ channel_to_test = os.environ.get("CHANNEL_TO_TEST", "latest/edge")
 backend = os.environ.get("BACKEND", None)
 profile = os.environ.get("LXC_PROFILE", "lxc/microk8s.profile")
 snap_data = os.environ.get("SNAP_DATA", "/var/snap/microk8s/current")
+distro = os.environ.get("DISTRO", "ubuntu:20.04")
 
 TEMPLATES = Path(__file__).absolute().parent / "templates"
 
@@ -96,8 +97,8 @@ extraSANs:
                     process.stdin.close()
 
             subprocess.check_call(
-                "/snap/bin/lxc launch -p default -p microk8s ubuntu:18.04 {}".format(
-                    self.vm_name
+                "/snap/bin/lxc launch -p default -p microk8s {} {}".format(
+                    distro, self.vm_name
                 ).split()
             )
             time.sleep(20)
@@ -169,8 +170,9 @@ extraSANs:
 
     def _setup_multipass(self, channel_or_snap):
         if not self.attached:
+            version = distro.split(":")
             subprocess.check_call(
-                "/snap/bin/multipass launch 18.04 -n {} -m 2G".format(self.vm_name).split()
+                "/snap/bin/multipass launch {} -n {} -m 2G".format(version[1], self.vm_name).split()
             )
             if is_ipv6_configured():
                 self._load_launch_configuration_multipass()


### PR DESCRIPTION
## Description

This PR fixes the addons-CI by changing the distro in the test and pinning pytest. For further info please refer to the back-ported PRs.
