### PR TITLE
ci: unblock the CI and add a few improvements

### DIFF
--- a/.github/actions/test-prep/action.yaml
+++ b/.github/actions/test-prep/action.yaml
@@ -12,8 +12,6 @@ runs:
       run: |
         set -x
         sudo pip3 install -R ./tests/requirements.txt
-        sudo apt-get -y install open-iscsi
-        sudo systemctl enable iscsid
     # Docker sets iptables rules that interfere with LXD and K8s.
     # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
     - name: Apply Docker iptables workaround

--- a/.github/actions/test-prep/action.yaml
+++ b/.github/actions/test-prep/action.yaml
@@ -3,12 +3,14 @@ name: Prepare test prerequisites
 runs:
   using: "composite"
   steps:
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
     - name: Install test dependencies
       shell: bash
       run: |
         set -x
-        sudo apt-get install python3-setuptools
-        sudo pip3 install --upgrade pip
         sudo pip3 install -U pytest==8.3.4 sh psutil requests
         sudo apt-get -y install open-iscsi
         sudo systemctl enable iscsid

--- a/.github/actions/test-prep/action.yaml
+++ b/.github/actions/test-prep/action.yaml
@@ -1,0 +1,26 @@
+name: Prepare test prerequisites
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install test dependencies
+      shell: bash
+      run: |
+        set -x
+        sudo apt-get install python3-setuptools
+        sudo pip3 install --upgrade pip
+        sudo pip3 install -U pytest==8.3.4 sh psutil requests
+        sudo apt-get -y install open-iscsi
+        sudo systemctl enable iscsid
+    # Docker sets iptables rules that interfere with LXD and K8s.
+    # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
+    - name: Apply Docker iptables workaround
+      shell: bash
+      run: sudo iptables -I DOCKER-USER -j ACCEPT
+    - name: Fetch snap
+      uses: actions/download-artifact@v4
+      with:
+        name: microk8s.snap
+        path: build
+    # - name: Setup tmate session
+    #   uses: mxschmitt/action-tmate@v3

--- a/.github/actions/test-prep/action.yaml
+++ b/.github/actions/test-prep/action.yaml
@@ -11,7 +11,7 @@ runs:
       shell: bash
       run: |
         set -x
-        sudo pip3 install -U pytest==8.3.4 sh psutil requests
+        sudo pip3 install -R ./tests/requirements.txt
         sudo apt-get -y install open-iscsi
         sudo systemctl enable iscsid
     # Docker sets iptables rules that interfere with LXD and K8s.
@@ -24,5 +24,3 @@ runs:
       with:
         name: microk8s.snap
         path: build
-    # - name: Setup tmate session
-    #   uses: mxschmitt/action-tmate@v3

--- a/.github/actions/test-prep/action.yaml
+++ b/.github/actions/test-prep/action.yaml
@@ -11,7 +11,7 @@ runs:
       shell: bash
       run: |
         set -x
-        sudo pip3 install -R ./tests/requirements.txt
+        sudo pip3 install -r ./tests/requirements.txt
     # Docker sets iptables rules that interfere with LXD and K8s.
     # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
     - name: Apply Docker iptables workaround

--- a/.github/actions/test-prep/action.yaml
+++ b/.github/actions/test-prep/action.yaml
@@ -11,7 +11,7 @@ runs:
       shell: bash
       run: |
         set -x
-        sudo pip3 install -r ./tests/requirements.txt
+        sudo pip3 install -U pytest==8.3.4 sh psutil requests
     # Docker sets iptables rules that interfere with LXD and K8s.
     # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
     - name: Apply Docker iptables workaround

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -18,6 +18,11 @@ jobs:
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
+      # Docker sets iptables rules that interfere with LXD or K8s.
+      # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
+      - name: Apply Docker iptables workaround
+        shell: bash
+        run: sudo iptables -I DOCKER-USER -j ACCEPT
       - name: Install snapcraft
         run: |
           sudo snap install snapcraft --classic
@@ -64,6 +69,7 @@ jobs:
     name: Test core addons
     runs-on: ubuntu-22.04
     needs: build
