### PR TITLE
fix(ci): update reviewer handles in update-images workflow

### DIFF
--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -45,7 +45,7 @@ jobs:
           commit-message: update list of images used by ${{ matrix.channel }}
           title: "[${{ matrix.channel }}] Update MicroK8s images"
           body: update list of images used by ${{ matrix.channel }}
-          reviewers: berkayoz,ktsakalozos
+          team-reviewers: canonical/kubernetes
           branch: auto-update-images/${{ matrix.branch }}
           delete-branch: true
           base: ${{ matrix.branch }}


### PR DESCRIPTION
## Problem

The daily `Update list of images` workflow has been failing every day since at least 2026-08-22 with:

```
Reviews may only be requested from collaborators. One or more of the users or
teams you specified is not a collaborator of the canonical/microk8s repository.
```

## Root cause

The individual reviewer handles in the `reviewers` field are either changed or leaving. Rather than maintaining a list of individual handles, this fix switches to the `canonical/kubernetes` team as reviewer, which is more resilient to personnel changes.

## Fix

Replace `reviewers: berkayoz,ktsakalozos` with `team-reviewers: canonical/kubernetes`.

## Note

The same fix needs to be backported to all other branches that have this workflow (1.27–1.35 and their strict variants). Please add backport labels as appropriate.