### PR TITLE
[Backport 1.32-strict] fix: update configure hook to add a newline before adding watchlist flag

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -390,6 +390,7 @@ if ! grep -e "WatchList" ${SNAP_DATA}/args/kube-apiserver
 then
   if ! grep -e "--feature-gates=" ${SNAP_DATA}/args/kube-apiserver
   then
+    echo "" >> ${SNAP_DATA}/args/kube-apiserver
     echo '--feature-gates=WatchList=false' >> ${SNAP_DATA}/args/kube-apiserver
   else
     # Find the line starting with --feature-gates= and append ,WatchList=false


### PR DESCRIPTION
Backports #4946 to `1.32-strict`