+    timeout-minutes: 30
 
     steps:
       - name: Checking out repo
@@ -76,6 +82,11 @@ jobs:
           sudo pip3 install -U pytest==8.3.4 sh psutil
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
+      # Docker sets iptables rules that interfere with LXD or K8s.
+      # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
+      - name: Apply Docker iptables workaround
+        shell: bash
+        run: sudo iptables -I DOCKER-USER -j ACCEPT
       - name: Fetch snap
         uses: actions/download-artifact@v4
         with:
@@ -127,6 +138,7 @@ jobs:
     name: Test core addons upgrade
     runs-on: ubuntu-22.04
     needs: build
+    timeout-minutes: 30
 
     steps:
       - name: Checking out repo
@@ -141,6 +153,11 @@ jobs:
           sudo pip3 install -U pytest sh psutil
           sudo apt-get -y install open-iscsi
           sudo systemctl enable iscsid
+      # Docker sets iptables rules that interfere with LXD or K8s.
+      # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
+      - name: Apply Docker iptables workaround
+        shell: bash
+        run: sudo iptables -I DOCKER-USER -j ACCEPT
       - name: Fetch snap
         uses: actions/download-artifact@v4
         with:
@@ -197,6 +214,11 @@ jobs:
           sudo lxc network set lxdbr0 ipv6.address=none
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
+      # Docker sets iptables rules that interfere with LXD or K8s.
+      # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
+      - name: Apply Docker iptables workaround
+        shell: bash
+        run: sudo iptables -I DOCKER-USER -j ACCEPT
       - name: Run airgap tests
         run: |
           sudo -E bash -x -c "./tests/libs/airgap.sh --distro ubuntu:22.04 --channel $PWD/build/microk8s.snap"

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -44,23 +44,12 @@ jobs:
     name: Upgrade path test
     runs-on: ubuntu-22.04
     needs: build
-
+    timeout-minutes: 30
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4
-      - name: Install test dependencies
-        run: |
-          set -x
-          sudo apt-get install python3-setuptools
-          sudo pip3 install --upgrade pip
-          sudo pip3 install -U pytest sh psutil
-          sudo apt-get -y install open-iscsi
-          sudo systemctl enable iscsid
-      - name: Fetch snap
-        uses: actions/download-artifact@v4
-        with:
-          name: microk8s.snap
-          path: build
+      - name: Prepare test prerequisites
+        uses: ./.github/actions/test-prep
       - name: Running upgrade path test
         run: |
           sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade-path.py
@@ -70,28 +59,11 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build
     timeout-minutes: 30
-
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4
-      - name: Install test dependencies
-        run: |
-          set -x
-          sudo apt-get install python3-setuptools
-          sudo pip3 install --upgrade pip
-          sudo pip3 install -U pytest==8.3.4 sh psutil
-          sudo apt-get -y install open-iscsi
-          sudo systemctl enable iscsid
-      # Docker sets iptables rules that interfere with LXD or K8s.
-      # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
-      - name: Apply Docker iptables workaround
-        shell: bash
-        run: sudo iptables -I DOCKER-USER -j ACCEPT
-      - name: Fetch snap
-        uses: actions/download-artifact@v4
-        with:
-          name: microk8s.snap
-          path: build
+      - name: Prepare test prerequisites
+        uses: ./.github/actions/test-prep
       - name: Running addons tests
         env:
           UNDER_TIME_PRESSURE: ${{ !contains(github.event.pull_request.labels.*.name, 'run-all-tests') }}
@@ -106,25 +78,12 @@ jobs:
     name: Test community addons
     runs-on: ubuntu-22.04
     needs: build
-
+    timeout-minutes: 30
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4
-      - name: Install test dependencies
-        run: |
-          set -x
-          sudo apt-get install python3-setuptools
-          sudo pip3 install --upgrade pip
-          sudo pip3 install -U pytest sh
-          sudo apt-get -y install open-iscsi
-          sudo systemctl enable iscsid
-      - name: Fetch snap
-        uses: actions/download-artifact@v4
-        with:
-          name: microk8s.snap
-          path: build
-      # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
+      - name: Prepare test prerequisites
+        uses: ./.github/actions/test-prep
       - name: Running addons tests
         env:
           UNDER_TIME_PRESSURE: ${{ !contains(github.event.pull_request.labels.*.name, 'run-all-tests') }}
