### PR TITLE
[1.32-strict] fix: camel case UNDER_TIME_PRESSURE value

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -82,6 +82,7 @@ jobs:
           export POD_CIDR="10.200.0.0/16"
           export POD_GATEWAY="10.200.0.1"
           export SKIP_PROMETHEUS="False"
+          export UNDER_TIME_PRESSURE=${UNDER_TIME_PRESSURE@u}
           sudo -E bash -c "cd /var/snap/microk8s/common/addons/core/tests; pytest -s -ra test-addons.py"
 
   test-addons-community:
@@ -104,6 +105,7 @@ jobs:
           sudo microk8s status --wait-ready --timeout 300
           sudo microk8s enable community
           export STRICT="yes"
+          export UNDER_TIME_PRESSURE=${UNDER_TIME_PRESSURE@u}
           sudo -E bash -c "cd /var/snap/microk8s/common/addons/community/; pytest -s -ra ./tests/"
 
   test-addons-core-upgrade:
@@ -122,6 +124,7 @@ jobs:
         run: |
           set -x
           export STRICT="yes"
+          export UNDER_TIME_PRESSURE=${UNDER_TIME_PRESSURE@u}
           sudo -E bash -c "UPGRADE_MICROK8S_FROM=1.32-strict/edge UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade.py"
 
   test-cluster-agent:


### PR DESCRIPTION
Backports https://github.com/canonical/microk8s/pull/5043