### PR TITLE
backport: [1.32-strict] Microk8s release CI by pre-install xdelta3

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -1,7 +1,7 @@
 name: Build and test MicroK8s snap
 
 on:
-  - push
+  - pull_request
 
 jobs:
   build:

--- a/tests/lxc/install-deps/ubuntu_20.04
+++ b/tests/lxc/install-deps/ubuntu_20.04
@@ -4,6 +4,7 @@ export $(grep -v '^#' /etc/environment | xargs)
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
+apt-get install xdelta3 -y
 apt-get install python3-pip docker.io -y
 pip3 install pytest==8.3.4 requests pyyaml sh psutil
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698


### PR DESCRIPTION
## Description
Unblocking Microk8s release CI by pre-install xdelta3 since snapd deb does not ship with it.
Backport of https://github.com/canonical/microk8s/pull/4975