### PR TITLE
fix: Always refresh the default hooks during upgrades

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Create snap package
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checking out repo
@@ -44,7 +44,7 @@ jobs:
 
   test-upgrade:
     name: Upgrade path test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 30
     steps:
@@ -58,7 +58,7 @@ jobs:
 
   test-addons-core:
     name: Test core addons
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 30
     steps:
@@ -78,7 +78,7 @@ jobs:
 
   test-addons-community:
     name: Test community addons
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 60
     steps:
@@ -97,7 +97,7 @@ jobs:
 
   test-addons-core-upgrade:
     name: Test core addons upgrade
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 30
     steps:
@@ -114,7 +114,7 @@ jobs:
 
   test-cluster-agent:
     name: Cluster agent health check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 30
     steps:
@@ -130,7 +130,7 @@ jobs:
 
   test-airgap:
     name: Test airgap installation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 30
     steps:
@@ -152,7 +152,7 @@ jobs:
 
   security-scan:
     name: Security scan
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 30
     steps:

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -78,7 +78,7 @@ jobs:
     name: Test community addons
     runs-on: ubuntu-22.04
     needs: build
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -17,7 +17,9 @@ jobs:
         run: |
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
-          sg lxd -c 'lxc version'
+          # `newgrp` does not work in GitHub Actions; use `sudo --user` instead
+          # See https://github.com/actions/runner-images/issues/9932#issuecomment-2573170305
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc version
       # Docker sets iptables rules that interfere with LXD or K8s.
       # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
       - name: Apply Docker iptables workaround
@@ -32,7 +34,7 @@ jobs:
           sudo snap refresh snapd --channel=latest/stable
       - name: Build snap
         run: |
-          sg lxd -c 'snapcraft --use-lxd'
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- snapcraft --use-lxd
           sudo mv microk8s*.snap microk8s.snap
       - name: Uploading snap
         uses: actions/upload-artifact@v4
@@ -141,7 +143,9 @@ jobs:
           sudo lxd init --auto
           sudo lxc network set lxdbr0 ipv6.address=none
           sudo usermod --append --groups lxd $USER
-          sg lxd -c 'lxc version'
+          # `newgrp` does not work in GitHub Actions; use `sudo --user` instead
+          # See https://github.com/actions/runner-images/issues/9932#issuecomment-2573170305
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc version
       - name: Run airgap tests
         run: |
           sudo -E bash -x -c "./tests/libs/airgap.sh --distro ubuntu:22.04 --channel $PWD/build/microk8s.snap"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -220,20 +220,13 @@ then
 
 fi
 
-# Install default-hooks
-if ! [ -d "${SNAP_COMMON}/hooks" ]
-then
-  cp -r --preserve=mode ${SNAP}/default-hooks ${SNAP_COMMON}/hooks
-else
-  # https://github.com/canonical/microk8s/pull/4819#issuecomment-2676378060
-  mkdir -p ${SNAP_COMMON}/hooks/reconcile.d
-  cp --preserve=mode ${SNAP}/default-hooks/reconcile.d/10-pods-restart ${SNAP_COMMON}/hooks/reconcile.d/
-fi
-
-# (1.28 -> 1.29) Install 10-pods-restart hook if missing
-if ! [ -e "${SNAP_COMMON}/hooks/reconcile.d/10-pods-restart" ]; then
-  cp -r --preserve=mode "${SNAP}/default-hooks/reconcile.d/10-pods-restart" "${SNAP_COMMON}/hooks/reconcile.d/10-pods-restart"
-fi
+# Install default-hooks.
+#
+# Updated hooks may contain fixes, so we'll always replace existing files.
+# Custom hooks are expected to use separate files so that they won't get
+# overwritten during upgrades.
+mkdir -p ${SNAP_COMMON}/hooks
+cp -r --preserve=mode ${SNAP}/default-hooks/* ${SNAP_COMMON}/hooks/
 
 # Make sure the server certificate includes the IP we are using
 if [ "$(produce_certs)" == "1" ]

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -224,6 +224,10 @@ fi
 if ! [ -d "${SNAP_COMMON}/hooks" ]
 then
   cp -r --preserve=mode ${SNAP}/default-hooks ${SNAP_COMMON}/hooks
+else
+  # https://github.com/canonical/microk8s/pull/4819#issuecomment-2676378060
+  mkdir -p ${SNAP_COMMON}/hooks/reconcile.d
+  cp --preserve=mode ${SNAP}/default-hooks/reconcile.d/10-pods-restart ${SNAP_COMMON}/hooks/reconcile.d/
 fi
 
 # (1.28 -> 1.29) Install 10-pods-restart hook if missing

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -100,9 +100,12 @@ def wait_for_pod_state(
     deadline = datetime.datetime.now() + datetime.timedelta(seconds=timeout_insec)
     while True:
         if datetime.datetime.now() > deadline:
-            raise TimeoutError(
-                "Pod {} not in {} after {} seconds.".format(pod, desired_state, timeout_insec)
-            )
+            all_res = kubectl("get all -A")
+            err_msg = f"Pod {pod} not in {desired_state} after {timeout_insec} seconds, "
+            err_msg += f"label: {label}, desired_reason: {desired_reason}.\n"
+            print(err_msg)
+            print(f"kubectl get all -A\n{all_res}\n")
+            raise TimeoutError(err_msg)
         cmd = "po {} -n {}".format(pod, namespace)
         if label:
             cmd += " -l {}".format(label)


### PR DESCRIPTION
## Always refresh the default hooks during upgrades
At the moment, the default hooks are not updated when refreshing
the snap[1].

There's an explicit check so this was most probably by design so that
custom hooks would not get overridden[2]. However, it means that bug
fixes are not applied automatically and the users need to copy the
files manually, which is undocumented and not very user friendly.

**Warning:**
This change will always refresh the default hooks, replacing
the existing files. Custom hooks are expected to use separate files
so that they won't get overridden during upgrades.

[1] https://github.com/canonical/microk8s/pull/4819
[2] https://github.com/canonical/microk8s/pull/4819#issuecomment-2676378060

<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

#### Testing
<!-- Please explain how you tested your changes. -->

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [ ] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
