### PR TITLE
fix(apparmor): allow sockets in cri-containerd profile (Backport #5218)

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -59,7 +59,7 @@ jobs:
     name: Test core addons
     runs-on: ubuntu-latest
     needs: build
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       # Avoid truncated "ps" output
       COLUMNS: 2048

--- a/microk8s-resources/containerd-profile
+++ b/microk8s-resources/containerd-profile
@@ -6,7 +6,11 @@ profile cri-containerd.apparmor.d flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
 
-  network,
+  network inet,
+  network inet6,
+  network unix,
+  network netlink,
+
   capability,
   file,
   umount,


### PR DESCRIPTION
Add explicit AppArmor rules to permit common socket types (inet, inet6, unix) needed by Kubernetes workloads (e.g., kube-controller, coredns). Plucky ships AppArmor 4.1.0, which is stricter and requires exact socket types to be set. This resolves "apparmor=DENIED operation=create class=net" denials.

Fixes #5082
Fixes #5190
Fixes #5140