@@ -139,30 +98,11 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build
     timeout-minutes: 30
-
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4
-      # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
-      - name: Install test dependencies
-        run: |
-          set -x
-          sudo apt-get install python3-setuptools
-          sudo pip3 install --upgrade pip
-          sudo pip3 install -U pytest sh psutil
-          sudo apt-get -y install open-iscsi
-          sudo systemctl enable iscsid
-      # Docker sets iptables rules that interfere with LXD or K8s.
-      # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
-      - name: Apply Docker iptables workaround
-        shell: bash
-        run: sudo iptables -I DOCKER-USER -j ACCEPT
-      - name: Fetch snap
-        uses: actions/download-artifact@v4
-        with:
-          name: microk8s.snap
-          path: build
+      - name: Prepare test prerequisites
+        uses: ./.github/actions/test-prep
       - name: Running upgrade tests
         env:
           UNDER_TIME_PRESSURE: ${{ !contains(github.event.pull_request.labels.*.name, 'run-all-tests') }}
@@ -174,21 +114,12 @@ jobs:
     name: Cluster agent health check
     runs-on: ubuntu-22.04
     needs: build
-
+    timeout-minutes: 30
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4
-      - name: Install test dependencies
-        run: |
-          set -x
-          sudo apt-get install python3-setuptools
-          sudo pip3 install --upgrade pip
-          sudo pip3 install -U pytest sh requests
-      - name: Fetch snap
-        uses: actions/download-artifact@v4
-        with:
-          name: microk8s.snap
-          path: build
+      - name: Prepare test prerequisites
+        uses: ./.github/actions/test-prep
       - name: Running cluster agent health check
         run: |
           set -x
@@ -199,26 +130,18 @@ jobs:
     name: Test airgap installation
     runs-on: ubuntu-22.04
     needs: build
-
+    timeout-minutes: 30
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4
-      - name: Fetch snap
-        uses: actions/download-artifact@v4
-        with:
-          name: microk8s.snap
-          path: build
+      - name: Prepare test prerequisites
+        uses: ./.github/actions/test-prep
       - name: Initialize LXD
         run: |
           sudo lxd init --auto
           sudo lxc network set lxdbr0 ipv6.address=none
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
-      # Docker sets iptables rules that interfere with LXD or K8s.
-      # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
-      - name: Apply Docker iptables workaround
-        shell: bash
-        run: sudo iptables -I DOCKER-USER -j ACCEPT
       - name: Run airgap tests
         run: |
           sudo -E bash -x -c "./tests/libs/airgap.sh --distro ubuntu:22.04 --channel $PWD/build/microk8s.snap"
@@ -227,6 +150,7 @@ jobs:
     name: Security scan
     runs-on: ubuntu-22.04
     needs: build
+    timeout-minutes: 30
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -82,11 +82,12 @@ jobs:
           name: microk8s.snap
           path: build
       - name: Running addons tests
+        env:
+          UNDER_TIME_PRESSURE: ${{ !contains(github.event.pull_request.labels.*.name, 'run-all-tests') }}
         run: |
           set -x
           sudo snap install build/microk8s.snap --classic --dangerous
           ./tests/smoke-test.sh
-          export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"
           sudo -E bash -c "cd /var/snap/microk8s/common/addons/core/tests; pytest -s -ra test-addons.py"
 
@@ -114,11 +115,12 @@ jobs:
       # - name: Setup tmate session
       #   uses: mxschmitt/action-tmate@v3
       - name: Running addons tests
+        env:
+          UNDER_TIME_PRESSURE: ${{ !contains(github.event.pull_request.labels.*.name, 'run-all-tests') }}
         run: |
           set -x
           sudo snap install build/microk8s.snap --classic --dangerous
           sudo microk8s enable community
