### PR TITLE
CI: fix CIS test failures caused by truncated ps output

### DIFF
--- a/.github/actions/test-prep/action.yaml
+++ b/.github/actions/test-prep/action.yaml
@@ -11,7 +11,7 @@ runs:
       shell: bash
       run: |
         set -x
-        sudo pip3 install -U pytest==8.3.4 sh psutil requests
+        sudo pip3 install -r ./tests/requirements.txt
     # Docker sets iptables rules that interfere with LXD and K8s.
     # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
     - name: Apply Docker iptables workaround

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -61,6 +61,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 30
+    env:
+      # Avoid truncated "ps" output
+      COLUMNS: 2048
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,11 +1,11 @@
 kubernetes
 jinja2
 pylxd
-pytest==8.3.4
+pytest
 pytest-xdist
 pyyaml
 sh
-jsonschema==4.0.0
+jsonschema>=4.0.0
 pdbpp
 psutil
 netifaces


### PR DESCRIPTION
The CIS tests are currently failing if we remove some Python
dependency constraints.

The reason is that these tests run a few "ps" commands and receive
truncated output[1].

As a workaround, we'll explicitly set the terminal size using
the COLUMNS env variable.

[1] https://github.com/canonical/microk8s-core-addons/blob/f2716f1d4c0e169762f0bff37d7496f7ac33db62/addons/cis-hardening/cfg/cis-1.24-microk8s/etcd.yaml#L13