### PR TITLE
backport: [1.28-strict] Check for PROXY in distro test, bump to core20, pre-…

### DIFF
--- a/tests/libs/utils.sh
+++ b/tests/libs/utils.sh
@@ -4,11 +4,10 @@ function create_machine() {
   local NAME=$1
   local DISTRO=$2
   local PROXY=$3
-  if ! lxc profile show microk8s
-  then
+  if ! lxc profile show microk8s; then
     lxc profile copy default microk8s
   fi
-  lxc profile edit microk8s < tests/lxc/microk8s.profile
+  lxc profile edit microk8s <tests/lxc/microk8s.profile
 
   lxc launch -p default -p microk8s "$DISTRO" "$NAME"
 
@@ -22,8 +21,7 @@ function create_machine() {
   sleep 20
 
   trap 'lxc delete '"${NAME}"' --force || true' EXIT
-  if [ "$#" -ne 1 ]
-  then
+  if [ ! -z "${PROXY}" ]; then
     lxc exec "$NAME" -- /bin/bash -c "echo HTTPS_PROXY=$PROXY >> /etc/environment"
     lxc exec "$NAME" -- /bin/bash -c "echo https_proxy=$PROXY >> /etc/environment"
     lxc exec "$NAME" -- reboot

--- a/tests/lxc/install-deps/ubuntu_20.04
+++ b/tests/lxc/install-deps/ubuntu_20.04
@@ -4,8 +4,9 @@ export $(grep -v '^#' /etc/environment | xargs)
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
+apt-get install -y xdelta3
 apt-get install python3-pip docker.io -y
 pip3 install pytest==8.3.4 requests pyyaml sh
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
-snap install core18 | true
+snap install core20 | true


### PR DESCRIPTION
## Description
Backport of https://github.com/canonical/microk8s/pull/4975, pieces from https://github.com/canonical/microk8s/pull/4973.
Unblocking Microk8s release CI by pre-install xdelta3 since snapd deb does not ship with it.
Jenkins run [605](https://jenkins.canonical.com/k8s-ps5/job/release-microk8s-arch-amd64/node=runner-cloud/605/console).