### PR TITLE
backport: [1.28] Check for PROXY in distro test, bump to core20, pre-install xdelta3

### DIFF
--- a/tests/libs/utils.sh
+++ b/tests/libs/utils.sh
@@ -13,8 +13,6 @@ function create_machine() {
 
   # Allow for the machine to boot and get an IP
   sleep 20
-  # CentOS 8,9 variants(rocky, alma) don't ship with tar, such a dirty hack...
-  lxc exec "$NAME" -- /bin/bash -c "yum install tar -y || true"
   tar cf - ./tests | lxc exec "$NAME" -- tar xvf - -C /root
   DISTRO_DEPS_TMP="${DISTRO//:/_}"
   DISTRO_DEPS="${DISTRO_DEPS_TMP////-}"

--- a/tests/libs/utils.sh
+++ b/tests/libs/utils.sh
@@ -13,15 +13,14 @@ function create_machine() {
   lxc launch -p default -p microk8s "$DISTRO" "$NAME"
 
   # Allow for the machine to boot and get an IP
-  timeout 60 bash -c 'until lxc list "$NAME" -c4 | grep -q eth; do sleep 5; done' || { echo "Error: $NAME did not get an IP within 60s"; exit 1; }
+  timeout 120 bash -c 'until lxc list "$NAME" -c4 | grep -q eth; do sleep 5; done' || { echo "Error: $NAME did not get an IP within 60s"; exit 1; }
 
   tar cf - ./tests | lxc exec "$NAME" -- tar xvf - -C /root
   DISTRO_DEPS_TMP="${DISTRO//:/_}"
   DISTRO_DEPS="${DISTRO_DEPS_TMP////-}"
   lxc exec "$NAME" -- /bin/bash "/root/tests/lxc/install-deps/$DISTRO_DEPS"
   lxc exec "$NAME" -- reboot
-  timeout 60 bash -c 'until lxc exec "$NAME" -- /bin/true; do sleep 5; done' || { echo "Error: Con
-tainer $NAME did not become ready in 60s"; exit 1; }
+  timeout 600 bash -c 'until lxc exec "$NAME" -- /bin/true; do sleep 5; done' || { echo "Error: Container $NAME did not become ready in 60s"; exit 1; }
 
   trap 'lxc delete '"${NAME}"' --force || true' EXIT
   if [ "$#" -ne 1 ]
@@ -29,8 +28,7 @@ tainer $NAME did not become ready in 60s"; exit 1; }
     lxc exec "$NAME" -- /bin/bash -c "echo HTTPS_PROXY=$PROXY >> /etc/environment"
     lxc exec "$NAME" -- /bin/bash -c "echo https_proxy=$PROXY >> /etc/environment"
     lxc exec "$NAME" -- reboot
-    timeout 60 bash -c 'until lxc exec "$NAME" -- /bin/true; do sleep 5; done' || { echo "Error: Con
-tainer $NAME did not become ready in 60s after applying proxy settings"; exit 1; }
+    timeout 600 bash -c 'until lxc exec "$NAME" -- /bin/true; do sleep 5; done' || { echo "Error: Container $NAME did not become ready in 60s after applying proxy settings"; exit 1; }
   fi
 }
 

--- a/tests/lxc/install-deps/ubuntu_20.04
+++ b/tests/lxc/install-deps/ubuntu_20.04
@@ -8,4 +8,4 @@ apt-get install python3-pip docker.io -y
 pip3 install pytest==8.3.4 requests pyyaml sh
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
-snap install core18 | true
+snap install core20 | true

--- a/tests/lxc/install-deps/ubuntu_20.04
+++ b/tests/lxc/install-deps/ubuntu_20.04
@@ -3,8 +3,8 @@
 export $(grep -v '^#' /etc/environment | xargs)
 export DEBIAN_FRONTEND=noninteractive
 
-snap wait core seed.loaded
 apt-get update
+apt-get install -y xdelta3
 apt-get install python3-pip docker.io -y
 pip3 install pytest==8.3.4 requests pyyaml sh
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698

--- a/tests/lxc/install-deps/ubuntu_20.04
+++ b/tests/lxc/install-deps/ubuntu_20.04
@@ -3,6 +3,7 @@
 export $(grep -v '^#' /etc/environment | xargs)
 export DEBIAN_FRONTEND=noninteractive
 
+snap wait core seed.loaded
 apt-get update
 apt-get install python3-pip docker.io -y
 pip3 install pytest==8.3.4 requests pyyaml sh


### PR DESCRIPTION
## Description

Backport of https://github.com/canonical/microk8s/pull/4975.

The microk8s release test was configuring the proxy for the distro test even when no PROXY argument was passed and consequently failing. This PR uses the 1.29 utils.sh script changes from https://github.com/canonical/microk8s/pull/4211/files#diff-ab9576bfebf72148bf033576bf8375386e2ca3724ce06bba9076280358ed5d90.

Release job success: [598](https://jenkins.canonical.com/k8s-ps5/job/release-microk8s-arch-amd64/node=runner-cloud/598/console)

Without `xdelta3` we get a failure: [599](https://jenkins.canonical.com/k8s-ps5/job/release-microk8s-arch-amd64/node=runner-cloud/599/console), `error: cannot communicate with server: Post "http://localhost/v2/snaps/microk8s": read unix @->/run/snapd.socket: read: connection reset by peer`