### PR TITLE
CI: [1.28] fix clustering flake

### DIFF
--- a/tests/libs/clustering.sh
+++ b/tests/libs/clustering.sh
@@ -4,14 +4,12 @@ function run_clustering_tests() {
   # Test clustering. This test will create lxc containers or multipass VMs
   # therefore we do not need to run it inside a VM/container
   TRY_ATTEMPT=0
-  while ! (timeout 3600 pytest -s tests/test-cluster.py) &&
-        ! [ ${TRY_ATTEMPT} -eq 3 ]
-  do
-    TRY_ATTEMPT=$((TRY_ATTEMPT+1))
+  while ! (timeout 5400 pytest -s tests/test-cluster.py) &&
+    ! [ ${TRY_ATTEMPT} -eq 5 ]; do
+    TRY_ATTEMPT=$((TRY_ATTEMPT + 1))
     sleep 1
   done
-  if [ ${TRY_ATTEMPT} -eq 3 ]
-  then
+  if [ ${TRY_ATTEMPT} -eq 5 ]; then
     echo "Test clusterring took longer than expected"
     exit 1
   fi


### PR DESCRIPTION
## Description
Fix clustering test flake by increasing the timeout and adding retries.