### PR TITLE
fix: camel case UNDER_TIME_PRESSURE value

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -81,6 +81,7 @@ jobs:
           export POD_CIDR="10.200.0.0/16"
           export POD_GATEWAY="10.200.0.1"
           export SKIP_PROMETHEUS="False"
+          export UNDER_TIME_PRESSURE=${UNDER_TIME_PRESSURE@u}
           sudo -E bash -c "cd /var/snap/microk8s/common/addons/core/tests; pytest -s -ra test-addons.py"
 
   test-addons-community:
@@ -100,6 +101,7 @@ jobs:
           set -x
           sudo snap install build/microk8s.snap --classic --dangerous
           sudo microk8s enable community
+          export UNDER_TIME_PRESSURE=${UNDER_TIME_PRESSURE@u}
           sudo -E bash -c "cd /var/snap/microk8s/common/addons/community/; pytest -s -ra ./tests/"
 
   test-addons-core-upgrade:
@@ -117,6 +119,7 @@ jobs:
           UNDER_TIME_PRESSURE: ${{ !contains(github.event.pull_request.labels.*.name, 'run-all-tests') }}
         run: |
           set -x
+          export UNDER_TIME_PRESSURE=${UNDER_TIME_PRESSURE@u}
           sudo -E bash -c "UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade.py"
 
   test-cluster-agent:


### PR DESCRIPTION
Adds `export UNDER_TIME_PRESSURE=${UNDER_TIME_PRESSURE@u}` to maintain compatibility with tests in addons repositories which expects a camel case value, e.g. `True`.