### PR TITLE
fix: flush the `CNI-HOSTPORT-DNAT` chain on stop

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -990,6 +990,8 @@ remove_all_containers() {
     do
         "${SNAP}/microk8s-ctr.wrapper" container delete $container &>/dev/null || true
     done
+
+    iptables-legacy -t nat -F CNI-HOSTPORT-DNAT || true
 }
 
 get_container_shim_pids() {


### PR DESCRIPTION
`microk8s stop` was changed to fully remove containers via ctr(#4755) which results in an old DNAT rule getting left-over that points to the old container id. flushing the chain should fix issues of hostPort connections dropping after a stop & start.

Fixes #4944 