### PR TITLE
fix: use v1.3.3 k8s-dqlite patch release 1.32-strict, fix sarif CI

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -168,6 +168,8 @@ jobs:
 
   security-scan:
     name: Security scan
+    outputs:
+      sarif_files: ${{ steps.get_sarif_files.outputs.sarif-files }}
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 30
@@ -198,7 +200,41 @@ jobs:
           cp build/microk8s.snap .
           unsquashfs microk8s.snap
           trivy rootfs ./squashfs-root/ --format sarif > sarifs/snap.sarif
-      - name: Upload Trivy scan results to GitHub Security tab
+      - name: Generate list of SARIF files
+        id: get_sarif_files
+        run: |
+          sarif_files=$(find sarifs -name "*.sarif" -printf "%P\n" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "sarif-files=$sarif_files" >> "$GITHUB_OUTPUT"
+      - name: Upload SARIF files artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sarifs
+          path: sarifs
+          retention-days: 1
+
+  upload_sarifs_matrix:
+    needs: security-scan
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        sarif_file_path: ${{ fromJson(needs.security-scan.outputs.sarif_files) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Download SARIF files artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sarifs
+          path: sarifs
+      - name: Prepare SARIF category
+        id: prepare_category
+        run: |
+          sarif_file="${{ matrix.sarif_file_path }}"
+          base_name=$(basename "$sarif_file" .sarif)
+          echo "category=$base_name" >> "$GITHUB_OUTPUT"
+      - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: "sarifs"
+          sarif_file: sarifs/${{ matrix.sarif_file_path }}
+          category: ${{ steps.prepare_category.outputs.category }}

--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.3.1"
+echo "v1.3.3"


### PR DESCRIPTION
## Description

This PR updates the k8s-dqlite tag due to a new patch, see https://github.com/canonical/k8s-dqlite/releases/tag/v1.3.3.

I also cherry-picked Reza's fix for Sarif in CI.