### PR TITLE
Fix: downgrade k8s-dqlite version v1.3.1

### DIFF
--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.4.1"
+echo "v1.3.1"


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary

This PR drops the k8s-dqlite tag down to v1.3.1 as we wait on the Dqlite release for v1.6.0 https://github.com/canonical/microk8s/pull/5004.
The missing event bug is resolved on 1.6.0 but not on v1.4.1. We decided to stay on the stable tag until we get the Dqlite release.
#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
Drop the k8s-dqlite version.
#### Testing
<!-- Please explain how you tested your changes. -->
CI testing.
#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->
NA
#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
NA
