### PR TITLE
chore: bump go version to 1.24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,7 @@ parts:
   build-deps:
     plugin: nil
     build-snaps:
-      - go/1.23/stable
+      - go/1.24/stable
     build-packages:
       - autoconf
       - automake


### PR DESCRIPTION
bumps go version to 1.24