-          export UNDER_TIME_PRESSURE="True"
           sudo -E bash -c "cd /var/snap/microk8s/common/addons/community/; pytest -s -ra ./tests/"
 
   test-addons-core-upgrade:
@@ -145,9 +147,10 @@ jobs:
           name: microk8s.snap
           path: build
       - name: Running upgrade tests
+        env:
+          UNDER_TIME_PRESSURE: ${{ !contains(github.event.pull_request.labels.*.name, 'run-all-tests') }}
         run: |
           set -x
-          export UNDER_TIME_PRESSURE="True"
           sudo -E bash -c "UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade.py"
 
   test-cluster-agent:

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Create snap package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checking out repo
@@ -37,7 +37,7 @@ jobs:
 
   test-upgrade:
     name: Upgrade path test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
 
     steps:
@@ -62,7 +62,7 @@ jobs:
 
   test-addons-core:
     name: Test core addons
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
 
     steps:
@@ -93,7 +93,7 @@ jobs:
 
   test-addons-community:
     name: Test community addons
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
 
     steps:
@@ -125,7 +125,7 @@ jobs:
 
   test-addons-core-upgrade:
     name: Test core addons upgrade
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
 
     steps:
@@ -155,7 +155,7 @@ jobs:
 
   test-cluster-agent:
     name: Cluster agent health check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
 
     steps:
@@ -180,7 +180,7 @@ jobs:
 
   test-airgap:
     name: Test airgap installation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
 
     steps:
@@ -199,11 +199,11 @@ jobs:
           sg lxd -c 'lxc version'
       - name: Run airgap tests
         run: |
-          sudo -E bash -x -c "./tests/libs/airgap.sh --distro ubuntu:20.04 --channel $PWD/build/microk8s.snap"
+          sudo -E bash -x -c "./tests/libs/airgap.sh --distro ubuntu:22.04 --channel $PWD/build/microk8s.snap"
 
   security-scan:
     name: Security scan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
     steps:
       - name: Checking out repo

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 kubernetes
 jinja2
 pylxd
-pytest
+pytest==8.3.4
 pytest-xdist
 pyyaml
 sh

--- a/tests/test-upgrade-path.py
+++ b/tests/test-upgrade-path.py
@@ -19,7 +19,7 @@ class TestUpgradePath(object):
     """
 
     @pytest.mark.skipif(
-        os.environ.get("UNDER_TIME_PRESSURE") == "True",
+        os.environ.get("UNDER_TIME_PRESSURE", "").lower() == "true",
         reason="Skipping refresh path test as we are under time pressure",
     )
     def test_refresh_path(self):

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -26,7 +26,7 @@ from utils import (
 upgrade_from = os.environ.get("UPGRADE_MICROK8S_FROM", "beta")
 # Have UPGRADE_MICROK8S_TO point to a file to upgrade to that file
 upgrade_to = os.environ.get("UPGRADE_MICROK8S_TO", "edge")
-under_time_pressure = os.environ.get("UNDER_TIME_PRESSURE", "False")
+under_time_pressure = os.environ.get("UNDER_TIME_PRESSURE", "false").lower()
 
 
 class TestUpgrade(object):
@@ -121,7 +121,7 @@ extraSANs:
             print("Will not test the metrics server")
 
         # AMD64 only tests
-        if platform.machine() == "x86_64" and under_time_pressure == "False":
+        if platform.machine() == "x86_64" and under_time_pressure == "false":
             try:
                 ip_ranges = (
                     "192.168.0.105-192.168.0.105,192.168.0.110-192.168.0.111,192.168.1.240/28"


### PR DESCRIPTION
* GH actions no longer support 20.04 runners, so we'll switch to 22.04
  * need to apply the well known iptables workaround to address the compatibility issue between LXD and Docker
* we're adding the run-all-tests label which controls the UNDER_TIME_PRESSURE env variable
* to avoid duplicate logic, we'll add a composite action that takes care of the test prerequisites, making them easier to maintain.
* we'll avoid installing python packages globally (no longer allowed by recent Python versions). Instead, we'll use actions/setup-python, which will also cache the packages.
* define job timeouts