### PR TITLE
backport: [1.32]  Microk8s release CI by pre-install xdelta3

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Create installer
         run: makensis.exe ${{ github.workspace }}/installer/windows/microk8s.nsi
       - name: Upload installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Windows installer
           path: ${{ github.workspace }}/installer/windows/microk8s-installer.exe

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -1,9 +1,7 @@
 name: Build and test MicroK8s snap
 
 on:
-  pull_request:
-    branches:
-      - master
+  - pull_request
 
 jobs:
   build:

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -28,7 +28,7 @@ jobs:
           sg lxd -c 'snapcraft --use-lxd'
           sudo mv microk8s*.snap microk8s.snap
       - name: Uploading snap
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: microk8s.snap
           path: microk8s.snap
@@ -50,7 +50,7 @@ jobs:
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -75,7 +75,7 @@ jobs:
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -105,7 +105,7 @@ jobs:
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -138,7 +138,7 @@ jobs:
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -163,7 +163,7 @@ jobs:
           sudo pip3 install --upgrade pip
           sudo pip3 install -U pytest sh requests
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -182,7 +182,7 @@ jobs:
       - name: Checking out repo
         uses: actions/checkout@v4
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build
@@ -204,7 +204,7 @@ jobs:
       - name: Checking out repo
         uses: actions/checkout@v4
       - name: Fetch snap
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.snap
           path: build

--- a/tests/lxc/install-deps/ubuntu_20.04
+++ b/tests/lxc/install-deps/ubuntu_20.04
@@ -4,6 +4,7 @@ export $(grep -v '^#' /etc/environment | xargs)
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
+apt-get install xdelta3 -y
 apt-get install python3-pip docker.io -y
 pip3 install pytest==8.3.4 requests pyyaml sh psutil
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698


### PR DESCRIPTION
## Description
Unblocking Microk8s release CI by pre-install xdelta3 since snapd deb does not ship with it.
Backport of https://github.com/canonical/microk8s/pull/4975