### PR TITLE
backport: [1.29-strict] Microk8s release CI by pre-install xdelta3

### DIFF
--- a/tests/lxc/install-deps/ubuntu_20.04
+++ b/tests/lxc/install-deps/ubuntu_20.04
@@ -4,6 +4,7 @@ export $(grep -v '^#' /etc/environment | xargs)
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
+apt-get install xdelta3 -y
 apt-get install python3-pip docker.io -y
 pip3 install pytest==8.3.4 requests pyyaml sh
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698


### PR DESCRIPTION
## Description
Unblocking Microk8s release CI by pre-install xdelta3 since snapd deb does not ship with it.
Backport of https://github.com/canonical/microk8s/pull/4975